### PR TITLE
Star repo example

### DIFF
--- a/examples/star-our-repo/.env.example
+++ b/examples/star-our-repo/.env.example
@@ -1,3 +1,3 @@
-GITHUB_COM_EMAIL=user@example.org
-GITHUB_COM_PASSWORD=mycoolpassword # pragma: allowlist secret
-GITHUB_COM_MFA_SECRET=ALCWSNTY9SNT
+GITHUB_COM_EMAIL=
+GITHUB_COM_PASSWORD= # pragma: allowlist secret
+GITHUB_COM_MFA_SECRET=

--- a/examples/star-our-repo/.env.example
+++ b/examples/star-our-repo/.env.example
@@ -1,0 +1,3 @@
+GITHUB_COM_EMAIL=user@example.org
+GITHUB_COM_PASSWORD=mycoolpassword # pragma: allowlist secret
+GITHUB_COM_MFA_SECRET=ALCWSNTY9SNT

--- a/examples/star-our-repo/README.md
+++ b/examples/star-our-repo/README.md
@@ -1,0 +1,13 @@
+# Star our repo agent
+
+This example shows a simple agent using an auth vault to load github credentials (including 2fa code), sign in, and star our github repo.
+
+## Setup
+
+Fill in your actual github credentials in your env variables or in a .env file (.env.example provided).
+
+## Run the agent
+
+```bash
+python agent.py
+```

--- a/examples/star-our-repo/agent.py
+++ b/examples/star-our-repo/agent.py
@@ -29,4 +29,4 @@ with notte.vaults.create() as vault:
         task="Go to the nottelabs/notte repo and star it. If it’s already starred (meaning, the text of the button says 'Starred' instead of 'Star'), don’t unstar it.You will need to sign in (including with your MFA). Be resilient.",
     )
 
-agent.replay().display()
+_ = agent.replay().display()

--- a/examples/star-our-repo/agent.py
+++ b/examples/star-our-repo/agent.py
@@ -1,0 +1,32 @@
+from dotenv import load_dotenv
+from notte_sdk import NotteClient
+
+# Load environment variables
+_ = load_dotenv()
+
+"""
+Add credentials from environment variables for a given URL.
+
+You should set the following environment variables for a given URL, i.e github.com:
+
+"""
+
+notte = NotteClient()
+with notte.vaults.create() as vault:
+    _ = vault.add_credentials_from_env(url="https://github.com/")
+
+    creds = vault.get_credentials("github.com")
+
+    if creds is None:
+        raise ValueError("Vault contains no creds for github, try setting your env variables")
+
+    for cred_type in ["email", "password", "mfa_secret"]:
+        if creds.get(cred_type) is None:
+            raise ValueError(f"No {cred_type} found for github.com, make sure your env variables are set correctly")
+
+    agent = notte.Agent(vault=vault)
+    response = agent.run(
+        task="Go to the nottelabs/notte repo and star it. If it’s already starred (meaning, the text of the button says 'Starred' instead of 'Star'), don’t unstar it.You will need to sign in (including with your MFA). Be resilient.",
+    )
+
+agent.replay().display()

--- a/packages/notte-core/src/notte_core/credentials/base.py
+++ b/packages/notte-core/src/notte_core/credentials/base.py
@@ -233,7 +233,7 @@ def get_with_fallback(creds: CredentialsDict | CreditCardDict, key: str) -> str 
         fallback = UserNameField.alias
         retval = username
 
-    elif key == UserNameField.alias and isinstance(email := creds.get(UserNameField.alias), str):
+    elif key == UserNameField.alias and isinstance(email := creds.get(EmailField.alias), str):
         fallback = EmailField.alias
         retval = email
 

--- a/packages/notte-core/src/notte_core/credentials/base.py
+++ b/packages/notte-core/src/notte_core/credentials/base.py
@@ -220,6 +220,29 @@ class CredentialsDict(TypedDict, total=True):
     mfa_secret: NotRequired[str]
 
 
+def get_with_fallback(creds: CredentialsDict | CreditCardDict, key: str) -> str | None:
+    correct = creds.get(key)
+
+    if isinstance(correct, str):
+        return correct
+
+    retval = None
+    fallback = None
+
+    if key == EmailField.alias and isinstance(username := creds.get(UserNameField.alias), str):
+        fallback = UserNameField.alias
+        retval = username
+
+    elif key == UserNameField.alias and isinstance(email := creds.get(UserNameField.alias), str):
+        fallback = EmailField.alias
+        retval = email
+
+    if retval is not None:
+        logger.warning(f"Could not find creds for {key}, using {fallback} as fallback")
+
+    return retval
+
+
 class CreditCardDict(TypedDict, total=True):
     card_holder_name: str
     card_number: str
@@ -467,13 +490,10 @@ class BaseVault(ABC):
             if creds_dict is None:
                 raise ValueError(f"No credentials found in vault for url={snapshot.metadata.url}")
 
-        cred_value = creds_dict.get(cred_key)
+        cred_value = get_with_fallback(creds_dict, cred_key)
 
         if cred_value is None:
             raise ValueError(f"No credential of type {cred_key} found in vault")
-
-        if not isinstance(cred_value, str):
-            raise ValueError(f"Invalid type for credential: {type(cred_value)}")
 
         cred_instance = cred_class(value=cred_value)
 

--- a/packages/notte-core/src/notte_core/utils/webp_replay.py
+++ b/packages/notte-core/src/notte_core/utils/webp_replay.py
@@ -18,10 +18,14 @@ class WebpReplay:
         with open(output_file, "wb") as f:
             _ = f.write(self.replay)
 
-    def display(self) -> Any:
+    def display_notebook(self) -> Any:
         from IPython.display import Image
 
         return Image(self.replay, format="webp")
+
+    def display(self) -> None:
+        image = Image.open(io.BytesIO(self.replay))
+        image.show()
 
 
 class ScreenshotReplay(BaseModel):

--- a/packages/notte-core/src/notte_core/utils/webp_replay.py
+++ b/packages/notte-core/src/notte_core/utils/webp_replay.py
@@ -18,14 +18,28 @@ class WebpReplay:
         with open(output_file, "wb") as f:
             _ = f.write(self.replay)
 
-    def display_notebook(self) -> Any:
-        from IPython.display import Image
+    @staticmethod
+    def in_notebook():
+        try:
+            from IPython import get_ipython  # pyright: ignore[reportPrivateImportUsage]
 
-        return Image(self.replay, format="webp")
+            ipython = get_ipython()
+            if ipython is None or "IPKernelApp" not in ipython.config:  # pragma: no cover
+                return False
+        except ImportError:
+            return False
+        except AttributeError:
+            return False
+        return True
 
-    def display(self) -> None:
-        image = Image.open(io.BytesIO(self.replay))
-        image.show()
+    def display(self) -> Any | None:
+        if WebpReplay.in_notebook():
+            from IPython.display import Image as IPythonImage
+
+            return IPythonImage(self.replay, format="webp")
+        else:
+            image = Image.open(io.BytesIO(self.replay))
+            image.show()
 
 
 class ScreenshotReplay(BaseModel):

--- a/packages/notte-sdk/pyproject.toml
+++ b/packages/notte-sdk/pyproject.toml
@@ -12,6 +12,7 @@ packages = [
 
 requires-python = ">=3.11"
 dependencies = [
+    "halo>=0.0.31",
     "notte-core==1.4.4.dev",
     "websockets>=13.1",
 ]

--- a/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
@@ -1,7 +1,9 @@
+import sys
 import time
 from collections.abc import Sequence
 from typing import Any, Unpack
 
+from halo import Halo  # pyright: ignore[reportMissingTypeStubs]
 from loguru import logger
 from notte_core.utils.webp_replay import WebpReplay
 from pydantic import BaseModel
@@ -168,9 +170,45 @@ class AgentsClient(BaseClient):
         Returns:
             AgentResponse: The response obtained from the agent run request.
         """
+        format = "<level>{level: <8}</level> - <level>{message}</level>"
+        _ = logger.configure(handlers=[dict(sink=sys.stderr, level="INFO", format=format)])  # pyright: ignore[reportArgumentType]
+
         request = AgentStartRequest.model_validate(data)
         response = self.request(AgentsClient.agent_start_endpoint().with_request(request))
         return response
+
+    @staticmethod
+    def pretty_string(step: _AgentResponse, colors: bool = True) -> str:
+        status = step.state["previous_goal_status"]
+        status_emoji: str = ""
+        match status:
+            case "unknown":
+                status_emoji = "❓"
+            case "success":
+                status_emoji = "✅"
+            case "failure":
+                status_emoji = "❌"
+            case _:
+                pass
+
+        def surround_tags(s: str, tags: tuple[str, ...] = ("b", "blue")) -> str:
+            if not colors:
+                return s
+
+            start = "".join(f"<{tag}>" for tag in tags)
+            end = "".join(f"</{tag}>" for tag in reversed(tags))
+            return f"{start}{s}{end}"
+
+        action_str = ""
+        actions = step.actions
+        for action in actions:
+            action_str += f"   ▶ {action}"
+        return f"""📝 {surround_tags("Current page:")} {step.state["page_summary"]}
+🔬 {surround_tags("Previous goal:")} {status_emoji} {step.state["previous_goal_eval"]}
+🧠 {surround_tags("Memory:")} {step.state["memory"]}
+🎯 {surround_tags("Next goal:")} {step.state["next_goal"]}
+⚡ {surround_tags("Taking action:")}
+{action_str}"""
 
     def wait(
         self,
@@ -192,17 +230,24 @@ class AgentsClient(BaseClient):
         last_step = 0
         for _ in range(max_attempts):
             response = self.status(agent_id=agent_id)
-            if response.status == AgentStatus.closed:
-                return response
             if len(response.steps) >= last_step:
                 for step in response.steps[last_step:]:
-                    for action in step.actions:
-                        logger.info(f"Executing action: {action}")
+                    for line in AgentsClient.pretty_string(step).split("\n"):
+                        time.sleep(0.1)
+                        logger.opt(colors=True).info(line)
+
                 last_step = len(response.steps)
-            logger.info(
-                f"Waiting {polling_interval_seconds} seconds for agent to complete (current step: {last_step})..."
+
+            if response.status == AgentStatus.closed:
+                return response
+
+            spinner = Halo(
+                text=f"Waiting {polling_interval_seconds} seconds for agent to complete (current step: {last_step})...",
             )
+            _ = spinner.start()  # pyright: ignore[reportUnknownMemberType]
             time.sleep(polling_interval_seconds)
+            _ = spinner.succeed()  # pyright: ignore[reportUnknownMemberType]
+
         raise TimeoutError("Agent did not complete in time")
 
     def stop(self, agent_id: str) -> AgentResponse:


### PR DESCRIPTION
- star repo example
- fallback on credentials
- nicer logging on sdk
- display replay outside of jupyter notebook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new example showcasing an agent that can sign in and star a GitHub repository using environment-based credentials and multi-factor authentication.
  - Added a sample environment file and detailed README instructions for easy setup and usage of the new example.
  - Enhanced the display of agent action replays with support for both notebook and standard image viewers.
- **Improvements**
  - Provided richer, colorized logging and visual feedback (spinner animation) during agent execution monitoring for a more user-friendly experience.
  - Improved credential retrieval with fallback logic for email and username fields.
- **Chores**
  - Added a new dependency to support spinner animations in the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->