### PR TITLE
Evaluate iframes independently when building dom tree

### DIFF
--- a/.github/workflows/test-cicd.yml
+++ b/.github/workflows/test-cicd.yml
@@ -23,6 +23,7 @@ env:
   CACHE_TYPE: "pip"
   NOTTE_API_KEY: ${{ secrets.NOTTE_API_KEY }}
   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+  RUNNING_IN_CI: 1
 
 jobs:
   tests:

--- a/packages/notte-browser/src/notte_browser/dom/buildDomNode.js
+++ b/packages/notte-browser/src/notte_browser/dom/buildDomNode.js
@@ -485,20 +485,8 @@
 			nodeData.children.push(...shadowChildren);
 		}
 
-		// Handle iframes
-		if (node.tagName === 'IFRAME') {
-			try {
-				const iframeDoc = node.contentDocument || node.contentWindow.document;
-				if (iframeDoc) {
-					const iframeChildren = Array.from(iframeDoc.body.childNodes).map(child =>
-						buildDomTree(child, node)
-					);
-					nodeData.children.push(...iframeChildren);
-				}
-			} catch (e) {
-				console.warn('Unable to access iframe:', node);
-			}
-		} else {
+		// Don't go through iframes: handle this through dom/parsing.py
+		if (node.tagName !== 'IFRAME') {
 			const children = Array.from(node.childNodes).map(child =>
 				buildDomTree(child, parentIframe)
 			);

--- a/tests/browser/oldBuildDom.js
+++ b/tests/browser/oldBuildDom.js
@@ -1,0 +1,513 @@
+// file taken from: https://github.com/browser-use/browser-use/blob/main/browser_use/dom/buildDomTree.js
+(
+	{highlight_elements, focus_element, viewport_expansion }
+) => {
+
+	let highlightIndex = 0; // Reset highlight index
+
+	function highlightElement(element, index, parentIframe = null) {
+		// Create or get highlight container
+		let container = document.getElementById('playwright-highlight-container');
+		if (!container) {
+			container = document.createElement('div');
+			container.id = 'playwright-highlight-container';
+			container.style.position = 'absolute';
+			container.style.pointerEvents = 'none';
+			container.style.top = '0';
+			container.style.left = '0';
+			container.style.width = '100%';
+			container.style.height = '100%';
+			container.style.zIndex = '2147483647'; // Maximum z-index value
+			document.body.appendChild(container);
+		}
+
+		// Generate a color based on the index
+		const colors = [
+			'#FF0000', '#00FF00', '#0000FF', '#FFA500',
+			'#800080', '#008080', '#FF69B4', '#4B0082',
+			'#FF4500', '#2E8B57', '#DC143C', '#4682B4'
+		];
+		const colorIndex = index % colors.length;
+		const baseColor = colors[colorIndex];
+		const backgroundColor = `${baseColor}1A`; // 10% opacity version of the color
+
+		// Create highlight overlay
+		const overlay = document.createElement('div');
+		overlay.style.position = 'absolute';
+		overlay.style.border = `2px solid ${baseColor}`;
+		overlay.style.backgroundColor = backgroundColor;
+		overlay.style.pointerEvents = 'none';
+		overlay.style.boxSizing = 'border-box';
+
+		// Position overlay based on element, including scroll position
+		const rect = element.getBoundingClientRect();
+		let top = rect.top + window.scrollY;
+		let left = rect.left + window.scrollX;
+
+		// Adjust position if element is inside an iframe
+		if (parentIframe) {
+			const iframeRect = parentIframe.getBoundingClientRect();
+			top += iframeRect.top;
+			left += iframeRect.left;
+		}
+
+		overlay.style.top = `${top}px`;
+		overlay.style.left = `${left}px`;
+		overlay.style.width = `${rect.width}px`;
+		overlay.style.height = `${rect.height}px`;
+
+		// Create label
+		const label = document.createElement('div');
+		label.className = 'playwright-highlight-label';
+		label.style.position = 'absolute';
+		label.style.background = baseColor;
+		label.style.color = 'white';
+		label.style.padding = '1px 4px';
+		label.style.borderRadius = '4px';
+		label.style.fontSize = `${Math.min(12, Math.max(8, rect.height / 2))}px`; // Responsive font size
+		label.textContent = index;
+
+		// Calculate label position
+		const labelWidth = 20; // Approximate width
+		const labelHeight = 16; // Approximate height
+
+		// Default position (top-right corner inside the box)
+		let labelTop = top + 2;
+		let labelLeft = left + rect.width - labelWidth - 2;
+
+		// Adjust if box is too small
+		if (rect.width < labelWidth + 4 || rect.height < labelHeight + 4) {
+			// Position outside the box if it's too small
+			labelTop = top - labelHeight - 2;
+			labelLeft = left + rect.width - labelWidth;
+		}
+
+
+		label.style.top = `${labelTop}px`;
+		label.style.left = `${labelLeft}px`;
+
+		// Add to container
+		container.appendChild(overlay);
+		container.appendChild(label);
+
+		// Store reference for cleanup
+		element.setAttribute('browser-user-highlight-id', `playwright-highlight-${index}`);
+
+		return index + 1;
+	}
+
+
+	// Helper function to generate XPath as a tree
+	function getXPathTree(element, stopAtBoundary = true) {
+		const segments = [];
+		let currentElement = element;
+
+		while (currentElement && currentElement.nodeType === Node.ELEMENT_NODE) {
+			// Stop if we hit a shadow root or iframe
+			if (stopAtBoundary && (currentElement.parentNode instanceof ShadowRoot || currentElement.parentNode instanceof HTMLIFrameElement)) {
+				break;
+			}
+
+			let index = 0;
+			let sibling = currentElement.previousSibling;
+			while (sibling) {
+				if (sibling.nodeType === Node.ELEMENT_NODE &&
+					sibling.nodeName === currentElement.nodeName) {
+					index++;
+				}
+				sibling = sibling.previousSibling;
+			}
+			// should also iteratate over the next siblings look if there is a next sibling with the same tag name
+			let moreSiblings = false;
+			let nextSibling = currentElement.nextSibling;
+			while (nextSibling) {
+				if (nextSibling.nodeType === Node.ELEMENT_NODE &&
+					nextSibling.nodeName === currentElement.nodeName) {
+					moreSiblings = true;
+				}
+				nextSibling = nextSibling.nextSibling;
+			}
+
+			const tagName = currentElement.nodeName.toLowerCase();
+			const xpathIndex = (index > 0 || moreSiblings) ? `[${index + 1}]` : '';
+			segments.unshift(`${tagName}${xpathIndex}`);
+
+			currentElement = currentElement.parentNode;
+		}
+
+		return segments.join('/');
+	}
+
+	// Helper function to check if element is accepted
+	function isElementAccepted(element) {
+		const leafElementDenyList = new Set(['svg', 'script', 'style', 'link', 'meta']);
+		return !leafElementDenyList.has(element.tagName.toLowerCase());
+	}
+
+
+    // Add isEditable check
+    function isEditableElement(element) {
+        // Check if element is disabled
+        if (element.disabled || element.getAttribute('aria-disabled') === 'true') {
+            return false;
+        }
+
+        // Check for readonly attribute
+        const isReadonly = element.hasAttribute('readonly') ||
+                          element.getAttribute('aria-readonly') === 'true';
+
+        // For select, input, and textarea, check readonly attribute
+        if (element.tagName.toLowerCase() in {'select': 1, 'input': 1, 'textarea': 1}) {
+            return !isReadonly;
+        }
+
+        // Check contenteditable
+        if (element.hasAttribute('contenteditable') &&
+            element.getAttribute('contenteditable') !== 'false') {
+            return !isReadonly;
+        }
+
+        return false;
+    }
+
+	// Helper function to check if element is interactive
+	function isInteractiveElement(element) {
+		// Base interactive elements and roles
+		const interactiveElements = new Set([
+			'a', 'button', 'details', 'embed', 'input', 'label',
+			'menu', 'menuitem', 'object', 'select', 'textarea', 'summary'
+		]);
+
+		const interactiveRoles = new Set([
+			'button', 'menu', 'menuitem', 'link', 'checkbox', 'radio',
+			'slider', 'tab', 'tabpanel', 'textbox', 'combobox', 'grid',
+			'listbox', 'option', 'progressbar', 'scrollbar', 'searchbox',
+			'switch', 'tree', 'treeitem', 'spinbutton', 'tooltip', 'a-button-inner', 'a-dropdown-button', 'click',
+			'menuitemcheckbox', 'menuitemradio', 'a-button-text', 'button-text', 'button-icon', 'button-icon-only', 'button-text-icon-only', 'dropdown', 'combobox'
+		]);
+
+		const tagName = element.tagName.toLowerCase();
+		const role = element.getAttribute('role');
+		const ariaRole = element.getAttribute('aria-role');
+		const tabIndex = element.getAttribute('tabindex');
+
+		// Add check for specific class
+		const hasAddressInputClass = element.classList.contains('address-input__container__input');
+
+		// Basic role/attribute checks
+		const hasInteractiveRole = hasAddressInputClass ||
+			interactiveElements.has(tagName) ||
+			interactiveRoles.has(role) ||
+			interactiveRoles.has(ariaRole) ||
+			(tabIndex !== null && tabIndex !== '-1') ||
+			element.getAttribute('data-action') === 'a-dropdown-select' ||
+			element.getAttribute('data-action') === 'a-dropdown-button';
+
+		if (hasInteractiveRole) return true;
+
+		// Get computed style
+		const style = window.getComputedStyle(element);
+
+		// Check if element has click-like styling
+		// const hasClickStyling = style.cursor === 'pointer' ||
+		//     element.style.cursor === 'pointer' ||
+		//     style.pointerEvents !== 'none';
+
+		// Check for event listeners
+		const hasClickHandler = element.onclick !== null ||
+			element.getAttribute('onclick') !== null ||
+			element.hasAttribute('ng-click') ||
+			element.hasAttribute('@click') ||
+			element.hasAttribute('v-on:click');
+
+		// Helper function to safely get event listeners
+		function getEventListeners(el) {
+			try {
+				// Try to get listeners using Chrome DevTools API
+				return window.getEventListeners?.(el) || {};
+			} catch (e) {
+				// Fallback: check for common event properties
+				const listeners = {};
+
+				// List of common event types to check
+				const eventTypes = [
+					'click', 'mousedown', 'mouseup',
+					'touchstart', 'touchend',
+					'keydown', 'keyup', 'focus', 'blur'
+				];
+
+				for (const type of eventTypes) {
+					const handler = el[`on${type}`];
+					if (handler) {
+						listeners[type] = [{
+							listener: handler,
+							useCapture: false
+						}];
+					}
+				}
+
+				return listeners;
+			}
+		}
+
+		// Check for click-related events on the element itself
+		const listeners = getEventListeners(element);
+		const hasClickListeners = listeners && (
+			listeners.click?.length > 0 ||
+			listeners.mousedown?.length > 0 ||
+			listeners.mouseup?.length > 0 ||
+			listeners.touchstart?.length > 0 ||
+			listeners.touchend?.length > 0
+		);
+
+		// Check for ARIA properties that suggest interactivity
+		const hasAriaProps = element.hasAttribute('aria-expanded') ||
+			element.hasAttribute('aria-pressed') ||
+			element.hasAttribute('aria-selected') ||
+			element.hasAttribute('aria-checked');
+
+		// Check for form-related functionality
+		const isFormRelated = element.form !== undefined ||
+			element.hasAttribute('contenteditable') ||
+			style.userSelect !== 'none';
+
+		// Check if element is draggable
+		const isDraggable = element.draggable ||
+			element.getAttribute('draggable') === 'true';
+
+		return hasAriaProps ||
+			// hasClickStyling ||
+			hasClickHandler ||
+			hasClickListeners ||
+			// isFormRelated ||
+			isDraggable;
+
+	}
+
+	// Helper function to check if element is visible
+	function isElementVisible(element) {
+		const style = window.getComputedStyle(element);
+		return element.offsetWidth > 0 &&
+			element.offsetHeight > 0 &&
+			style.visibility !== 'hidden' &&
+			style.display !== 'none';
+	}
+
+	// Helper function to check if element is the top element at its position
+	function isTopElement(element) {
+		// Find the correct document context and root element
+		let doc = element.ownerDocument;
+
+		// If we're in an iframe, elements are considered top by default
+		if (doc !== window.document) {
+			return true;
+		}
+
+		// For shadow DOM, we need to check within its own root context
+		const shadowRoot = element.getRootNode();
+		if (shadowRoot instanceof ShadowRoot) {
+			const rect = element.getBoundingClientRect();
+			const point = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+
+			try {
+				// Use shadow root's elementFromPoint to check within shadow DOM context
+				const topEl = shadowRoot.elementFromPoint(point.x, point.y);
+				if (!topEl) return false;
+
+				// Check if the element or any of its parents match our target element
+				let current = topEl;
+				while (current && current !== shadowRoot) {
+					if (current === element) return true;
+					current = current.parentElement;
+				}
+				return false;
+			} catch (e) {
+				return true; // If we can't determine, consider it visible
+			}
+		}
+
+		// Regular DOM elements
+		const rect = element.getBoundingClientRect();
+
+		// If viewportExpansion is -1, check if element is the top one at its position
+		if (viewport_expansion === -1) {
+			return true; // Consider all elements as top elements when expansion is -1
+		}
+
+		// Calculate expanded viewport boundaries including scroll position
+		const scrollX = window.scrollX;
+		const scrollY = window.scrollY;
+		const viewportTop = -viewport_expansion + scrollY;
+		const viewportLeft = -viewport_expansion + scrollX;
+		const viewportBottom = window.innerHeight + viewport_expansion + scrollY;
+		const viewportRight = window.innerWidth + viewport_expansion + scrollX;
+
+		// Get absolute element position
+		const absTop = rect.top + scrollY;
+		const absLeft = rect.left + scrollX;
+		const absBottom = rect.bottom + scrollY;
+		const absRight = rect.right + scrollX;
+
+		// Skip if element is completely outside expanded viewport
+		if (absBottom < viewportTop ||
+			absTop > viewportBottom ||
+			absRight < viewportLeft ||
+			absLeft > viewportRight) {
+			return false;
+		}
+
+		// For elements within expanded viewport, check if they're the top element
+		try {
+			const centerX = rect.left + rect.width / 2;
+			const centerY = rect.top + rect.height / 2;
+
+			// Only clamp the point if it's outside the actual document
+			const point = {
+				x: centerX,
+				y: centerY
+			};
+
+			if (point.x < 0 || point.x >= window.innerWidth ||
+				point.y < 0 || point.y >= window.innerHeight) {
+				return false; // Consider elements with center outside viewport as visible
+			}
+
+			const topEl = document.elementFromPoint(point.x, point.y);
+			if (!topEl) return false;
+
+			let current = topEl;
+			while (current && current !== document.documentElement) {
+				if (current === element) return true;
+				current = current.parentElement;
+			}
+			return false;
+		} catch (e) {
+			return true;
+		}
+	}
+
+	// Helper function to check if text node is visible
+	function isTextNodeVisible(textNode) {
+		const range = document.createRange();
+		range.selectNodeContents(textNode);
+		const rect = range.getBoundingClientRect();
+
+		return rect.width !== 0 &&
+			rect.height !== 0 &&
+			rect.top >= 0 &&
+			rect.top <= window.innerHeight &&
+			textNode.parentElement?.checkVisibility({
+				checkOpacity: true,
+				checkVisibilityCSS: true
+			});
+	}
+
+
+	// Function to traverse the DOM and create nested JSON
+	function buildDomTree(node, parentIframe = null) {
+		if (!node) return null;
+
+		// Special case for text nodes
+		if (node.nodeType === Node.TEXT_NODE) {
+			const textContent = node.textContent.trim();
+			if (textContent && isTextNodeVisible(node)) {
+				return {
+					type: "TEXT_NODE",
+					text: textContent,
+					isVisible: true,
+				};
+			}
+			return null;
+		}
+
+		// Check if element is accepted
+		if (node.nodeType === Node.ELEMENT_NODE && !isElementAccepted(node)) {
+			return null;
+		}
+
+		const nodeData = {
+			tagName: node.tagName ? node.tagName.toLowerCase() : null,
+			attributes: {},
+			xpath: node.nodeType === Node.ELEMENT_NODE ? getXPathTree(node, true) : null,
+			children: [],
+		};
+
+		// Copy all attributes if the node is an element
+		if (node.nodeType === Node.ELEMENT_NODE && node.attributes) {
+			// Use getAttributeNames() instead of directly iterating attributes
+			const attributeNames = node.getAttributeNames?.() || [];
+			for (const name of attributeNames) {
+				nodeData.attributes[name] = node.getAttribute(name);
+			}
+		}
+
+		if (node.nodeType === Node.ELEMENT_NODE) {
+			const isInteractive = isInteractiveElement(node);
+			const isVisible = isElementVisible(node);
+			const isTop = isTopElement(node);
+            const isEditable = isEditableElement(node);
+
+			nodeData.isInteractive = isInteractive;
+			nodeData.isVisible = isVisible;
+			nodeData.isTopElement = isTop;
+			nodeData.isEditable = isEditable;
+
+			// Highlight if element meets all criteria and highlighting is enabled
+			if (isInteractive && isVisible && isTop) {
+				nodeData.highlightIndex = highlightIndex++;
+				if (highlight_elements) {
+					if (focus_element >= 0) {
+						if (focus_element === nodeData.highlightIndex) {
+							highlightElement(node, nodeData.highlightIndex, parentIframe);
+						}
+					} else {
+						highlightElement(node, nodeData.highlightIndex, parentIframe);
+					}
+				}
+			}
+		}
+
+		// Only add iframeContext if we're inside an iframe
+		// if (parentIframe) {
+		//     nodeData.iframeContext = `iframe[src="${parentIframe.src || ''}"]`;
+		// }
+
+		// Only add shadowRoot field if it exists
+		if (node.shadowRoot) {
+			nodeData.shadowRoot = true;
+		}
+
+		// Handle shadow DOM
+		if (node.shadowRoot) {
+			const shadowChildren = Array.from(node.shadowRoot.childNodes).map(child =>
+				buildDomTree(child, parentIframe)
+			);
+			nodeData.children.push(...shadowChildren);
+		}
+
+		// Handle iframes
+		if (node.tagName === 'IFRAME') {
+			try {
+				const iframeDoc = node.contentDocument || node.contentWindow.document;
+				if (iframeDoc) {
+					const iframeChildren = Array.from(iframeDoc.body.childNodes).map(child =>
+						buildDomTree(child, node)
+					);
+					nodeData.children.push(...iframeChildren);
+				}
+			} catch (e) {
+				console.warn('Unable to access iframe:', node);
+			}
+		} else {
+			const children = Array.from(node.childNodes).map(child =>
+				buildDomTree(child, parentIframe)
+			);
+			nodeData.children.push(...children);
+		}
+
+		return nodeData;
+	}
+
+
+	return buildDomTree(document.body);
+}

--- a/tests/browser/test_iframe.py
+++ b/tests/browser/test_iframe.py
@@ -122,15 +122,8 @@ SINGLE_WEBSITES = MULTI_WEBSITES + [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("url", SINGLE_WEBSITES)
 async def test_parsing_disabled_websecurity_session(url: str):
-    old_session = NotteSession(
-        config=NotteSessionConfig().disable_perception().headless().disable_web_security(),
-        llmserve=MockLLMService(mock_response=""),
-    )
-    async with old_session as sesh:
-        _ = await sesh.goto("https://bing.com")
-        raise ValueError(sesh.window.page.viewport_size)
-    # old_res, new_res = await get_parsed_nodes_single_session(url, max_depth=20)
-    # TestCase().assertListEqual(old_res, new_res)
+    old_res, new_res = await get_parsed_nodes_single_session(url, max_depth=10)
+    TestCase().assertListEqual(old_res, new_res)
 
 
 @pytest.mark.asyncio

--- a/tests/browser/test_iframe.py
+++ b/tests/browser/test_iframe.py
@@ -1,0 +1,129 @@
+import difflib
+import json
+from pathlib import Path
+from typing import TypeAlias
+from unittest import TestCase
+
+import pytest
+from loguru import logger
+from notte_browser.dom.parsing import DomParsingConfig, DomTreeDict, ParseDomTreePipe
+from notte_browser.dom.types import DOMBaseNode
+from notte_browser.session import NotteSession, NotteSessionConfig
+from notte_core.errors.processing import SnapshotProcessingError
+from patchright.async_api import Page
+
+from tests.mock.mock_service import MockLLMService
+
+DomDict: TypeAlias = dict[str, str]
+
+
+def node_to_dict(node: DOMBaseNode, max_depth: int = 4) -> DomDict:
+    if max_depth <= 0:
+        return {}
+
+    if node.role.lower() == "iframe":
+        print(node.name, node.children[:1])
+
+    curr = {"name": node.name, "role": node.role}
+    curr["children"] = [node_to_dict(child, max_depth - 1) for child in node.children]  # pyright: ignore[reportArgumentType]
+    return curr
+
+
+async def old_parse_dom_tree(page: Page, config: DomParsingConfig) -> DOMBaseNode:
+    js_code = Path("tests/browser/oldBuildDom.js").read_text()
+
+    if config.verbose:
+        logger.info(f"Parsing DOM tree for {page.url} with config: {config.model_dump()}")
+    node: DomTreeDict | None = await page.evaluate(js_code, config.model_dump())
+    if node is None:
+        raise SnapshotProcessingError(page.url, "Failed to parse HTML to dictionary")
+    parsed = ParseDomTreePipe._parse_node(
+        node,
+        parent=None,
+        in_iframe=False,
+        in_shadow_root=False,
+        iframe_parent_css_paths=[],
+        notte_selector=page.url,
+    )
+    if parsed is None:
+        raise SnapshotProcessingError(page.url, f"Failed to parse DOM tree. Dom Tree is empty. {node}")
+    return parsed
+
+
+async def get_parsed_nodes(website_url: str) -> tuple[DomDict, DomDict]:
+    config = DomParsingConfig()
+    # start browser with disabled web security, old parse dom tree
+    old_session = NotteSession(
+        config=NotteSessionConfig().disable_perception().headless().disable_web_security(),
+        llmserve=MockLLMService(mock_response=""),
+    )
+
+    async with old_session as sesh:
+        _ = await sesh.goto(website_url)
+        await sesh.window.long_wait()
+        old_res = node_to_dict(await old_parse_dom_tree(sesh.window.page, config))
+        # dom_content = await sesh.window.page.locator("html").inner_html()  # Recommended!
+        new_res = node_to_dict(await ParseDomTreePipe.parse_dom_tree(sesh.window.page, config))
+
+    # start browser with enabled web security, new parse dom tree
+    # new_session = NotteSession(
+    #     config=NotteSessionConfig().disable_perception().headless().enable_web_security(),
+    #     llmserve=MockLLMService(mock_response=""),
+    # )
+    #
+    # async with new_session as sesh:
+    #     _ = await sesh.goto(website_url)
+    #     # await sesh.window.page.evaluate(f"""() => {{
+    #     #     document.documentElement.innerHTML = `{dom_content}`;
+    #     # }}""")
+    #     new_res = node_to_dict(await ParseDomTreePipe.parse_dom_tree(sesh.window.page, config))
+    #
+    return old_res, new_res
+
+
+@pytest.mark.asyncio
+async def test_same_parsed_nodes():
+    # old_res, new_res = await get_parsed_nodes("https://www.bbc.com/news")
+    old_res, new_res = await get_parsed_nodes("https://www.allrecipes.com")
+    d1 = json.dumps(old_res, indent=1)
+    d2 = json.dumps(new_res, indent=1)
+    # print("OLD")
+    # print(d1)
+    # print("\n\nNEW\n\n")
+    # print(d2)
+    # print("\n\nDIFF\n\n")
+    # print(diff_checker(d1, d2))
+    # compare results
+    TestCase().assertDictEqual(old_res, new_res)
+
+
+def diff_checker(text1, text2):
+    """
+    Compares two strings and returns a human-readable difference output similar to diffchecker.
+
+    Args:
+      text1: The first string.
+      text2: The second string.
+
+    Returns:
+      A string representing the differences between the two input strings.
+    """
+
+    d = difflib.Differ()
+    diff = d.compare(
+        text1.splitlines(keepends=True), text2.splitlines(keepends=True)
+    )  # Split into lines and keep the newline characters
+
+    result = []
+    for line in diff:
+        if line.startswith("  "):  # Common line
+            result.append("  " + line[2:])  # Keep only the actual content
+        elif line.startswith("+ "):  # Added line
+            result.append("+ " + line[2:])  # Prefix with '+' and remove ' '
+        elif line.startswith("- "):  # Removed line
+            result.append("- " + line[2:])  # Prefix with '-' and remove ' '
+        elif line.startswith("? "):  # Inline change (ignored for simplicity)
+            #  Optional: you could add some more sophisticated handling here if you wanted to highlight parts of lines that are different
+            pass  # Skip for now
+        else:  # Other codes (e.g., end of file)
+            result.append(line)

--- a/tests/browser/test_iframe.py
+++ b/tests/browser/test_iframe.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Any, TypeAlias
 from unittest import TestCase
@@ -121,15 +120,18 @@ SINGLE_WEBSITES = MULTI_WEBSITES + [
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(bool(os.getenv("RUNNING_IN_CI")), reason="Flaky on CI for some reason")
 @pytest.mark.parametrize("url", SINGLE_WEBSITES)
 async def test_parsing_disabled_websecurity_session(url: str):
-    old_res, new_res = await get_parsed_nodes_single_session(url, max_depth=20)
-    TestCase().assertListEqual(old_res, new_res)
+    old_session = NotteSession(
+        config=NotteSessionConfig().disable_perception().headless().disable_web_security(),
+        llmserve=MockLLMService(mock_response=""),
+    )
+    raise ValueError(old_session.window.page.viewport_size)
+    # old_res, new_res = await get_parsed_nodes_single_session(url, max_depth=20)
+    # TestCase().assertListEqual(old_res, new_res)
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(bool(os.getenv("RUNNING_IN_CI")), reason="Flaky on CI for some reason")
 @pytest.mark.parametrize("url", MULTI_WEBSITES)
 async def test_parsing_enabled_websecurity_session(url: str):
     old_res, new_res = await get_parsed_nodes_multi_session(url, max_depth=5)

--- a/tests/browser/test_iframe.py
+++ b/tests/browser/test_iframe.py
@@ -12,6 +12,9 @@ from patchright.async_api import Page
 from tests.mock.mock_service import MockLLMService
 
 DomList: TypeAlias = list[Any]
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36"
+)
 
 
 def node_to_sorted_list(node: DOMBaseNode, max_depth: int) -> DomList:
@@ -64,7 +67,7 @@ async def get_parsed_nodes_single_session(website_url: str, max_depth: int) -> t
 
     # start browser with disabled web security, old parse dom tree
     old_session = NotteSession(
-        config=NotteSessionConfig().disable_perception().headless().disable_web_security(),
+        config=NotteSessionConfig().disable_perception().headless().disable_web_security().set_user_agent(USER_AGENT),
         llmserve=MockLLMService(mock_response=""),
     )
 
@@ -84,11 +87,11 @@ async def get_parsed_nodes_multi_session(website_url: str, max_depth: int) -> tu
     config = DomParsingConfig()
 
     old_session = NotteSession(
-        config=NotteSessionConfig().disable_perception().headless().disable_web_security(),
+        config=NotteSessionConfig().disable_perception().headless().disable_web_security().set_user_agent(USER_AGENT),
         llmserve=MockLLMService(mock_response=""),
     )
     new_session = NotteSession(
-        config=NotteSessionConfig().disable_perception().headless().enable_web_security(),
+        config=NotteSessionConfig().disable_perception().headless().enable_web_security().set_user_agent(USER_AGENT),
         llmserve=MockLLMService(mock_response=""),
     )
 
@@ -110,8 +113,8 @@ async def get_parsed_nodes_multi_session(website_url: str, max_depth: int) -> tu
 
 
 MULTI_WEBSITES = [
-    "https://www.espn.co.uk/",
     "https://www.thetimes.com/",
+    "https://www.espn.co.uk/",
 ]
 
 SINGLE_WEBSITES = MULTI_WEBSITES + [

--- a/tests/browser/test_iframe.py
+++ b/tests/browser/test_iframe.py
@@ -3,7 +3,6 @@ from typing import Any, TypeAlias
 from unittest import TestCase
 
 import pytest
-from loguru import logger
 from notte_browser.dom.parsing import DomParsingConfig, DomTreeDict, ParseDomTreePipe
 from notte_browser.dom.types import DOMBaseNode
 from notte_browser.session import NotteSession, NotteSessionConfig
@@ -19,9 +18,6 @@ def node_to_sorted_list(node: DOMBaseNode, max_depth: int) -> DomList:
     def _node_to_dict(node: DOMBaseNode, max_depth: int) -> dict[Any, Any]:
         if max_depth <= 0:
             return {}
-
-        if node.role.lower() == "iframe":
-            print(node.name, node.children[:1])
 
         curr = {"name": node.name, "role": node.role}
         curr["children"] = [_node_to_dict(child, max_depth - 1) for child in node.children]  # pyright: ignore[reportArgumentType]
@@ -43,8 +39,6 @@ def node_to_sorted_list(node: DOMBaseNode, max_depth: int) -> DomList:
 async def old_parse_dom_tree(page: Page, config: DomParsingConfig) -> DOMBaseNode:
     js_code = Path("tests/browser/oldBuildDom.js").read_text()
 
-    if config.verbose:
-        logger.info(f"Parsing DOM tree for {page.url} with config: {config.model_dump()}")
     node: DomTreeDict | None = await page.evaluate(js_code, config.model_dump())
     if node is None:
         raise SnapshotProcessingError(page.url, "Failed to parse HTML to dictionary")
@@ -120,7 +114,6 @@ MULTI_WEBSITES = [
 ]
 
 SINGLE_WEBSITES = MULTI_WEBSITES + [
-    "https://www.allrecipes.com",
     "https://www.bbc.com/news",
 ]
 

--- a/tests/browser/test_iframe.py
+++ b/tests/browser/test_iframe.py
@@ -101,6 +101,7 @@ async def get_parsed_nodes_multi_session(website_url: str, max_depth: int) -> tu
     # start browser with enabled web security, new parse dom tree
     async with new_session as sesh:
         _ = await sesh.goto(website_url)
+        await sesh.window.long_wait()
         new_res = node_to_sorted_list(
             await ParseDomTreePipe.parse_dom_tree(sesh.window.page, config), max_depth=max_depth
         )

--- a/tests/browser/test_iframe.py
+++ b/tests/browser/test_iframe.py
@@ -126,7 +126,9 @@ async def test_parsing_disabled_websecurity_session(url: str):
         config=NotteSessionConfig().disable_perception().headless().disable_web_security(),
         llmserve=MockLLMService(mock_response=""),
     )
-    raise ValueError(old_session.window.page.viewport_size)
+    async with old_session as sesh:
+        _ = await sesh.goto("https://bing.com")
+        raise ValueError(sesh.window.page.viewport_size)
     # old_res, new_res = await get_parsed_nodes_single_session(url, max_depth=20)
     # TestCase().assertListEqual(old_res, new_res)
 

--- a/tests/integration/test_basic_scripts.py
+++ b/tests/integration/test_basic_scripts.py
@@ -6,16 +6,18 @@ from tests.mock.mock_service import MockLLMService
 
 
 def config() -> NotteSessionConfig:
-    return NotteSessionConfig().headless()
+    return NotteSessionConfig().headless().set_viewport(width=1280, height=1080)
 
 
 @pytest.mark.asyncio
 async def test_google_flights() -> None:
     async with NotteSession(config(), llmserve=MockLLMService(mock_response="")) as page:
         _ = await page.goto("https://www.google.com/travel/flights")
+
         cookie_node = page.snapshot.dom_node.find("B2")
         if cookie_node is not None and "reject" in cookie_node.text.lower():
             _ = await page.execute("B2", enter=False)  # reject cookies
+
         _ = await page.execute("I3", "Paris", enter=True)
         _ = await page.execute("I4", "London", enter=True)
         _ = await page.execute("I5", "14/06/2025", enter=True)
@@ -31,8 +33,10 @@ async def test_google_flights_with_agent() -> None:
         # observe a webpage, and take a random action
         _ = await page.act(GotoAction(url="https://www.google.com/travel/flights"))
         cookie_node = page.snapshot.dom_node.find("B2")
+
         if cookie_node is not None:
             _ = await page.act(ClickAction(id="B2"))
+
         _ = await page.act(FillAction(id="I3", value="Paris", press_enter=True))
         _ = await page.act(FillAction(id="I4", value="London", press_enter=True))
         _ = await page.act(FillAction(id="I5", value="14/06/2025"))


### PR DESCRIPTION
This gives us a way to bypass cross origin security checks that force us to disable web security currently.

Draft for now because it still doesn't fix google console example and isn't thoroughly tested 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced DOM parsing with improved recursive iframe handling for more accurate nested content representation.
- **Bug Fixes**
  - Improved error handling and messaging during iframe parsing for increased robustness.
- **Tests**
  - Added comprehensive tests ensuring consistency between legacy and new DOM parsing methods under different browser security settings.
- **Chores**
  - Updated test configurations to include viewport sizing and improved code readability.
- **Documentation**
  - Added detailed inline comments clarifying iframe handling delegation and parsing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->