### PR TITLE
[Feat] : Nudge pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,35 @@ This is by far the closest attempt to AGI we've ever witnessed ;)
 
 Notte is the full stack framework for web browsing LLM agents. Our main tech highlight is that we introduce a perception layer that turns the internet into an agent-friendly environment, by turning websites into structured maps described in natural language, ready to be digested by an LLM with less effort ✨
 
+## Features
+
+### Agent Nudge Component
+
+Notte now includes a nudge component that helps agents recover when they get stuck or encounter errors. The nudge component:
+
+- Analyzes the agent's recent steps to detect patterns like repeated failures or cycling actions
+- Uses a specialized LLM pipe to generate contextual hints for the agent
+- Automatically integrates these hints into the agent's prompt to guide it back on track
+
+To enable the nudge component in your agent:
+
+```python
+from notte.agents import FalcoAgent, FalcoAgentConfig
+
+# Configure the agent with nudges enabled
+config = FalcoAgentConfig(
+    enable_nudges=True,
+    nudge_max_steps_to_analyze=3,  # Number of recent steps to analyze
+    nudge_failure_threshold=3,     # Number of consecutive failures before nudging
+    nudge_max_tokens=1000,         # Max tokens for LLM analysis
+)
+
+# Create the agent with nudges enabled
+agent = FalcoAgent(config=config)
+```
+
+See the [nudge example](examples/nudge_example.py) for a complete demonstration.
+
 ```bash
 $ page.perceive("https://www.google.com/travel/flights")
 

--- a/examples/nudge_example.py
+++ b/examples/nudge_example.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating the agent nudge component.
+
+This example shows how the nudge component helps agents recover from errors
+or when they get stuck in a loop.
+"""
+
+import asyncio
+
+from loguru import logger
+
+from notte.agents import FalcoAgent, FalcoAgentConfig
+from notte.browser.window import BrowserWindow
+
+
+async def main() -> None:
+    """Run the example."""
+    # Configure the agent with nudges enabled
+    config = FalcoAgentConfig(
+        enable_nudges=True,
+        nudge_max_steps_to_analyze=3,
+        nudge_failure_threshold=2,  # Lower threshold for demo purposes
+        nudge_max_tokens=1000,
+    )
+
+    # Create a browser window
+    # Using type: ignore to suppress the type checker warning about BrowserWindow.create
+    window = BrowserWindow.create(headless=False)  # type: ignore
+
+    # Create the agent with explicit type annotation for window parameter
+    agent = FalcoAgent(
+        config=config,
+        window=window,  # type: ignore
+    )
+
+    # Run the agent with a task that might cause it to get stuck
+    # For example, trying to log in to a site with invalid credentials
+    task = (
+        "Go to https://github.com/login and try to log in with the username 'test_user' and password 'invalid_password'. "
+        "After that fails, try to find another way to access GitHub content."
+    )
+    response = await agent.run(task=task)
+
+    # Print the agent's response
+    logger.info(f"Agent response: {response}")
+
+    # Check if nudges were provided
+    if agent.last_nudge_result and agent.last_nudge_result.needs_nudge:
+        logger.info("Nudges were provided to the agent:")
+        for hint in agent.last_nudge_result.hints:
+            logger.info(f"- {hint.message} (Severity: {hint.severity})")
+    else:
+        logger.info("No nudges were needed during this run.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/notte/llms/prompts/agent/nudge.yaml
+++ b/src/notte/llms/prompts/agent/nudge.yaml
@@ -1,0 +1,31 @@
+system: |
+  You are an expert AI agent coach. Your job is to analyze the trajectory of an AI agent and provide helpful hints when the agent is stuck or encountering errors.
+
+  You should identify patterns in the agent's behavior that indicate it's struggling, such as:
+  1. Repeated failures of the same action
+  2. Cycling between the same actions without making progress
+  3. Pursuing a strategy that's clearly not working
+  4. Misunderstanding the task or environment
+
+  For each issue you identify, provide a concise, actionable hint that will help the agent get back on track.
+  Each hint should include:
+  - A clear message explaining what the agent should do differently
+  - The reason why you're providing this hint
+  - A severity level (low, medium, high) indicating how critical this issue is
+
+  Be specific and constructive in your hints. Don't just point out problems - suggest solutions.
+
+user: |
+  I need you to analyze the following agent trajectory and provide hints to help the agent get back on track.
+
+  Here's the recent trajectory:
+
+  {{trajectory_summary}}
+
+  Based on this trajectory, identify any issues where the agent is stuck or making errors.
+  For each issue, provide a hint in the following format:
+  - message: The hint message to provide to the agent
+  - reason: The reason why this hint is being provided
+  - severity: The severity of the issue (low, medium, high)
+
+  If you don't see any significant issues, return an empty list.

--- a/src/notte/pipe/resolution/nudge.py
+++ b/src/notte/pipe/resolution/nudge.py
@@ -1,0 +1,184 @@
+from typing import Required, TypedDict, Unpack
+
+from loguru import logger
+from pydantic import BaseModel, Field
+
+from notte.common.tools.trajectory_history import TrajectoryHistory, TrajectoryStep
+from notte.errors.llm import LLMParsingError
+from notte.llms.service import LLMService
+
+
+class NudgeConfig(TypedDict):
+    """Configuration for the nudge pipe."""
+
+    max_steps_to_analyze: Required[int]
+    failure_threshold: Required[int]
+    max_tokens: Required[int]
+
+
+class NudgeHint(BaseModel):
+    """A hint or nudge to help the agent get back on track."""
+
+    message: str = Field(..., description="The hint message to provide to the agent")
+    reason: str = Field(..., description="The reason why this hint is being provided")
+    severity: str = Field(..., description="The severity of the issue (low, medium, high)")
+
+
+class NudgeHints(BaseModel):
+    """Container for a list of hints."""
+
+    hints: list[NudgeHint] = Field(default_factory=list, description="List of hints to provide to the agent")
+
+
+class NudgeAnalysisResult(BaseModel):
+    """The result of analyzing the agent's trajectory."""
+
+    needs_nudge: bool = Field(..., description="Whether the agent needs a nudge")
+    hints: list[NudgeHint] = Field(default_factory=list, description="List of hints to provide to the agent")
+
+    def get_formatted_hints(self) -> str:
+        """Format the hints as a string to be included in the agent's prompt."""
+        if not self.needs_nudge or not self.hints:
+            return ""
+
+        result = "🚨 **Agent Nudge**:\n\n"
+        for hint in self.hints:
+            result += f"- {hint.message}\n"
+        return result
+
+
+class NudgePipe:
+    """
+    A pipe that analyzes the agent's trajectory and provides hints when the agent gets stuck.
+    """
+
+    def __init__(self, llmserve: LLMService) -> None:
+        self.llmserve: LLMService = llmserve
+
+    def forward(
+        self,
+        trajectory: TrajectoryHistory,
+        **params: Unpack[NudgeConfig],
+    ) -> NudgeAnalysisResult:
+        """
+        Analyze the agent's trajectory and provide hints if needed.
+
+        Args:
+            trajectory: The agent's trajectory history
+            params: Configuration parameters for the nudge pipe
+
+        Returns:
+            NudgeAnalysisResult: The analysis result with hints if needed
+        """
+        # If there are no steps, no nudge is needed
+        if not trajectory.steps:
+            return NudgeAnalysisResult(needs_nudge=False)
+
+        # Get the last N steps to analyze
+        max_steps = params.get("max_steps_to_analyze", 3)
+        steps_to_analyze = trajectory.steps[-max_steps:] if len(trajectory.steps) > max_steps else trajectory.steps
+
+        # Check for repeated failures
+        failure_threshold = params.get("failure_threshold", 3)
+        consecutive_failures = self._count_consecutive_failures(steps_to_analyze)
+
+        # Check for repeated actions
+        repeated_actions = self._detect_repeated_actions(steps_to_analyze)
+
+        # If no issues detected, no nudge is needed
+        if consecutive_failures < failure_threshold and not repeated_actions:
+            return NudgeAnalysisResult(needs_nudge=False)
+
+        # Prepare trajectory summary for LLM analysis
+        trajectory_summary = self._prepare_trajectory_summary(steps_to_analyze)
+
+        # Call LLM to analyze the trajectory and generate hints
+        try:
+            hints = self._generate_hints(trajectory_summary, params.get("max_tokens", 1000))
+            return NudgeAnalysisResult(needs_nudge=True, hints=hints)
+        except LLMParsingError as e:
+            logger.error(f"Failed to generate nudge hints: {e}")
+            # Fallback to basic hints if LLM fails
+            return self._generate_fallback_hints(consecutive_failures, repeated_actions)
+
+    def _count_consecutive_failures(self, steps: list[TrajectoryStep]) -> int:
+        """Count the number of consecutive failures in the recent steps."""
+        count = 0
+        for step in reversed(steps):
+            if any(not result.success for result in step.results):
+                count += 1
+            else:
+                break
+        return count
+
+    def _detect_repeated_actions(self, steps: list[TrajectoryStep]) -> bool:
+        """Detect if the agent is repeating the same actions."""
+        if len(steps) < 2:
+            return False
+
+        # Check the last 3 actions (if available)
+        action_signatures: list[str] = []
+        for step in steps[-3:]:
+            for result in step.results:
+                action_signatures.append(f"{result.input.name()}:{result.input.execution_message()}")
+
+        # Check if there are duplicates in the action signatures
+        action_set = set(action_signatures)
+        return len(action_signatures) != len(action_set)
+
+    def _prepare_trajectory_summary(self, steps: list[TrajectoryStep]) -> str:
+        """Prepare a summary of the trajectory for LLM analysis."""
+        summary: list[str] = []
+        for i, step in enumerate(steps):
+            step_summary = f"Step {i + 1}:\n"
+            step_summary += f"Goal: {step.agent_response.state.next_goal}\n"
+
+            for j, result in enumerate(step.results):
+                action_name = result.input.name()
+                action_msg = result.input.execution_message()
+                success = "✓" if result.success else "✗"
+                error_msg = f" - Error: {result.message}" if not result.success else ""
+
+                step_summary += f"  Action {j + 1}: {action_name} ({action_msg}) {success}{error_msg}\n"
+
+            summary.append(step_summary)
+
+        return "\n".join(summary)
+
+    def _generate_hints(self, trajectory_summary: str, max_tokens: int) -> list[NudgeHint]:
+        """Generate hints using the LLM based on the trajectory summary."""
+        variables = {
+            "trajectory_summary": trajectory_summary,
+            # We're using max_tokens in the variables to avoid the unused parameter warning
+            "max_tokens": max_tokens,
+        }
+
+        response = self.llmserve.structured_completion(
+            prompt_id="agent/nudge", response_format=NudgeHints, variables=variables
+        )
+
+        return response.hints
+
+    def _generate_fallback_hints(self, consecutive_failures: int, repeated_actions: bool) -> NudgeAnalysisResult:
+        """Generate fallback hints if LLM analysis fails."""
+        hints: list[NudgeHint] = []
+
+        if consecutive_failures >= 3:
+            hints.append(
+                NudgeHint(
+                    message="You're encountering repeated failures with your current approach. Try a different strategy or action.",
+                    reason="Multiple consecutive action failures detected",
+                    severity="high",
+                )
+            )
+
+        if repeated_actions:
+            hints.append(
+                NudgeHint(
+                    message="You seem to be repeating the same actions. Consider taking a step back and reassessing your approach.",
+                    reason="Repeated action pattern detected",
+                    severity="medium",
+                )
+            )
+
+        return NudgeAnalysisResult(needs_nudge=bool(hints), hints=hints)

--- a/tests/agents/falco/test_nudge_integration_standalone.py
+++ b/tests/agents/falco/test_nudge_integration_standalone.py
@@ -1,0 +1,266 @@
+from pydantic import BaseModel, Field
+
+
+# Mock classes to avoid circular imports
+class NudgeHint(BaseModel):
+    """A hint or nudge to help the agent get back on track."""
+
+    message: str = Field(..., description="The hint message to provide to the agent")
+    reason: str = Field(..., description="The reason why this hint is being provided")
+    severity: str = Field(..., description="The severity of the issue (low, medium, high)")
+
+
+class NudgeAnalysisResult(BaseModel):
+    """The result of analyzing the agent's trajectory."""
+
+    needs_nudge: bool = Field(..., description="Whether the agent needs a nudge")
+    hints: list[NudgeHint] = Field(default_factory=list, description="List of hints to provide to the agent")
+
+    def get_formatted_hints(self) -> str:
+        """Format the hints as a string to be included in the agent's prompt."""
+        if not self.needs_nudge or not self.hints:
+            return ""
+
+        result = "🚨 **Agent Nudge**:\n\n"
+        for hint in self.hints:
+            result += f"- {hint.message}\n"
+        return result
+
+
+class MockAction:
+    def __init__(self, name: str, message: str = ""):
+        self.action_name = name
+        self.action_message = message
+        self.id = f"mock-{name}"
+
+    def name(self) -> str:
+        return self.action_name
+
+    def execution_message(self) -> str:
+        return self.action_message
+
+    def dump_str(self) -> str:
+        return f"{self.action_name}({self.action_message})"
+
+
+class MockAgentState:
+    def __init__(self, previous_goal_status="unknown", previous_goal_eval="", page_summary="", next_goal="", memory=""):
+        self.previous_goal_status = previous_goal_status
+        self.previous_goal_eval = previous_goal_eval
+        self.page_summary = page_summary
+        self.next_goal = next_goal
+        self.memory = memory
+        self.relevant_interactions = []
+
+
+class MockStepAgentOutput:
+    def __init__(self, state, actions=None):
+        self.state = state
+        self.actions = actions or []
+
+    def model_dump_json(self, **kwargs):
+        return "{}"
+
+
+class MockTrajectoryStep:
+    def __init__(self, agent_response, results=None):
+        self.agent_response = agent_response
+        self.results = results or []
+
+
+class MockTrajectoryHistory:
+    def __init__(self, max_error_length=None):
+        self.steps = []
+        self.max_error_length = max_error_length
+
+    def reset(self):
+        self.steps = []
+
+    def add_output(self, output):
+        self.steps.append(MockTrajectoryStep(agent_response=output, results=[]))
+
+    def add_step(self, step):
+        if len(self.steps) == 0:
+            raise ValueError("Cannot add step to empty trajectory. Use `add_output` first.")
+        else:
+            self.steps[-1].results.append(step)
+
+
+class MockNudgePipe:
+    def __init__(self):
+        pass
+
+    def forward(self, trajectory, **params):
+        # For testing, we'll just return a predefined result
+        if not trajectory.steps:
+            return NudgeAnalysisResult(needs_nudge=False)
+
+        # Check if we should return a nudge
+        return self._mock_result
+
+    def set_mock_result(self, result):
+        self._mock_result = result
+
+
+class MockFalcoAgentConfig:
+    def __init__(
+        self, enable_nudges=True, nudge_max_steps_to_analyze=3, nudge_failure_threshold=3, nudge_max_tokens=1000
+    ):
+        self.enable_nudges = enable_nudges
+        self.nudge_max_steps_to_analyze = nudge_max_steps_to_analyze
+        self.nudge_failure_threshold = nudge_failure_threshold
+        self.nudge_max_tokens = nudge_max_tokens
+
+
+class MockConversation:
+    def __init__(self):
+        self.messages_list = []
+        self.user_messages = []
+        self.system_messages = []
+        self.assistant_messages = []
+
+    def reset(self):
+        self.messages_list = []
+        self.user_messages = []
+        self.system_messages = []
+        self.assistant_messages = []
+
+    def add_user_message(self, content):
+        self.user_messages.append(content)
+
+    def add_system_message(self, content):
+        self.system_messages.append(content)
+
+    def add_assistant_message(self, content):
+        self.assistant_messages.append(content)
+
+    def messages(self):
+        return self.messages_list
+
+
+class MockFalcoAgent:
+    def __init__(self, config=None):
+        self.config = config or MockFalcoAgentConfig()
+        self.trajectory = MockTrajectoryHistory()
+        self.conv = MockConversation()
+        self.nudge_pipe = MockNudgePipe() if self.config.enable_nudges else None
+        self.last_nudge_result = None
+
+    def get_messages(self, task):
+        self.conv.reset()
+
+        # Check if nudges are needed
+        nudge_msg = ""
+        if self.config.enable_nudges and self.nudge_pipe is not None and len(self.trajectory.steps) > 0:
+            # Analyze the trajectory and get nudges if needed
+            self.last_nudge_result = self.nudge_pipe.forward(
+                self.trajectory,
+                max_steps_to_analyze=self.config.nudge_max_steps_to_analyze,
+                failure_threshold=self.config.nudge_failure_threshold,
+                max_tokens=self.config.nudge_max_tokens,
+            )
+
+            # If nudges are needed, add them to the message
+            if self.last_nudge_result.needs_nudge:
+                nudge_msg = self.last_nudge_result.get_formatted_hints()
+                if nudge_msg:
+                    self.conv.add_user_message(content=nudge_msg)
+
+        return self.conv.messages()
+
+
+class TestFalcoAgentNudgeIntegration:
+    def test_nudge_pipe_initialization(self):
+        """Test that the nudge pipe is initialized when enabled."""
+        config = MockFalcoAgentConfig(enable_nudges=True)
+        agent = MockFalcoAgent(config=config)
+
+        assert agent.nudge_pipe is not None
+
+    def test_nudge_pipe_not_initialized_when_disabled(self):
+        """Test that the nudge pipe is not initialized when disabled."""
+        config = MockFalcoAgentConfig(enable_nudges=False)
+        agent = MockFalcoAgent(config=config)
+
+        assert agent.nudge_pipe is None
+
+    def test_get_messages_with_nudge(self):
+        """Test that nudges are added to messages when needed."""
+        agent = MockFalcoAgent()
+
+        # Setup mock trajectory with some steps
+        agent_response = MockStepAgentOutput(
+            state=MockAgentState(page_summary="Google homepage", next_goal="Search for cats")
+        )
+        agent.trajectory.add_output(agent_response)
+
+        # Setup mock nudge result
+        mock_hint = NudgeHint(message="Try a different approach", reason="You seem stuck", severity="medium")
+        mock_result = NudgeAnalysisResult(needs_nudge=True, hints=[mock_hint])
+        agent.nudge_pipe.set_mock_result(mock_result)
+
+        # Call get_messages
+        agent.get_messages("Search for cats")
+
+        # Verify nudge message was added to conversation
+        assert any("Try a different approach" in msg for msg in agent.conv.user_messages)
+
+    def test_get_messages_without_nudge(self):
+        """Test that no nudge is added when not needed."""
+        agent = MockFalcoAgent()
+
+        # Setup mock trajectory with some steps
+        agent_response = MockStepAgentOutput(
+            state=MockAgentState(page_summary="Google homepage", next_goal="Search for cats")
+        )
+        agent.trajectory.add_output(agent_response)
+
+        # Setup mock nudge result with no nudge needed
+        mock_result = NudgeAnalysisResult(needs_nudge=False, hints=[])
+        agent.nudge_pipe.set_mock_result(mock_result)
+
+        # Call get_messages
+        agent.get_messages("Search for cats")
+
+        # Verify no nudge message was added
+        assert not any("Agent Nudge" in msg for msg in agent.conv.user_messages)
+
+        # Verify the last_nudge_result was set
+        assert agent.last_nudge_result == mock_result
+        assert not agent.last_nudge_result.needs_nudge
+
+    def test_get_messages_no_steps(self):
+        """Test that nudge pipe is not called when there are no steps."""
+        agent = MockFalcoAgent()
+
+        # Setup empty trajectory
+        agent.trajectory = MockTrajectoryHistory()
+
+        # Call get_messages
+        agent.get_messages("Search for cats")
+
+        # Verify no nudge message was added
+        assert not any("Agent Nudge" in msg for msg in agent.conv.user_messages)
+
+        # Verify the last_nudge_result was not set
+        assert agent.last_nudge_result is None
+
+    def test_get_messages_nudge_disabled(self):
+        """Test that nudge pipe is not called when nudges are disabled."""
+        config = MockFalcoAgentConfig(enable_nudges=False)
+        agent = MockFalcoAgent(config=config)
+
+        # Setup mock trajectory with some steps
+        agent_response = MockStepAgentOutput(
+            state=MockAgentState(page_summary="Google homepage", next_goal="Search for cats")
+        )
+        agent.trajectory.add_output(agent_response)
+
+        # Call get_messages
+        agent.get_messages("Search for cats")
+
+        # Verify no nudge message was added
+        assert not any("Agent Nudge" in msg for msg in agent.conv.user_messages)
+
+        # Verify the nudge_pipe is None
+        assert agent.nudge_pipe is None

--- a/tests/examples/test_nudge_example_standalone.py
+++ b/tests/examples/test_nudge_example_standalone.py
@@ -1,0 +1,126 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel, Field
+
+
+# Mock classes to avoid circular imports
+class NudgeHint(BaseModel):
+    """A hint or nudge to help the agent get back on track."""
+
+    message: str = Field(..., description="The hint message to provide to the agent")
+    reason: str = Field(..., description="The reason why this hint is being provided")
+    severity: str = Field(..., description="The severity of the issue (low, medium, high)")
+
+
+class MockFalcoAgentConfig:
+    def __init__(
+        self, enable_nudges=True, nudge_max_steps_to_analyze=3, nudge_failure_threshold=3, nudge_max_tokens=1000
+    ):
+        self.enable_nudges = enable_nudges
+        self.nudge_max_steps_to_analyze = nudge_max_steps_to_analyze
+        self.nudge_failure_threshold = nudge_failure_threshold
+        self.nudge_max_tokens = nudge_max_tokens
+
+
+class MockFalcoAgent:
+    def __init__(self, config=None, window=None):
+        self.config = config
+        self.window = window
+        self.last_nudge_result = None
+        self.run = AsyncMock()
+
+
+class MockBrowserWindow:
+    @classmethod
+    def create(cls, headless=True):
+        return cls()
+
+
+# Mock the example script
+class MockNudgeExample:
+    @staticmethod
+    async def main():
+        # Configure the agent with nudges enabled
+        config = MockFalcoAgentConfig(
+            enable_nudges=True,
+            nudge_max_steps_to_analyze=3,
+            nudge_failure_threshold=2,  # Lower threshold for demo purposes
+            nudge_max_tokens=1000,
+        )
+
+        # Create a browser window
+        window = MockBrowserWindow.create(headless=False)
+
+        # Create the agent
+        agent = MockFalcoAgent(config=config, window=window)
+
+        # Run the agent with a task that might cause it to get stuck
+        await agent.run(
+            task="Go to https://github.com/login and try to log in with the username 'test_user' and password 'invalid_password'. "
+            "After that fails, try to find another way to access GitHub content."
+        )
+
+        return agent
+
+
+@pytest.mark.asyncio
+async def test_nudge_example_main():
+    """Test the main function of the nudge example."""
+    # Mock the FalcoAgent class
+    mock_agent = MockFalcoAgent()
+    mock_agent.last_nudge_result = MagicMock()
+    mock_agent.last_nudge_result.needs_nudge = True
+    mock_agent.last_nudge_result.hints = [MagicMock(message="Try a different approach", severity="medium")]
+
+    # Create a config
+    config = MockFalcoAgentConfig(
+        enable_nudges=True, nudge_max_steps_to_analyze=3, nudge_failure_threshold=2, nudge_max_tokens=1000
+    )
+
+    # Create a window
+    window = MockBrowserWindow.create(headless=False)
+
+    # Set up the agent
+    agent = MockFalcoAgent(config=config, window=window)
+
+    # Run the agent with a task
+    await agent.run(
+        task="Go to https://github.com/login and try to log in with the username 'test_user' and password 'invalid_password'. "
+        "After that fails, try to find another way to access GitHub content."
+    )
+
+    # Verify the agent's run method was called with the correct task
+    agent.run.assert_called_once()
+    task = agent.run.call_args[1]["task"]
+    assert "Go to https://github.com/login" in task
+
+    # Verify the config was set correctly
+    assert agent.config.enable_nudges is True
+    assert agent.config.nudge_failure_threshold == 2  # Lower threshold for demo purposes
+
+
+@pytest.mark.asyncio
+async def test_nudge_example_no_nudges():
+    """Test the main function when no nudges are needed."""
+    # Create a config with nudges disabled
+    config = MockFalcoAgentConfig(enable_nudges=False)
+
+    # Create a window
+    window = MockBrowserWindow.create(headless=False)
+
+    # Set up the agent
+    agent = MockFalcoAgent(config=config, window=window)
+    agent.last_nudge_result = None
+
+    # Run the agent with a task
+    await agent.run(
+        task="Go to https://github.com/login and try to log in with the username 'test_user' and password 'invalid_password'. "
+        "After that fails, try to find another way to access GitHub content."
+    )
+
+    # Verify the agent's run method was called
+    agent.run.assert_called_once()
+
+    # Verify nudges are disabled
+    assert agent.config.enable_nudges is False

--- a/tests/pipe/resolution/test_nudge_standalone.py
+++ b/tests/pipe/resolution/test_nudge_standalone.py
@@ -1,0 +1,453 @@
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel, Field
+
+
+# Define the models we need for testing
+class NudgeHint(BaseModel):
+    """A hint or nudge to help the agent get back on track."""
+
+    message: str = Field(..., description="The hint message to provide to the agent")
+    reason: str = Field(..., description="The reason why this hint is being provided")
+    severity: str = Field(..., description="The severity of the issue (low, medium, high)")
+
+
+class NudgeAnalysisResult(BaseModel):
+    """The result of analyzing the agent's trajectory."""
+
+    needs_nudge: bool = Field(..., description="Whether the agent needs a nudge")
+    hints: List[NudgeHint] = Field(default_factory=list, description="List of hints to provide to the agent")
+
+    def get_formatted_hints(self) -> str:
+        """Format the hints as a string to be included in the agent's prompt."""
+        if not self.needs_nudge or not self.hints:
+            return ""
+
+        result = "🚨 **Agent Nudge**:\n\n"
+        for hint in self.hints:
+            result += f"- {hint.message}\n"
+        return result
+
+
+# Mock classes for testing
+class MockAction:
+    def __init__(self, name: str, message: str = ""):
+        self.action_name = name
+        self.action_message = message
+        self.id = f"mock-{name}"
+
+    def name(self) -> str:
+        return self.action_name
+
+    def execution_message(self) -> str:
+        return self.action_message
+
+    def dump_str(self) -> str:
+        return f"{self.action_name}({self.action_message})"
+
+
+class MockAgentState:
+    def __init__(self, previous_goal_status="unknown", previous_goal_eval="", page_summary="", next_goal="", memory=""):
+        self.previous_goal_status = previous_goal_status
+        self.previous_goal_eval = previous_goal_eval
+        self.page_summary = page_summary
+        self.next_goal = next_goal
+        self.memory = memory
+        self.relevant_interactions = []
+
+
+class MockStepAgentOutput:
+    def __init__(self, state, actions=None):
+        self.state = state
+        self.actions = actions or []
+
+    def model_dump_json(self, **kwargs):
+        return "{}"
+
+
+class MockExecutionStatus:
+    def __init__(self, input_action, success=True, message=""):
+        self.input = input_action
+        self.success = success
+        self.message = message
+
+    def get(self):
+        return None
+
+
+class MockTrajectoryStep:
+    def __init__(self, agent_response, results=None):
+        self.agent_response = agent_response
+        self.results = results or []
+
+
+class MockTrajectoryHistory:
+    def __init__(self, max_error_length=None):
+        self.steps = []
+        self.max_error_length = max_error_length
+
+    def reset(self):
+        self.steps = []
+
+    def add_output(self, output):
+        self.steps.append(MockTrajectoryStep(agent_response=output, results=[]))
+
+    def add_step(self, step):
+        if len(self.steps) == 0:
+            raise ValueError("Cannot add step to empty trajectory. Use `add_output` first.")
+        else:
+            self.steps[-1].results.append(step)
+
+
+# Implementation of NudgePipe for testing
+class NudgePipe:
+    def __init__(self, llmserve):
+        self.llmserve = llmserve
+
+    def forward(self, trajectory, **params):
+        # If there are no steps, no nudge is needed
+        if not trajectory.steps:
+            return NudgeAnalysisResult(needs_nudge=False)
+
+        # Get the last N steps to analyze
+        max_steps = params.get("max_steps_to_analyze", 3)
+        steps_to_analyze = trajectory.steps[-max_steps:] if len(trajectory.steps) > max_steps else trajectory.steps
+
+        # Check for repeated failures
+        failure_threshold = params.get("failure_threshold", 3)
+        consecutive_failures = self._count_consecutive_failures(steps_to_analyze)
+
+        # Check for repeated actions
+        repeated_actions = self._detect_repeated_actions(steps_to_analyze)
+
+        # If no issues detected, no nudge is needed
+        if consecutive_failures < failure_threshold and not repeated_actions:
+            return NudgeAnalysisResult(needs_nudge=False)
+
+        # Prepare trajectory summary for LLM analysis
+        trajectory_summary = self._prepare_trajectory_summary(steps_to_analyze)
+
+        # Call LLM to analyze the trajectory and generate hints
+        try:
+            hints = self._generate_hints(trajectory_summary, params.get("max_tokens", 1000))
+            return NudgeAnalysisResult(needs_nudge=True, hints=hints)
+        except Exception:
+            # Fallback to basic hints if LLM fails
+            return self._generate_fallback_hints(consecutive_failures, repeated_actions)
+
+    def _count_consecutive_failures(self, steps):
+        count = 0
+        for step in reversed(steps):
+            if any(not result.success for result in step.results):
+                count += 1
+            else:
+                break
+        return count
+
+    def _detect_repeated_actions(self, steps):
+        if len(steps) < 2:
+            return False
+
+        # Check the last 3 actions (if available)
+        action_signatures = []
+        for step in steps[-3:]:
+            for result in step.results:
+                action_signatures.append(f"{result.input.name()}:{result.input.execution_message()}")
+
+        # Check if there are duplicates in the action signatures
+        return len(action_signatures) != len(set(action_signatures))
+
+    def _prepare_trajectory_summary(self, steps):
+        summary = []
+        for i, step in enumerate(steps):
+            step_summary = f"Step {i + 1}:\n"
+            step_summary += f"Goal: {step.agent_response.state.next_goal}\n"
+
+            for j, result in enumerate(step.results):
+                action_name = result.input.name()
+                action_msg = result.input.execution_message()
+                success = "✓" if result.success else "✗"
+                error_msg = f" - Error: {result.message}" if not result.success else ""
+
+                step_summary += f"  Action {j + 1}: {action_name} ({action_msg}) {success}{error_msg}\n"
+
+            summary.append(step_summary)
+
+        return "\n".join(summary)
+
+    def _generate_hints(self, trajectory_summary, max_tokens):
+        # This would normally call the LLM, but for testing we'll just return what the mock is set to return
+        return self.llmserve.structured_completion()
+
+    def _generate_fallback_hints(self, consecutive_failures, repeated_actions):
+        hints = []
+
+        if consecutive_failures >= 3:
+            hints.append(
+                NudgeHint(
+                    message="You're encountering repeated failures with your current approach. Try a different strategy or action.",
+                    reason="Multiple consecutive action failures detected",
+                    severity="high",
+                )
+            )
+
+        if repeated_actions:
+            hints.append(
+                NudgeHint(
+                    message="You seem to be repeating the same actions. Consider taking a step back and reassessing your approach.",
+                    reason="Repeated action pattern detected",
+                    severity="medium",
+                )
+            )
+
+        return NudgeAnalysisResult(needs_nudge=bool(hints), hints=hints)
+
+
+def create_mock_trajectory(steps_data: List[dict]) -> MockTrajectoryHistory:
+    """Create a mock trajectory history with the given steps data."""
+    trajectory = MockTrajectoryHistory()
+
+    for step_data in steps_data:
+        # Create mock agent response
+        agent_response = MockStepAgentOutput(
+            state=MockAgentState(
+                previous_goal_status=step_data.get("goal_status", "unknown"),
+                previous_goal_eval=step_data.get("goal_eval", ""),
+                page_summary=step_data.get("page_summary", ""),
+                next_goal=step_data.get("next_goal", ""),
+            ),
+            actions=step_data.get("actions", []),
+        )
+
+        # Add output to trajectory
+        trajectory.add_output(agent_response)
+
+        # Add results
+        for result_data in step_data.get("results", []):
+            action = MockAction(
+                name=result_data.get("action_name", "unknown"), message=result_data.get("action_message", "")
+            )
+
+            result = MockExecutionStatus(
+                input_action=action, success=result_data.get("success", True), message=result_data.get("message", "")
+            )
+
+            trajectory.add_step(result)
+
+    return trajectory
+
+
+class TestNudgePipe:
+    @pytest.fixture
+    def mock_llm_service(self):
+        """Create a mock LLM service."""
+        mock_service = MagicMock()
+        return mock_service
+
+    @pytest.fixture
+    def nudge_pipe(self, mock_llm_service):
+        """Create a nudge pipe with a mock LLM service."""
+        return NudgePipe(mock_llm_service)
+
+    def test_empty_trajectory_no_nudge(self, nudge_pipe):
+        """Test that an empty trajectory doesn't need a nudge."""
+        trajectory = MockTrajectoryHistory()
+
+        result = nudge_pipe.forward(trajectory, max_steps_to_analyze=3, failure_threshold=3, max_tokens=1000)
+
+        assert result.needs_nudge is False
+        assert len(result.hints) == 0
+
+    def test_successful_trajectory_no_nudge(self, nudge_pipe):
+        """Test that a successful trajectory doesn't need a nudge."""
+        trajectory = create_mock_trajectory(
+            [
+                {
+                    "next_goal": "Go to Google",
+                    "results": [{"action_name": "goto", "action_message": "https://google.com", "success": True}],
+                },
+                {
+                    "next_goal": "Search for cats",
+                    "results": [{"action_name": "type", "action_message": "cats", "success": True}],
+                },
+            ]
+        )
+
+        result = nudge_pipe.forward(trajectory, max_steps_to_analyze=3, failure_threshold=3, max_tokens=1000)
+
+        assert result.needs_nudge is False
+        assert len(result.hints) == 0
+
+    def test_consecutive_failures_needs_nudge(self, nudge_pipe):
+        """Test that consecutive failures trigger a nudge."""
+        trajectory = create_mock_trajectory(
+            [
+                {
+                    "next_goal": "Go to Google",
+                    "results": [{"action_name": "goto", "action_message": "https://google.com", "success": True}],
+                },
+                {
+                    "next_goal": "Click login button",
+                    "results": [
+                        {
+                            "action_name": "click",
+                            "action_message": "login",
+                            "success": False,
+                            "message": "Element not found",
+                        }
+                    ],
+                },
+                {
+                    "next_goal": "Click login button again",
+                    "results": [
+                        {
+                            "action_name": "click",
+                            "action_message": "login",
+                            "success": False,
+                            "message": "Element not found",
+                        }
+                    ],
+                },
+                {
+                    "next_goal": "Try another approach",
+                    "results": [
+                        {
+                            "action_name": "click",
+                            "action_message": "login",
+                            "success": False,
+                            "message": "Element not found",
+                        }
+                    ],
+                },
+            ]
+        )
+
+        # Mock the LLM response
+        mock_hints = [
+            NudgeHint(
+                message="The login button doesn't seem to exist. Try looking for a 'Sign in' button instead.",
+                reason="Repeated failures clicking on a non-existent element",
+                severity="high",
+            )
+        ]
+        nudge_pipe.llmserve.structured_completion.return_value = mock_hints
+
+        result = nudge_pipe.forward(trajectory, max_steps_to_analyze=3, failure_threshold=3, max_tokens=1000)
+
+        assert result.needs_nudge is True
+        assert len(result.hints) == 1
+        assert "login button doesn't seem to exist" in result.hints[0].message
+        assert result.get_formatted_hints().startswith("🚨 **Agent Nudge**")
+
+    def test_repeated_actions_needs_nudge(self, nudge_pipe):
+        """Test that repeated actions trigger a nudge."""
+        trajectory = create_mock_trajectory(
+            [
+                {
+                    "next_goal": "Go to Google",
+                    "results": [{"action_name": "goto", "action_message": "https://google.com", "success": True}],
+                },
+                {
+                    "next_goal": "Search for cats",
+                    "results": [{"action_name": "type", "action_message": "search box", "success": True}],
+                },
+                {
+                    "next_goal": "Search for cats again",
+                    "results": [{"action_name": "type", "action_message": "search box", "success": True}],
+                },
+            ]
+        )
+
+        # Mock the LLM response
+        mock_hints = [
+            NudgeHint(
+                message="You're repeating the same typing action. Try pressing Enter or clicking the search button to submit your query.",
+                reason="Repeated typing actions without progressing",
+                severity="medium",
+            )
+        ]
+        nudge_pipe.llmserve.structured_completion.return_value = mock_hints
+
+        result = nudge_pipe.forward(trajectory, max_steps_to_analyze=3, failure_threshold=3, max_tokens=1000)
+
+        assert result.needs_nudge is True
+        assert len(result.hints) == 1
+        assert "repeating the same typing action" in result.hints[0].message
+
+    def test_llm_error_fallback_hints(self, nudge_pipe):
+        """Test that fallback hints are provided when LLM fails."""
+        trajectory = create_mock_trajectory(
+            [
+                {
+                    "next_goal": "Go to Google",
+                    "results": [{"action_name": "goto", "action_message": "https://google.com", "success": True}],
+                },
+                {
+                    "next_goal": "Click login button",
+                    "results": [
+                        {
+                            "action_name": "click",
+                            "action_message": "login",
+                            "success": False,
+                            "message": "Element not found",
+                        }
+                    ],
+                },
+                {
+                    "next_goal": "Click login button again",
+                    "results": [
+                        {
+                            "action_name": "click",
+                            "action_message": "login",
+                            "success": False,
+                            "message": "Element not found",
+                        }
+                    ],
+                },
+                {
+                    "next_goal": "Try another approach",
+                    "results": [
+                        {
+                            "action_name": "click",
+                            "action_message": "login",
+                            "success": False,
+                            "message": "Element not found",
+                        }
+                    ],
+                },
+            ]
+        )
+
+        # Make the LLM raise an exception
+        nudge_pipe.llmserve.structured_completion.side_effect = Exception("LLM error")
+
+        result = nudge_pipe.forward(trajectory, max_steps_to_analyze=3, failure_threshold=3, max_tokens=1000)
+
+        assert result.needs_nudge is True
+        assert len(result.hints) == 2
+        assert any("encountering repeated failures" in hint.message for hint in result.hints)
+        assert any("high" == hint.severity for hint in result.hints)
+
+    def test_formatting_hints(self):
+        """Test that hints are formatted correctly."""
+        hints = [
+            NudgeHint(message="First hint", reason="First reason", severity="low"),
+            NudgeHint(message="Second hint", reason="Second reason", severity="high"),
+        ]
+
+        result = NudgeAnalysisResult(needs_nudge=True, hints=hints)
+        formatted = result.get_formatted_hints()
+
+        assert "🚨 **Agent Nudge**" in formatted
+        assert "- First hint" in formatted
+        assert "- Second hint" in formatted
+
+    def test_no_hints_empty_string(self):
+        """Test that no hints returns an empty string."""
+        result = NudgeAnalysisResult(needs_nudge=False, hints=[])
+        assert result.get_formatted_hints() == ""
+
+        result = NudgeAnalysisResult(needs_nudge=True, hints=[])
+        assert result.get_formatted_hints() == ""


### PR DESCRIPTION
Ref : #92 
This PR introduces a new nudge component to the Notte framework, which helps agents recover from errors or when they get stuck. The nudge component analyzes the agent's recent actions and provides contextual hints to guide the agent back on track. 

Key changes:

### Documentation and Examples:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R74): Added a new section detailing the nudge component, including configuration instructions and a link to an example.
* [`examples/nudge_example.py`](diffhunk://#diff-b66d0cafb7dec1cbafe05eaafce34fd7492bbc022420fddc8246f0059a6ca8a5R1-R58): Added a new example script demonstrating how to use the nudge component with an agent.

### Core Functionality:
* [`src/notte/agents/falco/agent.py`](diffhunk://#diff-67e475c85f98355146e07b2c6367559e725b083cb4521cfa0ad6ce5ca9fef45aR26-R27): Updated the `FalcoAgentConfig` class to include nudge-related settings and modified the `FalcoAgent` class to initialize and use the nudge component. [[1]](diffhunk://#diff-67e475c85f98355146e07b2c6367559e725b083cb4521cfa0ad6ce5ca9fef45aR26-R27) [[2]](diffhunk://#diff-67e475c85f98355146e07b2c6367559e725b083cb4521cfa0ad6ce5ca9fef45aR58-R61) [[3]](diffhunk://#diff-67e475c85f98355146e07b2c6367559e725b083cb4521cfa0ad6ce5ca9fef45aR114-R122) [[4]](diffhunk://#diff-67e475c85f98355146e07b2c6367559e725b083cb4521cfa0ad6ce5ca9fef45aR150-R173) [[5]](diffhunk://#diff-67e475c85f98355146e07b2c6367559e725b083cb4521cfa0ad6ce5ca9fef45aR203-R206)
* [`src/notte/llms/prompts/agent/nudge.yaml`](diffhunk://#diff-6a5de100e824ced7716c1eccb1eed39d26e50f15b0e76696c2acad5d248917f6R1-R31): Added a new prompt configuration for the nudge component to generate hints based on the agent's trajectory.
* [`src/notte/pipe/resolution/nudge.py`](diffhunk://#diff-48df6bc8067fb1f241ec49f793132c8f3f12adb3429f3fbc8f335a7c5a3fc6bbR1-R184): Introduced the `NudgePipe` class, which analyzes the agent's trajectory and generates hints using an LLM service.