### PR TITLE
Support running interaction action from kwargs

### DIFF
--- a/packages/notte-browser/src/notte_browser/controller.py
+++ b/packages/notte-browser/src/notte_browser/controller.py
@@ -94,6 +94,7 @@ class BrowserController:
     async def execute_interaction_action(self, window: BrowserWindow, action: InteractionAction) -> bool:
         if action.selector is None:
             raise ValueError(f"Selector is required for {action.name()}")
+
         press_enter = False
         if action.press_enter is not None:
             press_enter = action.press_enter
@@ -151,7 +152,7 @@ class BrowserController:
                     await window.page.wait_for_timeout(100)
             case FallbackFillAction(value=value):
                 await locator.click()
-                await locator.press_sequentially(get_str_value(value))
+                await locator.press_sequentially(get_str_value(value), delay=100)
                 await window.short_wait()
             case CheckAction(value=value):
                 if value:

--- a/packages/notte-browser/src/notte_browser/dom/locate.py
+++ b/packages/notte-browser/src/notte_browser/dom/locate.py
@@ -20,6 +20,11 @@ async def locale_element_in_iframes(page: Page, selectors: NodeSelectors) -> Fra
 
 async def locate_element(page: Page, selectors: NodeSelectors) -> Locator:
     frame: Page | FrameLocator = page
+
+    # playwright selectors cant go through shadow / iframe for now anyway
+    if selectors.playwright_selector is not None:
+        return frame.locator(selectors.playwright_selector)
+
     if selectors.in_iframe:
         frame = await locale_element_in_iframes(page, selectors)
     # regular case, locate element + scroll into view if needed

--- a/packages/notte-browser/src/notte_browser/resolution.py
+++ b/packages/notte-browser/src/notte_browser/resolution.py
@@ -40,13 +40,16 @@ class NodeResolutionPipe:
 
         if not isinstance(action, InteractionAction):
             raise InvalidActionError("unknown", f"action is not an interaction action: {action.type}")
-        # resolve selector
-        selector_map: dict[str, InteractionDomNode] = {inode.id: inode for inode in snapshot.interaction_nodes()}
-        if action.id not in selector_map:
-            raise InvalidActionError(action_id=action.id, reason=f"action '{action.id}' not found in page context.")
-        node = selector_map[action.id]
-        action.selector = NodeResolutionPipe.resolve_selectors(node, verbose)
-        action.text_label = node.text
+
+        if not action.bypass_action_resolution:
+            # resolve selector
+            selector_map: dict[str, InteractionDomNode] = {inode.id: inode for inode in snapshot.interaction_nodes()}
+            if action.id not in selector_map:
+                raise InvalidActionError(action_id=action.id, reason=f"action '{action.id}' not found in page context.")
+            node = selector_map[action.id]
+            action.selector = NodeResolutionPipe.resolve_selectors(node, verbose)
+            action.text_label = node.text
+
         return action
 
     @staticmethod

--- a/packages/notte-core/src/notte_core/actions.py
+++ b/packages/notte-core/src/notte_core/actions.py
@@ -89,7 +89,7 @@ class BaseAction(BaseModel, metaclass=ABCMeta):
 
     @staticmethod
     def validate_type(action_type: str) -> bool:
-        return action_type in BaseAction.ACTION_REGISTRY
+        return action_type in BrowserAction.ACTION_REGISTRY
 
     def __init_subclass__(cls, **kwargs: dict[Any, Any]):
         super().__init_subclass__(**kwargs)  # type: ignore
@@ -116,6 +116,7 @@ class BaseAction(BaseModel, metaclass=ABCMeta):
             "press_enter",
             "option_selector",
             "text_label",
+            "bypass_action_resolution",
             # executable action fields
             "params",
             "code",
@@ -483,6 +484,7 @@ class InteractionAction(BaseAction, metaclass=ABCMeta):
     press_enter: bool | None = Field(default=None, exclude=True)
     text_label: str | None = Field(default=None, exclude=True)
     param: ActionParameter | None = Field(default=None, exclude=True)
+    bypass_action_resolution: bool = False
 
     INTERACTION_ACTION_REGISTRY: ClassVar[dict[str, typeAlias["InteractionAction"]]] = {}
 
@@ -494,6 +496,33 @@ class InteractionAction(BaseAction, metaclass=ABCMeta):
             if name in cls.INTERACTION_ACTION_REGISTRY:
                 raise ValueError(f"Base Action {name} is duplicated")
             cls.INTERACTION_ACTION_REGISTRY[name] = cls
+
+    @staticmethod
+    def from_param(
+        action_type: str, value: bool | str | int | None = None, selector: str | None = None
+    ) -> "InteractionAction":
+        action_cls = InteractionAction.INTERACTION_ACTION_REGISTRY.get(action_type)
+        if action_cls is None:
+            raise ValueError(f"Invalid action type: {action_type}")
+
+        action_params: dict[str, Any] = {"id": "", "bypass_action_resolution": True}
+        if value is not None:
+            action_params["value"] = value
+
+        action = action_cls.model_validate(action_params)
+
+        # have to assume simple playwright selector in this case
+        # could maybe dispatch?
+        action.selector = NodeSelectors(
+            playwright_selector=selector,
+            css_selector="",
+            xpath_selector="",
+            notte_selector="",
+            in_iframe=False,
+            in_shadow_root=False,
+            iframe_parent_css_selectors=[],
+        )
+        return action
 
 
 class ClickAction(InteractionAction):


### PR DESCRIPTION
Supports stuff like
```
page.step(type="click", selector="playwright selector")
page.step(type="click", id="B1")
page.step(type="fill", selector="playwright selector", value="my fill")
```

Similarly to the current browser actions, without using an ID

Draft because I need to add tests