### PR TITLE
better parser for step call

### DIFF
--- a/notte/common/parser.py
+++ b/notte/common/parser.py
@@ -18,7 +18,6 @@ class EnvStepParams(BaseModel):
     action_id: str
     params: dict[str, str] | None
 
-
 class Parser(ABC):
 
     @abstractmethod
@@ -86,8 +85,8 @@ class BaseNotteParser(Parser):
         if action is None or not isinstance(action, str):
             raise ValueError("No action found")
         d = json.loads(action)
-        action_id = list(d.keys())[0]
-        params = d[action_id] if d[action_id] != {} else None
+        action_id = d["action-id"]
+        params = d["params"]
         return EnvStepParams(action_id=action_id, params=params)
 
     @override
@@ -111,8 +110,8 @@ If the action is parameterized, provide the value for each parameter.
 Use the exact following format:
 <action>
 {
-"action-id": {} # if an action has no params
-"action-id": { "name":"value" } # for action with params
+"action-id": "<YOUR_ACTION_ID>",
+"params": { "param_name":"param_value" } 
 }
 </action>
 \nIf you're done, just say <done/>. Nothing else!

--- a/notte/common/parser.py
+++ b/notte/common/parser.py
@@ -18,6 +18,7 @@ class EnvStepParams(BaseModel):
     action_id: str
     params: dict[str, str] | None
 
+
 class Parser(ABC):
 
     @abstractmethod
@@ -85,8 +86,10 @@ class BaseNotteParser(Parser):
         if action is None or not isinstance(action, str):
             raise ValueError("No action found")
         d = json.loads(action)
+        if "action-id" not in d:
+            raise ValueError("No action-id found in action")
         action_id = d["action-id"]
-        params = d["params"]
+        params = d["params"] if d["params"] is not None else None
         return EnvStepParams(action_id=action_id, params=params)
 
     @override
@@ -111,7 +114,7 @@ Use the exact following format:
 <action>
 {
 "action-id": "<YOUR_ACTION_ID>",
-"params": { "param_name":"param_value" } 
+"params": { "<YOUR_PARAM_NAME>": "<YOUR_PARAM_VALUE>" }
 }
 </action>
 \nIf you're done, just say <done/>. Nothing else!

--- a/notte/env.py
+++ b/notte/env.py
@@ -147,7 +147,7 @@ class NotteEnv(AsyncResource):
             return self._parser.textify(obs)
         elif endpoint == "step":
             step_params = self._parser.step(text)
-            obs = await self.step(step_params.action_id, step_params.params, enter=False)
+            obs = await self.step(step_params.action_id, step_params.params, enter=True)
             return self._parser.textify(obs)
         return self._parser.rules()
 

--- a/notte/env.py
+++ b/notte/env.py
@@ -147,7 +147,7 @@ class NotteEnv(AsyncResource):
             return self._parser.textify(obs)
         elif endpoint == "step":
             step_params = self._parser.step(text)
-            obs = await self.step(step_params.action_id, step_params.params, enter=True)
+            obs = await self.step(step_params.action_id, step_params.params)
             return self._parser.textify(obs)
         return self._parser.rules()
 


### PR DESCRIPTION
Works best for :
```python
from notte.env import NotteEnv
import litellm

goal = "Find best flights from Boston to Tokyo on google flights"
messages = [{"role": "system", "content": goal}]
max_steps = 10

def llm_agent(messages):
    response = litellm.completion(
        model="cerebras/llama3.1-70b",
        messages=messages,
    )
    return response.choices[0].message.content

async def main(max_steps=10):
    async with NotteEnv(headless=False) as env:
        while '<done>' not in messages[-1]['content'] and max_steps > 0:
            resp = llm_agent(messages) # query your llm policy.
            obs = await env.chat(resp) # query notte with llm response.
            messages.append({"role": "assistant", "content": resp})
            messages.append({"role": "user", "content": obs})
            max_steps -= 1

await main()
```