### PR TITLE
fix cdp chrome args bugs

### DIFF
--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -26,7 +26,7 @@ client.sessions.stop(session.session_id)
 
 ```python
 from patchright.async_api import async_playwright
-from notte_core.sdk.client import NotteClient
+from notte_sdk import NotteClient
 
 client = NotteClient(api_key="<your-api-key>")
 

--- a/packages/notte-browser/src/notte_browser/playwright.py
+++ b/packages/notte-browser/src/notte_browser/playwright.py
@@ -122,7 +122,7 @@ class WindowManager(PlaywrightManager):
                     headless=options.headless,
                     proxy=options.proxy.to_playwright() if options.proxy is not None else None,
                     timeout=self.BROWSER_CREATION_TIMEOUT_SECONDS * 1000,
-                    args=options.chrome_args,
+                    args=options.get_chrome_args(),
                 )
             case BrowserType.FIREFOX:
                 browser = await self.playwright.firefox.launch(

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -53,6 +53,8 @@ class BrowserWindowOptions(FrozenConfig):
         if self.cookies_path is not None and self.cookies is None:
             cookies = Cookie.from_json(self.cookies_path)
             object.__setattr__(self, "cookies", cookies)
+
+    def get_chrome_args(self) -> list[str]:
         chrome_args = self.chrome_args or []
         if self.chrome_args is None:
             chrome_args.extend(
@@ -87,7 +89,7 @@ class BrowserWindowOptions(FrozenConfig):
             )
         if self.debug_port is not None:
             chrome_args.append(f"--remote-debugging-port={self.debug_port}")
-        object.__setattr__(self, "chrome_args", chrome_args)
+        return chrome_args
 
     def set_port(self, port: int) -> Self:
         return self._copy_and_validate(debug_port=port)

--- a/tests/integration/sdk/test_cdp.py
+++ b/tests/integration/sdk/test_cdp.py
@@ -1,0 +1,21 @@
+from notte_sdk.client import NotteClient
+from patchright.sync_api import sync_playwright
+
+
+def test_cdp_connection():
+    client = NotteClient()
+
+    # start notte session
+    session = client.sessions.start()
+
+    debug_info = client.sessions.debug_info(session.session_id)
+
+    # connect using CDP
+    with sync_playwright() as p:
+        browser = p.chromium.connect_over_cdp(debug_info.ws_url)
+        page = browser.contexts[0].pages[0]
+        _ = page.goto("https://www.google.com")
+        screenshot = page.screenshot(path="screenshot.png")
+        assert screenshot is not None
+
+    _ = client.sessions.close(session.session_id)

--- a/tests/sdk/test_openapi_spec.py
+++ b/tests/sdk/test_openapi_spec.py
@@ -1,8 +1,10 @@
+import pytest
 import requests
 
 
+@pytest.mark.skip(reason="Run this manually when you want to update the spec")
 def test_openapi_spec_should_identical_on_staging_and_prod():
     "Compare spec on staging and production"
     staging_spec = requests.get("https://staging.notte.cc/openapi.json")
     production_spec = requests.get("https://api.notte.cc/openapi.json")
-    assert staging_spec.json() == production_spec.json()
+    assert staging_spec.json() == production_spec.json(), "Staging and production specs are not identical"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the SDK tutorial to reflect the correct import path for NotteClient.
- **New Features**
  - Added a new integration test to verify connecting to browser sessions via Chrome DevTools Protocol (CDP) using the SDK.
- **Refactor**
  - Improved the way Chrome command-line arguments are constructed and retrieved for browser sessions, allowing for more flexible configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->