### PR TITLE
get frame in replay

### DIFF
--- a/tests/integration/sdk/test_sessions.py
+++ b/tests/integration/sdk/test_sessions.py
@@ -48,3 +48,14 @@ def test_replay_session(session_id: str):
     client = NotteClient()
     response = client.sessions.replay(session_id=session_id)
     assert len(response.replay) > 0
+
+
+def test_replay_session_with_frame(session_id: str):
+    client = NotteClient()
+    response = client.sessions.replay(session_id=session_id)
+    assert len(response.replay) > 0
+    first_frame = response.frame(frame_idx=0)
+    assert first_frame is not None
+    last_frame = response.frame(frame_idx=-1)
+    assert last_frame is not None
+    assert first_frame != last_frame


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to extract and save specific frames from animated WebP images in replays.
  - Users can now access individual frames and export them as PNG files.

- **Tests**
  - Introduced new integration tests to verify frame extraction and ensure correct behavior when accessing first and last frames in replay sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->