### PR TITLE
remove cdp url from session response

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -624,9 +624,9 @@ class RemoteSession(SyncResource):
         """
         if self.response is None:
             raise ValueError("You need to start the session first to get the cdp url")
-        if self.response.cdp_url is not None:
+        if self.request.cdp_url is not None:
             # cdp url from another session provider
-            return self.response.cdp_url
+            return self.request.cdp_url
         # cdp url from the session provider
         debug = self.debug_info()
         return debug.ws.cdp

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -608,7 +608,6 @@ class SessionResponse(SdkBaseModel):
         ),
     ] = False
     browser_type: BrowserType = BrowserType.CHROMIUM
-    cdp_url: Annotated[str | None, Field(description="The CDP URL of the session")] = None
 
     @field_validator("closed_at", mode="before")
     @classmethod

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -643,7 +643,6 @@ class SessionResponseDict(TypedDict, total=False):
     error: str | None
     proxies: bool
     browser_type: BrowserType
-    cdp_url: str | None
 
 
 # ############################################################


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the retrieval method for the Chrome DevTools Protocol (CDP) URL in session handling.
- **Chores**
	- Removed the CDP URL field from session response data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->