### PR TITLE
LLM too large context error, start custom endpoint

### DIFF
--- a/packages/notte-agent/src/notte_agent/common/validator.py
+++ b/packages/notte-agent/src/notte_agent/common/validator.py
@@ -84,7 +84,10 @@ Agent task output:
         try:
             _ = response_format.model_validate_json(output.answer)
         except ValidationError as e:
-            return CompletionValidation(is_valid=False, reason=str(e))
+            return CompletionValidation(
+                is_valid=False,
+                reason=f"Expecting agent answer to follow the schema {response_format.model_json_schema()}, but found errors: {e.errors()}",
+            )
         return CompletionValidation(
             is_valid=True, reason="The output returned by the agent is a valid according to the response format."
         )

--- a/packages/notte-core/src/notte_core/llms/engine.py
+++ b/packages/notte-core/src/notte_core/llms/engine.py
@@ -93,6 +93,7 @@ class LLMEngine:
                 raise e
             except NotteBaseError as e:
                 raise e
+
             except Exception as e:
                 raise e
             content = self.sc.extract(content).strip()
@@ -104,7 +105,7 @@ class LLMEngine:
                 messages.append(
                     ChatCompletionUserMessage(
                         role="user",
-                        content=f"Invalid LLM response. JSON code blocks or JSON object expected, got: {content}. Retrying",
+                        content="Invalid LLM response. JSON code blocks or JSON object expected, but content does not start with curly brackets. Retrying",
                     )
                 )
                 continue


### PR DESCRIPTION
- pydantic validation crops error messages, which isnt super helpful 
- reduce content when only issue is not starting with curly brackets / json output
- custom endpoint should now be used like `client.agents.run_custom(request)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running custom agents asynchronously and in batch mode, including parallel execution strategies.
  * Introduced new methods for custom agent requests in the client interface.

* **Refactor**
  * Unified and streamlined batch execution logic for agents, removing redundant methods and consolidating custom agent execution at the client level.

* **Bug Fixes**
  * Improved error messages for response validation and agent retries to provide clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->