### PR TITLE
Add user_agent and proxy as parameters

### DIFF
--- a/src/notte/browser/pool/cdp_pool.py
+++ b/src/notte/browser/pool/cdp_pool.py
@@ -5,7 +5,7 @@ from patchright.async_api import Browser as PatchrightBrowser
 from pydantic import BaseModel
 from typing_extensions import override
 
-from notte.browser.pool.base import BaseBrowserPool, BrowserWithContexts
+from notte.browser.pool.base import BaseBrowserPool, BrowserResourceOptions, BrowserWithContexts
 
 
 class CDPSession(BaseModel):
@@ -25,14 +25,14 @@ class CDPBrowserPool(BaseBrowserPool, ABC):
         pass
 
     @override
-    async def create_playwright_browser(self, headless: bool) -> PatchrightBrowser:
+    async def create_playwright_browser(self, resource_options: BrowserResourceOptions) -> PatchrightBrowser:
         cdp_session = self.create_session_cdp()
         self.last_session = cdp_session
         return await self.playwright.chromium.connect_over_cdp(cdp_session.cdp_url)
 
     @override
-    async def create_browser(self, headless: bool) -> BrowserWithContexts:
-        browser = await super().create_browser(headless)
+    async def create_browser(self, resource_options: BrowserResourceOptions) -> BrowserWithContexts:
+        browser = await super().create_browser(resource_options)
         if self.last_session is None:
             raise ValueError("Last session is not set")
         self.sessions[browser.browser_id] = self.last_session

--- a/src/notte/common/config.py
+++ b/src/notte/common/config.py
@@ -12,7 +12,7 @@ class FrozenConfig(BaseModel):
 
     def _copy_and_validate(self: Self, **kwargs: Any) -> Self:
         # kwargs should be validated before being passed to model_copy
-        _ = self.model_validate(kwargs)
+        _ = self.model_validate(dict(self.model_dump(), **kwargs))
         config = self.model_copy(deep=True, update=kwargs)
         return config
 

--- a/src/notte/common/fastapi.py
+++ b/src/notte/common/fastapi.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 try:
-    from fastapi import APIRouter, HTTPException  # type: ignore[reportMissingModuleSource]
+    from fastapi import APIRouter, HTTPException
 except ImportError:
     raise ImportError("fastapi is required to use the FastAPI router. Install it with 'uv sync --extra api'")
 
@@ -9,7 +9,7 @@ from notte.common.agent.base import BaseAgent
 from notte.common.agent.types import AgentRequest, AgentResponse
 
 
-def create_agent_router(agent: BaseAgent, prefix: str = "agent") -> APIRouter:  # type: ignore[reportUnknownParameterType]
+def create_agent_router(agent: BaseAgent, prefix: str = "agent") -> APIRouter:
     """
     Creates a FastAPI router that serves the given agent.
 
@@ -20,16 +20,16 @@ def create_agent_router(agent: BaseAgent, prefix: str = "agent") -> APIRouter:  
     Returns:
         APIRouter instance with agent endpoints
     """
-    router = APIRouter(  # type: ignore[reportUnknownMemberType]
+    router = APIRouter(
         prefix=prefix,
         tags=[agent.__class__.__name__],
     )
 
-    @router.post("/run", response_model=AgentResponse)  # type: ignore[reportUntypedFunctionDecorator]
+    @router.post("/run", response_model=AgentResponse)
     async def run_agent(request: Annotated[AgentRequest, "Agent request parameters"]) -> AgentResponse:  # type: ignore[unused-function]
         try:
             return await agent.run(task=request.task, url=request.url)
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))
 
-    return router  # type: ignore[reportUnknownReturn]
+    return router

--- a/src/notte/errors/base.py
+++ b/src/notte/errors/base.py
@@ -63,14 +63,22 @@ class NotteBaseError(ValueError):
 
 class NotteTimeoutError(NotteBaseError):
     def __init__(self, message: str) -> None:
-        super().__init__(dev_message=message, user_message=message, agent_message=message, should_retry_later=True)
+        super().__init__(
+            dev_message=message,
+            user_message=message,
+            agent_message=message,
+            should_retry_later=True,
+        )
 
 
 class AccessibilityTreeMissingError(NotteBaseError):
     def __init__(self, message: str = "") -> None:
         error_message = f"Accessibility tree is missing. {message}"
         super().__init__(
-            dev_message=error_message, user_message=error_message, agent_message=error_message, should_retry_later=True
+            dev_message=error_message,
+            user_message=error_message,
+            agent_message=error_message,
+            should_retry_later=True,
         )
 
 

--- a/src/notte_eval/patcher.py
+++ b/src/notte_eval/patcher.py
@@ -51,9 +51,9 @@ class AgentPatcher:
             return json.dumps(to_dump)
         except TypeError as te:
             try:
-                from langchain_core.load.dump import dumps  # type: ignore[import]
+                from langchain_core.load.dump import dumps
 
-                return dumps(to_dump)  # type: ignore[import, has-type]
+                return dumps(to_dump)
             except ImportError:
                 raise CantDumpArgumentError from te
 

--- a/tests/integration/test_user_agent.py
+++ b/tests/integration/test_user_agent.py
@@ -1,0 +1,16 @@
+import json
+
+import pytest
+
+from notte.env import NotteEnv, NotteEnvConfig
+
+
+@pytest.mark.asyncio
+async def test_user_agent():
+    """Test validation of special action parameters"""
+
+    USER_AGENT = "test-user-agent"
+    async with NotteEnv(NotteEnvConfig().set_user_agent(USER_AGENT).headless()) as env:
+        _ = await env.goto("https://ifconfig.co/json")
+        json_resp = json.loads(env.snapshot.dom_node.inner_text())
+        assert json_resp["user_agent"]["raw_value"] == USER_AGENT


### PR DESCRIPTION
Fixes #169 #168 
Idea is to be able to just run:

`
uv run python examples/cli_agent.py --task "go to https://ifconfig.co/json and return your ip and user agent" --env.user_agent "my_user_agent" --env.proxy='{"server":"<server_url>","username":"<user>","password":"<pass>"}'        
`
> `AgentResponse(success=True, duration_in_s=4.58, answer=IP address: <proxy ip>, User agent: my_user_agent) `

As mentioned in #169, headless user agent is not great, so we now enforce that headless=True means that we set a user agent manually