### PR TITLE
Fixed typo on doc sdk_tutorial.md

### DIFF
--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -37,7 +37,7 @@ with client.Session(proxies=False, max_steps=1) as session:
         assert screenshot is not None
 ```
 
-you can also easily visualize the live session using `session.viewer(). This will open a new browser tab with the session in action.
+you can also easily visualize the live session using `session.viewer()`. This will open a new browser tab with the session in action.
 
 
 


### PR DESCRIPTION
This PR fixes a typo in the sdk_tutorial documentation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a minor formatting issue in the tutorial by correcting an inline code reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->