### PR TITLE
make adding credentials nicer

### DIFF
--- a/examples/leetcode_agent.py
+++ b/examples/leetcode_agent.py
@@ -5,7 +5,6 @@ from dotenv import load_dotenv
 
 from notte.agents import Agent
 from notte.common.agent.types import AgentResponse
-from notte.common.credential_vault.base import CredentialField, EmailField, PasswordField, VaultCredentials
 from notte.common.credential_vault.hashicorp.vault import HashiCorpVault
 
 
@@ -18,11 +17,9 @@ async def main():
     vault = HashiCorpVault.create_from_env()
 
     # Add leetcode credentials
-    creds: list[CredentialField] = [
-        EmailField(value=os.environ["LEETCODE_USERNAME"]),
-        PasswordField(value=os.environ["LEETCODE_PASSWORD"]),
-    ]
-    await vault.add_credentials(VaultCredentials(url="https://leetcode.com", creds=creds))
+    email = os.environ["LEETCODE_USERNAME"]
+    password = os.environ["LEETCODE_PASSWORD"]
+    await vault.add_credentials(url="https://leetcode.com", email=email, password=password)
 
     agent: Agent = Agent(vault=vault)
 

--- a/examples/vault_agent.py
+++ b/examples/vault_agent.py
@@ -5,7 +5,6 @@ from dotenv import load_dotenv
 
 from notte.agents.falco.agent import FalcoAgent as Agent
 from notte.agents.falco.agent import FalcoAgentConfig as AgentConfig
-from notte.common.credential_vault.base import CredentialField, EmailField, MFAField, PasswordField, VaultCredentials
 from notte.common.credential_vault.hashicorp.vault import HashiCorpVault
 
 
@@ -18,13 +17,13 @@ async def main():
     # - VAULT_DEV_ROOT_TOKEN_ID: The root token for authentication in dev mode
     vault = HashiCorpVault.create_from_env()
 
-    # Add twitter credentials
-    creds: list[CredentialField] = [
-        EmailField(value=os.environ["GITHUB_USERNAME"]),
-        PasswordField(value=os.environ["GITHUB_PASSWORD"]),
-        MFAField(value=os.environ["GITHUB_2FA"]),
-    ]
-    await vault.add_credentials(VaultCredentials(url="https://github.com", creds=creds))
+    email = os.environ["GITHUB_USERNAME"]
+    password = os.environ["GITHUB_PASSWORD"]
+    mfa_secret = os.environ["GITHUB_2FA"]
+
+    await vault.add_credentials(
+        url="https://github.com", email=email, username=email, password=password, mfa_secret=mfa_secret
+    )
 
     config = (
         AgentConfig()

--- a/src/notte/common/credential_vault/base.py
+++ b/src/notte/common/credential_vault/base.py
@@ -5,12 +5,12 @@ import logging
 import re
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Callable, ClassVar
+from typing import Any, Callable, ClassVar, Unpack
 
 from patchright.async_api import Locator
 from pydantic import BaseModel, Field, field_validator, model_serializer
 from pyotp.totp import TOTP
-from typing_extensions import override
+from typing_extensions import TypedDict, override
 
 from notte.actions.base import ActionParameterValue, ExecutableAction
 from notte.browser.snapshot import BrowserSnapshot
@@ -21,13 +21,16 @@ from notte.llms.engine import TResponseFormat
 
 class CredentialField(BaseModel, ABC, frozen=True):  # type: ignore[reportUnsafeInheritance]
     value: str
+    alias: ClassVar[str]
     singleton: ClassVar[bool] = False
     placeholder_value: ClassVar[str]
     registry: ClassVar[dict[str, type[CredentialField]]] = {}
 
     def __init_subclass__(cls, **kwargs: dict[Any, Any]):
         super().__init_subclass__(**kwargs)  # type: ignore
-        CredentialField.registry[cls.__qualname__] = cls
+
+        if hasattr(cls, "alias"):
+            CredentialField.registry[cls.alias] = cls
 
     @abstractmethod
     async def validate_element(self, locator: Locator) -> bool:
@@ -47,7 +50,7 @@ class CredentialField(BaseModel, ABC, frozen=True):  # type: ignore[reportUnsafe
     @model_serializer
     def to_dict(self):
         dic = self.__dict__
-        dic["field_name"] = self.__class__.__name__
+        dic["field_name"] = self.alias
         return dic
 
     @staticmethod
@@ -66,6 +69,7 @@ class CredentialField(BaseModel, ABC, frozen=True):  # type: ignore[reportUnsafe
 
 class EmailField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = False
+    alias: ClassVar[str] = "email"
     placeholder_value: ClassVar[str] = "user@example.org"
     field_autocomplete: ClassVar[str] = "username"
 
@@ -81,6 +85,7 @@ class EmailField(CredentialField, frozen=True):
 
 class PhoneNumberField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = False
+    alias: ClassVar[str] = "phone_number"
     placeholder_value: ClassVar[str] = "8005550175"
 
     @override
@@ -98,6 +103,7 @@ class PhoneNumberField(CredentialField, frozen=True):
 
 class FirstNameField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = False
+    alias: ClassVar[str] = "first_name"
     placeholder_value: ClassVar[str] = "Johnny"
 
     @override
@@ -112,6 +118,7 @@ class FirstNameField(CredentialField, frozen=True):
 
 class LastNameField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = False
+    alias: ClassVar[str] = "last_name"
     placeholder_value: ClassVar[str] = "Dough"
 
     @override
@@ -126,6 +133,7 @@ class LastNameField(CredentialField, frozen=True):
 
 class UserNameField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = False
+    alias: ClassVar[str] = "username"
     placeholder_value: ClassVar[str] = "cooljohnny1567"
 
     @override
@@ -140,6 +148,7 @@ class UserNameField(CredentialField, frozen=True):
 
 class MFAField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = False
+    alias: ClassVar[str] = "mfa_secret"
     placeholder_value: ClassVar[str] = "999779"
 
     @override
@@ -154,6 +163,7 @@ class MFAField(CredentialField, frozen=True):
 
 class DoBDayField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = True
+    alias: ClassVar[str] = "day_of_birth"
     placeholder_value: ClassVar[str] = "01"
 
     @override
@@ -168,6 +178,7 @@ class DoBDayField(CredentialField, frozen=True):
 
 class DoBMonthField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = True
+    alias: ClassVar[str] = "month_of_birth"
     placeholder_value: ClassVar[str] = "01"
 
     @override
@@ -182,6 +193,7 @@ class DoBMonthField(CredentialField, frozen=True):
 
 class DoBYearField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = True
+    alias: ClassVar[str] = "year_of_birth"
     placeholder_value: ClassVar[str] = "1990"
 
     @override
@@ -196,6 +208,7 @@ class DoBYearField(CredentialField, frozen=True):
 
 class PasswordField(CredentialField, frozen=True):
     singleton: ClassVar[bool] = False
+    alias: ClassVar[str] = "password"
     placeholder_value: ClassVar[str] = "mycoolpassword"
     field_autocomplete: ClassVar[str] = "current-password"
 
@@ -235,6 +248,7 @@ class RegexCredentialField(CredentialField, ABC, frozen=True):
 
 class CardHolderField(RegexCredentialField, frozen=True):
     singleton: ClassVar[bool] = True
+    alias: ClassVar[str] = "card_holder_name"
     placeholder_value: ClassVar[str] = "John Doe"
     field_autocomplete: ClassVar[str] = "cc-name"
     field_regex: ClassVar[re.Pattern[str]] = re.compile(
@@ -245,14 +259,16 @@ class CardHolderField(RegexCredentialField, frozen=True):
 
 class CardNumberField(RegexCredentialField, frozen=True):
     singleton: ClassVar[bool] = False
+    alias: ClassVar[str] = "card_number"
     placeholder_value: ClassVar[str] = "4242 4242 4242 4242"
     field_autocomplete: ClassVar[str] = "cc-number"
     field_regex: ClassVar[re.Pattern[str]] = re.compile(r"(cc|card).*-?(num|number|no)|number|card-no", re.IGNORECASE)
     instruction_name: ClassVar[str] = "a payment form card number"
 
 
-class CardCCVField(RegexCredentialField, frozen=True):
+class CardCVVField(RegexCredentialField, frozen=True):
     singleton: ClassVar[bool] = True
+    alias: ClassVar[str] = "card_cvv"
     placeholder_value: ClassVar[str] = "444"
     field_autocomplete: ClassVar[str] = "cc-csc"
     field_regex: ClassVar[re.Pattern[str]] = re.compile(
@@ -264,6 +280,7 @@ class CardCCVField(RegexCredentialField, frozen=True):
 
 class CardFullExpirationField(RegexCredentialField, frozen=True):
     singleton: ClassVar[bool] = True
+    alias: ClassVar[str] = "card_full_expiration"
     placeholder_value: ClassVar[str] = "04/25"
     field_autocomplete: ClassVar[str] = "cc-exp"
     field_regex: ClassVar[re.Pattern[str]] = re.compile(
@@ -275,6 +292,7 @@ class CardFullExpirationField(RegexCredentialField, frozen=True):
 
 class CardMonthExpirationField(RegexCredentialField, frozen=True):
     singleton: ClassVar[bool] = True
+    alias: ClassVar[str] = "card_month_expiration"
     placeholder_value: ClassVar[str] = "05"
     field_autocomplete: ClassVar[str] = "cc-exp-month"
     field_regex: ClassVar[re.Pattern[str]] = re.compile(
@@ -286,6 +304,7 @@ class CardMonthExpirationField(RegexCredentialField, frozen=True):
 
 class CardYearExpirationField(RegexCredentialField, frozen=True):
     singleton: ClassVar[bool] = True
+    alias: ClassVar[str] = "card_year_expiration"
     placeholder_value: ClassVar[str] = "25"
     field_autocomplete: ClassVar[str] = "cc-exp-year"
     field_regex: ClassVar[re.Pattern[str]] = re.compile(
@@ -320,19 +339,60 @@ class VaultCredentials(BaseModel):
 recursive_data = list["recursive_data"] | dict[str, "recursive_data"] | str | Any
 
 
+class CredentialsDict(TypedDict, total=False):
+    email: str | None
+    phone: str | None
+    first_name: str | None
+    last_name: str | None
+    username: str | None
+    mfa_secret: str | None
+    day_of_birth: str | None
+    month_of_birth: str | None
+    year_of_birth: str | None
+    password: str | None
+    card_holder_name: str | None
+    card_number: str | None
+    card_cvv: str | None
+    card_full_expiration: str | None
+    card_month_expiration: str | None
+    card_year_expiration: str | None
+
+
 class BaseVault(ABC):
     """Base class for vault implementations that handle credential storage and retrieval."""
 
     _retrieved_credentials: dict[str, VaultCredentials] = {}
 
     @abstractmethod
-    async def add_credentials(self, creds: VaultCredentials) -> None:
+    async def _add_credentials(self, creds: VaultCredentials) -> None:
         """Store credentials for a given URL"""
         pass
 
-    @abstractmethod
-    async def set_singleton_credentials(self, creds: list[CredentialField]) -> None:
+    async def add_credentials(self, url: str | None, **kwargs: Unpack[CredentialsDict]) -> None:
         """Store credentials for a given URL"""
+        creds: list[CredentialField] = []
+
+        for key, value in kwargs.items():
+            cred_class = CredentialField.registry.get(key)
+
+            if cred_class is None:
+                raise ValueError(f"Invalid credential type {key}. Valid types are: {CredentialField.registry.keys()}")
+
+            if not isinstance(value, str):
+                raise ValueError("Invalid credential type {type(value)}, should be str")
+
+            creds.append(cred_class(value=value))
+
+        if url is None:
+            return await self._set_singleton_credentials(creds=creds)
+        return await self._add_credentials(VaultCredentials(url=url, creds=creds))
+
+    async def set_singleton_credentials(self, **kwargs: Unpack[CredentialsDict]) -> None:
+        return await self.add_credentials(url=None, **kwargs)
+
+    @abstractmethod
+    async def _set_singleton_credentials(self, creds: list[CredentialField]) -> None:
+        """Set credentials which are shared across all urls, not hidden"""
         pass
 
     @abstractmethod

--- a/src/notte/common/credential_vault/base.py
+++ b/src/notte/common/credential_vault/base.py
@@ -340,22 +340,22 @@ recursive_data = list["recursive_data"] | dict[str, "recursive_data"] | str | An
 
 
 class CredentialsDict(TypedDict, total=False):
-    email: str | None
-    phone: str | None
-    first_name: str | None
-    last_name: str | None
-    username: str | None
-    mfa_secret: str | None
-    day_of_birth: str | None
-    month_of_birth: str | None
-    year_of_birth: str | None
-    password: str | None
-    card_holder_name: str | None
-    card_number: str | None
-    card_cvv: str | None
-    card_full_expiration: str | None
-    card_month_expiration: str | None
-    card_year_expiration: str | None
+    email: str
+    phone_number: str
+    first_name: str
+    last_name: str
+    username: str
+    mfa_secret: str
+    day_of_birth: str
+    month_of_birth: str
+    year_of_birth: str
+    password: str
+    card_holder_name: str
+    card_number: str
+    card_cvv: str
+    card_full_expiration: str
+    card_month_expiration: str
+    card_year_expiration: str
 
 
 class BaseVault(ABC):

--- a/src/notte/common/credential_vault/hashicorp/vault.py
+++ b/src/notte/common/credential_vault/hashicorp/vault.py
@@ -80,7 +80,7 @@ class HashiCorpVault(BaseVault):
         return tldextract.extract(url).domain or url
 
     @override
-    async def set_singleton_credentials(self, creds: list[CredentialField]) -> None:
+    async def _set_singleton_credentials(self, creds: list[CredentialField]) -> None:
         for cred in creds:
             if not cred.singleton:
                 raise ValueError(f"{cred.__class__} can't be set as singleton credential: url-specific only")
@@ -105,7 +105,7 @@ class HashiCorpVault(BaseVault):
         return [CredentialField.registry[key](value=value) for key, value in data.items()]
 
     @override
-    async def add_credentials(self, creds: VaultCredentials) -> None:
+    async def _add_credentials(self, creds: VaultCredentials) -> None:
         for cred in creds.creds:
             if cred.singleton:
                 raise ValueError(f"{cred.__class__} can't be set as url specific credential: singleton only")

--- a/src/notte/sdk/client.py
+++ b/src/notte/sdk/client.py
@@ -4,6 +4,7 @@ from notte.sdk.endpoints.agents import AgentsClient
 from notte.sdk.endpoints.env import EnvClient
 from notte.sdk.endpoints.persona import PersonaClient
 from notte.sdk.endpoints.sessions import SessionsClient
+from notte.sdk.vault import SdkVault
 
 
 @final
@@ -32,3 +33,6 @@ class NotteClient:
         self.agents: AgentsClient = AgentsClient(api_key=api_key, verbose=verbose)
         self.env: EnvClient = EnvClient(api_key=api_key, verbose=verbose)
         self.persona: PersonaClient = PersonaClient(api_key=api_key, verbose=verbose)
+
+    def vault(self, persona_id: str) -> SdkVault:
+        return SdkVault(persona_client=self.persona, persona_id=persona_id)

--- a/src/notte/sdk/vault.py
+++ b/src/notte/sdk/vault.py
@@ -12,15 +12,15 @@ from notte.common.credential_vault.base import (
     CredentialField,
     VaultCredentials,
 )
-from notte.sdk.client import NotteClient
+from notte.sdk.endpoints.persona import PersonaClient
 
 
 @final
 class SdkVault(BaseVault):
     """Vault that fetches credentials stored using the sdk"""
 
-    def __init__(self, sdk_client: NotteClient, persona_id: str):
-        self.sdk_client = sdk_client
+    def __init__(self, persona_client: PersonaClient, persona_id: str):
+        self.persona_client = persona_client
         self.persona_id = persona_id
 
     @staticmethod
@@ -29,39 +29,39 @@ class SdkVault(BaseVault):
         return ".".join((extracted.domain, extracted.suffix)) or url
 
     @override
-    async def set_singleton_credentials(self, creds: list[CredentialField]) -> None:
+    async def _set_singleton_credentials(self, creds: list[CredentialField]) -> None:
         for cred in creds:
             if not cred.singleton:
                 raise ValueError(f"{cred.__class__} can't be set as singleton credential: url-specific only")
 
-        _ = self.sdk_client.persona.add_credentials(self.persona_id, url=None, credentials=list(creds))
+        _ = self.persona_client.add_credentials(self.persona_id, url=None, credentials=list(creds))
 
     @override
     async def get_singleton_credentials(self) -> list[CredentialField]:
         try:
-            return self.sdk_client.persona.get_credentials(self.persona_id, url=None).credentials
+            return self.persona_client.get_credentials(self.persona_id, url=None).credentials
         except Exception as e:
             logger.warning(f"Could not get singleton credentials: {e} {traceback.format_exc()}")
             return []
 
     @override
-    async def add_credentials(self, creds: VaultCredentials) -> None:
+    async def _add_credentials(self, creds: VaultCredentials) -> None:
         for cred in creds.creds:
             if cred.singleton:
                 raise ValueError(f"{cred.__class__} can't be set as url specific credential: singleton only")
 
         domain = SdkVault.get_root_domain(creds.url)
-        _ = self.sdk_client.persona.add_credentials(self.persona_id, url=domain, credentials=list(creds.creds))
+        _ = self.persona_client.add_credentials(self.persona_id, url=domain, credentials=list(creds.creds))
 
     @override
     async def _get_credentials_impl(self, url: str) -> VaultCredentials | None:
         try:
             domain = SdkVault.get_root_domain(url)
-            creds = self.sdk_client.persona.get_credentials(self.persona_id, url=domain).credentials
+            creds = self.persona_client.get_credentials(self.persona_id, url=domain).credentials
             return VaultCredentials(url=url, creds=creds)
         except Exception:
             logger.warning(f"Failed to get creds: {traceback.format_exc()}")
 
     @override
     async def remove_credentials(self, url: str | None) -> None:
-        _ = self.sdk_client.persona.delete_credentials(self.persona_id, url=url)
+        _ = self.persona_client.delete_credentials(self.persona_id, url=url)


### PR DESCRIPTION
allows doing

```
from notte.sdk.client import NotteClient
client = NotteClient(api_key="<my_api_key>")
vault = client.vault(persona_id="<my_persona_id>")
vault.add_credentials(url="my_url", email="myemail@gmail.com", username="myusername", password="mypassword", mfa_code="mfa_code")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new vault integration within the client interface, allowing users to easily obtain secure credential management for their identity.

- **Refactor**
	- Streamlined the credential handling process by simplifying assignments and enhancing type safety.
	- Improved the overall structure to deliver a more robust, maintainable, and efficient credential management experience.
	- Enhanced method visibility for better clarity on intended usage.
	- Updated credential handling for LeetCode and Vault Agent to utilize direct assignments from environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->