### PR TITLE
feat: telemetry skeleton w PostHog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,19 @@ GROQ_API_KEY=
 CEREBRAS_API_KEY=
 DEEPSEEK_API_KEY=
 GEMINI_API_KEY=
+
+# #############################
+# ######### TELEMETRY #########
+# #############################
+
+# Enable or disable telemetry collection
+# We use PostHog for telemetry collection. The data is completely anonymized and
+# contains no personally identifiable information.
+# Set to 'false' to disable telemetry collection
+ANONYMIZED_TELEMETRY=true
+
+# Add your PostHog API key
+POSTHOG_API_KEY=
+
+# Add your PostHog host URL
+POSTHOG_HOST=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ discord = [
 slack = [
     "slack-sdk>=3.34.0",
 ]
+telemetry = [
+    "posthog>=3.0.1",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/notte/__init__.py
+++ b/src/notte/__init__.py
@@ -12,3 +12,8 @@ def set_error_mode(mode: ErrorMode) -> None:
 
 # Default to user mode
 ErrorConfig.set_message_mode(ErrorMessageMode.DEVELOPER.value)
+
+# Initialize telemetry
+# This import only initializes the module, actual tracking will be disabled
+# if ANONYMIZED_TELEMETRY=false is set or if PostHog is not installed
+from notte.common import telemetry  # type: ignore # noqa

--- a/src/notte/common/telemetry.py
+++ b/src/notte/common/telemetry.py
@@ -1,0 +1,112 @@
+import importlib.metadata as metadata
+import logging
+import os
+import platform
+import uuid
+from functools import wraps
+from typing import Any, Callable, TypeVar
+
+logger = logging.getLogger("notte.telemetry")
+
+try:
+    # Try to get the version of the package
+    __version__ = metadata.version("notte")
+except Exception:
+    __version__ = "unknown"
+
+
+TELEMETRY_ENABLED: bool = os.environ.get("ANONYMIZED_TELEMETRY", "true").lower() != "false"
+
+# anonymous ID
+INSTALLATION_ID: str = str(uuid.uuid4())
+
+
+POSTHOG_API_KEY: str = os.environ.get("POSTHOG_API_KEY", "phc_your_default_key_here")
+
+# PostHog host URL
+POSTHOG_HOST: str = os.environ.get("POSTHOG_HOST", "https://app.posthog.com")
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+# avoid unbound variable errors
+posthog = None
+posthog_available = False
+
+try:
+    import posthog
+
+    posthog_available = True
+except (ImportError, ModuleNotFoundError):
+    posthog = None  # Explicitly set to None
+    logger.debug("PostHog not installed. Telemetry will be disabled.")
+    posthog_available = False
+
+
+def setup_posthog() -> Any | None:
+    """Set up the PostHog client if enabled and available."""
+    if not TELEMETRY_ENABLED or not posthog_available or posthog is None:
+        return None
+
+    try:
+        # Use explicit Any type for client to resolve unknown type warnings
+        # And ignore the unknown type for posthog.Posthog
+        client: Any = posthog.Posthog(
+            api_key=POSTHOG_API_KEY,
+            host=POSTHOG_HOST,
+        )
+        return client
+    except Exception as e:
+        logger.debug(f"Failed to initialize PostHog: {e}")
+        return None
+
+
+# Initialize PostHog
+posthog_client = setup_posthog()
+
+
+def get_system_info() -> dict[str, Any]:
+    """Get anonymous system information."""
+    return {
+        "os": platform.system(),
+        "python_version": platform.python_version(),
+        "notte_version": __version__,
+    }
+
+
+def capture_event(event_name: str, properties: dict[str, Any] | None = None) -> None:
+    """Capture an event if telemetry is enabled."""
+    if not TELEMETRY_ENABLED or posthog_client is None:
+        return
+
+    try:
+        event_properties = properties or {}
+
+        # Add system info
+        event_properties.update(get_system_info())
+
+        # Send event to PostHog
+        posthog_client.capture(distinct_id=INSTALLATION_ID, event=event_name, properties=event_properties)
+    except Exception as e:
+        logger.debug(f"Telemetry error: {e}")
+
+
+def track_usage(method_name: str | None = None) -> Callable[[F], F]:
+    """Decorator to track usage of a method."""
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Capture event before function execution
+            event_name = method_name if method_name is not None else f"{func.__module__}.{func.__name__}"
+            capture_event(f"method.called.{event_name}")
+
+            # Execute the function
+            result = func(*args, **kwargs)
+
+            # Return the original result
+            return result
+
+        return wrapper  # type: ignore
+
+    return decorator


### PR DESCRIPTION
Ref #165 
This PR sets the foundation for telemetry via PostHog.
Further it can be extended in future.

<img width="918" alt="image" src="https://github.com/user-attachments/assets/9b4f47b8-0cc1-453f-b0f7-58262fd58c26" />

The changes include enabling or disabling telemetry collection, setting up the PostHog client, and tracking events. The most important changes are listed below:

### Telemetry Configuration:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR22-R37): Added configuration options for enabling/disabling telemetry and specifying PostHog API key and host URL.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R50-R52): Added `posthog` dependency under a new `telemetry` section.

### Telemetry Initialization:

* [`src/notte/__init__.py`](diffhunk://#diff-14c5f14eafe62543c774c97da41e88f698eb8ae8a26aed9001611486bd6be5b5R15-R19): Initialized the telemetry module to enable tracking if configured.
* [`src/notte/common/telemetry.py`](diffhunk://#diff-982cbb154342eafc80f62495aba60385655b85ab767795ef14bf58eadd290843R1-R112): Implemented the telemetry module with functions to set up PostHog, capture events, and track method usage.

### Event Tracking:

* [`src/notte/env.py`](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R19): Integrated telemetry tracking into various methods using the `track_usage` decorator and `capture_event` function to record method calls and environment initialization. [[1]](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R19) [[2]](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R191-R203) [[3]](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R301-R307) [[4]](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R323) [[5]](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R340) [[6]](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R362) [[7]](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R380) [[8]](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R393) [[9]](diffhunk://#diff-d92cc33a07f1de9054e6cdbcdec9a471ba4ab6a1bd34a249203953acb9c79c10R416)