### PR TITLE
allow disable tracing

### DIFF
--- a/packages/notte-core/src/notte_core/common/tracer.py
+++ b/packages/notte-core/src/notte_core/common/tracer.py
@@ -10,7 +10,7 @@ from litellm import AllMessageValues
 from pydantic import BaseModel, Field
 from typing_extensions import override
 
-IS_TRACING_ENABLED = os.getenv("NOTTE_LLM_TRACING_ENABLED", "false").lower() != "false"
+IS_TRACING_ENABLED = os.getenv("DISABLE_NOTTE_LLM_TRACING", "false").lower() == "false"
 LOCAL_TRACES_DIR = Path(__file__).parent.parent.parent.parent / "traces"
 TRACES_DIR = Path(os.getenv("NOTTE_TRACES_DIR", LOCAL_TRACES_DIR))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Tracing can now be toggled via an environment variable (enabled by default) and outputs to a configurable directory.
  * Remote script execution supports specifying a script version and runs in-memory for smoother execution.
* Refactor
  * RemoteScript.run now accepts an optional version parameter.
  * RemoteScript.download supports an optional path: returns the script content when omitted, or writes to a provided .py path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->