### PR TITLE
Screenshot after execution

### DIFF
--- a/packages/notte-agent/src/notte_agent/agent.py
+++ b/packages/notte-agent/src/notte_agent/agent.py
@@ -269,7 +269,9 @@ class NotteAgent(BaseAgent):
                     conv.add_user_message(
                         content=self.perception.perceive_action_result(step, include_ids=False, include_data=True)
                     )
-                case Observation():
+
+                # observation or screenshot
+                case _:
                     # TODO: add partial info for previous?
                     pass
 

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -18,9 +18,9 @@ from notte_core.actions import (
     ScrapeAction,
     ToolAction,
 )
-from notte_core.browser.observation import ExecutionResult, Observation
+from notte_core.browser.observation import ExecutionResult, Observation, Screenshot
 from notte_core.browser.snapshot import BrowserSnapshot
-from notte_core.common.config import PerceptionType, RaiseCondition, ScreenshotType, config
+from notte_core.common.config import PerceptionType, RaiseCondition, config
 from notte_core.common.logging import timeit
 from notte_core.common.resource import AsyncResource, SyncResource
 from notte_core.common.telemetry import track_usage
@@ -204,13 +204,14 @@ class NotteSession(AsyncResource, SyncResource):
         return actions
 
     @track_usage("local.session.replay")
-    def replay(self, screenshot_type: ScreenshotType = config.screenshot_type) -> WebpReplay:
-        observations = list(self.trajectory.observations())
-        screenshots: list[bytes] = [obs.screenshot.bytes(screenshot_type) for obs in observations]
+    def replay(self) -> WebpReplay:
+        screenshots_traj = list(self.trajectory.all_screenshots())
+        screenshots: list[bytes] = [screen.bytes(self._request.screenshot_type) for screen in screenshots_traj]
         if len(screenshots) == 0:
             raise ValueError("No screenshots found in agent trajectory")
-        # remove first obs if it's empty observation (for agent, the first one is always empty)
-        elif len(screenshots) > 1 and observations[0] is Observation.empty():
+        elif len(screenshots) > 1 and screenshots[0] == Observation.empty().screenshot.bytes(
+            self._request.screenshot_type
+        ):
             screenshots = screenshots[1:]
         return ScreenshotReplay.from_bytes(screenshots).get(quality=90)  # pyright: ignore [reportArgumentType]
 
@@ -253,6 +254,16 @@ class NotteSession(AsyncResource, SyncResource):
                 )
 
         return space
+
+    async def ascreenshot(self) -> Screenshot:
+        screenshot = Screenshot(raw=(await self.window.screenshot()), bboxes=[], last_action_id=None)
+        self.trajectory.append(screenshot)
+        return screenshot
+
+    def screenshot(
+        self,
+    ) -> Screenshot:
+        return asyncio.run(self.ascreenshot())
 
     @timeit("observe")
     @track_usage("local.session.observe")
@@ -444,6 +455,9 @@ class NotteSession(AsyncResource, SyncResource):
                 raise InvalidActionError(reason="Could not resolve action", action_id="")
             else:
                 resolved_action = step_action
+
+        # add screenshot to trajectory
+        _ = await self.ascreenshot()
 
         execution_result = ExecutionResult(
             action=resolved_action,

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -204,6 +204,7 @@ class NotteSession(AsyncResource, SyncResource):
         return actions
 
     @track_usage("local.session.replay")
+    @profiler.profiled()
     def replay(self) -> WebpReplay:
         screenshots_traj = list(self.trajectory.all_screenshots())
         screenshots: list[bytes] = [screen.bytes(self._request.screenshot_type) for screen in screenshots_traj]

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -20,7 +20,7 @@ from notte_core.actions import (
 )
 from notte_core.browser.observation import ExecutionResult, Observation, Screenshot
 from notte_core.browser.snapshot import BrowserSnapshot
-from notte_core.common.config import PerceptionType, RaiseCondition, config
+from notte_core.common.config import PerceptionType, RaiseCondition, ScreenshotType, config
 from notte_core.common.logging import timeit
 from notte_core.common.resource import AsyncResource, SyncResource
 from notte_core.common.telemetry import track_usage
@@ -205,14 +205,12 @@ class NotteSession(AsyncResource, SyncResource):
 
     @track_usage("local.session.replay")
     @profiler.profiled()
-    def replay(self) -> WebpReplay:
+    def replay(self, screenshot_type: ScreenshotType = config.screenshot_type) -> WebpReplay:
         screenshots_traj = list(self.trajectory.all_screenshots())
-        screenshots: list[bytes] = [screen.bytes(self._request.screenshot_type) for screen in screenshots_traj]
+        screenshots: list[bytes] = [screen.bytes(screenshot_type) for screen in screenshots_traj]
         if len(screenshots) == 0:
             raise ValueError("No screenshots found in agent trajectory")
-        elif len(screenshots) > 1 and screenshots[0] == Observation.empty().screenshot.bytes(
-            self._request.screenshot_type
-        ):
+        elif len(screenshots) > 1 and screenshots[0] == Observation.empty().screenshot.bytes(screenshot_type):
             screenshots = screenshots[1:]
         return ScreenshotReplay.from_bytes(screenshots).get(quality=90)  # pyright: ignore [reportArgumentType]
 

--- a/packages/notte-core/src/notte_core/browser/observation.py
+++ b/packages/notte-core/src/notte_core/browser/observation.py
@@ -50,6 +50,7 @@ class Screenshot(BaseModel):
                 return self.raw
             case "last_action":
                 bboxes = [bbox for bbox in self.bboxes if bbox.notte_id == self.last_action_id]
+
                 if self.last_action_id is None or len(bboxes) == 0:
                     return self.raw
                 return ScreenshotHighlighter.forward(self.raw, bboxes)

--- a/packages/notte-core/src/notte_core/trajectory.py
+++ b/packages/notte-core/src/notte_core/trajectory.py
@@ -8,9 +8,9 @@ from loguru import logger
 from typing_extensions import override
 
 from notte_core.agent_types import AgentCompletion
-from notte_core.browser.observation import ExecutionResult, Observation
+from notte_core.browser.observation import ExecutionResult, Observation, Screenshot
 
-TrajectoryHoldee = ExecutionResult | Observation | AgentCompletion
+TrajectoryHoldee = ExecutionResult | Observation | AgentCompletion | Screenshot
 StepId: TypeAlias = int
 
 
@@ -20,7 +20,7 @@ class TrajectoryElement:
         self.step_id: StepId | None = step_id
 
 
-ElementLiteral: TypeAlias = Literal["observation", "execution_result", "agent_completion"]
+ElementLiteral: TypeAlias = Literal["observation", "execution_result", "agent_completion", "screenshot"]
 
 
 @dataclass
@@ -28,6 +28,7 @@ class StepBundle:
     agent_completion: AgentCompletion | None = None
     execution_result: ExecutionResult | None = None
     observation: Observation | None = None
+    screenshot: Screenshot | None = None
 
     @staticmethod
     def get_element_key(element: TrajectoryHoldee) -> ElementLiteral:
@@ -35,6 +36,8 @@ class StepBundle:
             return "observation"
         elif isinstance(element, ExecutionResult):
             return "execution_result"
+        elif isinstance(element, Screenshot):
+            return "screenshot"
         elif isinstance(element, AgentCompletion):  # pyright: ignore [reportUnnecessaryIsInstance]
             return "agent_completion"
         else:
@@ -205,6 +208,13 @@ class Trajectory:
     @overload
     def set_callback(
         self,
+        on: Literal["screenshot"],
+        callback: Callable[[Screenshot], None],
+    ) -> None: ...
+
+    @overload
+    def set_callback(
+        self,
         on: Literal["step"],
         callback: Callable[[StepBundle], None],
     ) -> None: ...
@@ -243,6 +253,9 @@ class Trajectory:
     def filter_by_type(self, element_type: type[Observation]) -> Iterator[Observation]: ...
 
     @overload
+    def filter_by_type(self, element_type: type[Screenshot]) -> Iterator[Screenshot]: ...
+
+    @overload
     def filter_by_type(self, element_type: type[ExecutionResult]) -> Iterator[ExecutionResult]: ...
 
     @overload
@@ -251,14 +264,57 @@ class Trajectory:
     def filter_by_type(self, element_type: type[TrajectoryHoldee]) -> Iterator[TrajectoryHoldee]:
         return (step for step in self.elements if isinstance(step, element_type))
 
+    def screenshots(self) -> Iterator[Screenshot]:
+        return self.filter_by_type(Screenshot)
+
+    def _get_next_action_id(self, elements_list: list[TrajectoryHoldee], current_index: int) -> str | None:
+        """Get the action ID from the next ExecutionResult after the current index."""
+        for j in range(current_index + 1, len(elements_list)):
+            next_step = elements_list[j]
+            if isinstance(next_step, ExecutionResult):
+                if hasattr(next_step.action, "id"):
+                    return getattr(next_step.action, "id")
+                break
+        return None
+
+    def all_screenshots(self) -> Iterator[Screenshot]:
+        # Convert elements to list to allow lookahead
+        elements_list = list(self.elements)
+
+        for i, step in enumerate(elements_list):
+            if isinstance(step, Observation):
+                next_action_id = self._get_next_action_id(elements_list, i)
+
+                # Create a new screenshot with the action ID of the following ExecutionResult
+                screenshot = step.screenshot
+                new_screenshot = Screenshot(raw=screenshot.raw, bboxes=screenshot.bboxes, last_action_id=next_action_id)
+                yield new_screenshot
+            elif isinstance(step, Screenshot):
+                yield step
+
     def observations(self) -> Iterator[Observation]:
-        return self.filter_by_type(Observation)
+        # Convert elements to list to allow lookahead
+        elements_list = list(self.elements)
+
+        for i, step in enumerate(elements_list):
+            if isinstance(step, Observation):
+                next_action_id = self._get_next_action_id(elements_list, i)
+
+                # Create a new screenshot with the action ID of the following ExecutionResult
+                screenshot = step.screenshot
+                step.screenshot = Screenshot(
+                    raw=screenshot.raw, bboxes=screenshot.bboxes, last_action_id=next_action_id
+                )
+                yield step
 
     def execution_results(self) -> Iterator[ExecutionResult]:
         return self.filter_by_type(ExecutionResult)
 
     def agent_completions(self) -> Iterator[AgentCompletion]:
         return self.filter_by_type(AgentCompletion)
+
+    @overload
+    def last_element(self, element_type: type[Screenshot]) -> Screenshot | None: ...
 
     @overload
     def last_element(self, element_type: type[Observation]) -> Observation | None: ...
@@ -274,6 +330,10 @@ class Trajectory:
             if isinstance(step.inner, element_type):
                 return step.inner
         return None
+
+    @property
+    def last_screenshot(self) -> Screenshot | None:
+        return self.last_element(Screenshot)
 
     @property
     def last_observation(self) -> Observation | None:
@@ -357,6 +417,8 @@ class Trajectory:
                     action_name = type(element.action).__name__ if element.action else "None"
                     success = element.success
                     lines.append(f" ExecutionResult({action_name}, success={success}{step_id_str})")
+                case Screenshot():
+                    lines.append(" Screenshot()")
                 case AgentCompletion():
                     lines.append(f" AgentCompletion(next_goal={element.state.next_goal}{step_id_str})")
 

--- a/packages/notte-core/src/notte_core/trajectory.py
+++ b/packages/notte-core/src/notte_core/trajectory.py
@@ -302,10 +302,8 @@ class Trajectory:
 
                 # Create a new screenshot with the action ID of the following ExecutionResult
                 screenshot = step.screenshot
-                step.screenshot = Screenshot(
-                    raw=screenshot.raw, bboxes=screenshot.bboxes, last_action_id=next_action_id
-                )
-                yield step
+                new_screenshot = Screenshot(raw=screenshot.raw, bboxes=screenshot.bboxes, last_action_id=next_action_id)
+                yield step.model_copy(update={"screenshot": new_screenshot})
 
     def execution_results(self) -> Iterator[ExecutionResult]:
         return self.filter_by_type(ExecutionResult)

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -18,7 +18,14 @@ from notte_core.agent_types import AgentCompletion
 from notte_core.browser.dom_tree import NodeSelectors
 from notte_core.browser.observation import ExecutionResult, Observation
 from notte_core.browser.snapshot import TabsData
-from notte_core.common.config import BrowserType, LlmModel, PerceptionType, PlaywrightProxySettings, config
+from notte_core.common.config import (
+    BrowserType,
+    LlmModel,
+    PerceptionType,
+    PlaywrightProxySettings,
+    ScreenshotType,
+    config,
+)
 from notte_core.credentials.base import Credential, CredentialsDict, CreditCardDict
 from notte_core.data.space import DataSpace
 from notte_core.trajectory import ElementLiteral
@@ -457,6 +464,7 @@ class SessionStartRequestDict(TypedDict, total=False):
     viewport_height: int | None
     cdp_url: str | None
     use_file_storage: bool
+    screenshot_type: ScreenshotType
 
 
 class SessionStartRequest(SdkBaseModel):
@@ -496,6 +504,9 @@ class SessionStartRequest(SdkBaseModel):
 
     use_file_storage: Annotated[bool, Field(description="Whether FileStorage should be attached to the session.")] = (
         False
+    )
+    screenshot_type: Annotated[ScreenshotType, Field(description="Type of screenshot to store for replay")] = (
+        config.screenshot_type
     )
 
     @field_validator("timeout_minutes")

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -23,7 +23,6 @@ from notte_core.common.config import (
     LlmModel,
     PerceptionType,
     PlaywrightProxySettings,
-    ScreenshotType,
     config,
 )
 from notte_core.credentials.base import Credential, CredentialsDict, CreditCardDict
@@ -464,7 +463,6 @@ class SessionStartRequestDict(TypedDict, total=False):
     viewport_height: int | None
     cdp_url: str | None
     use_file_storage: bool
-    screenshot_type: ScreenshotType
 
 
 class SessionStartRequest(SdkBaseModel):
@@ -504,9 +502,6 @@ class SessionStartRequest(SdkBaseModel):
 
     use_file_storage: Annotated[bool, Field(description="Whether FileStorage should be attached to the session.")] = (
         False
-    )
-    screenshot_type: Annotated[ScreenshotType, Field(description="Type of screenshot to store for replay")] = (
-        config.screenshot_type
     )
 
     @field_validator("timeout_minutes")

--- a/tests/browser/test_screenshot_types.py
+++ b/tests/browser/test_screenshot_types.py
@@ -1,0 +1,56 @@
+import pytest
+from notte_browser.session import NotteSession
+from notte_core.actions import FillAction, GotoAction
+from notte_core.common.config import ScreenshotType
+from notte_core.utils.webp_replay import WebpReplay
+from PIL import Image
+
+
+@pytest.mark.asyncio
+async def test_different_screenshot_types_produce_different_screenshots() -> None:
+    """
+    Test that when running sessions with different screenshot types (raw, full, last_action),
+    we get different screenshots for each type.
+    """
+    screenshot_types: list[ScreenshotType] = ["raw", "full", "last_action"]
+    screenshots: dict[ScreenshotType, Image.Image] = {}
+    FRAME_INDEX = -2
+
+    for screenshot_type in screenshot_types:
+        # Create a new session for each screenshot type
+        async with NotteSession(screenshot_type=screenshot_type) as session:
+            # Navigate to Google
+            _ = await session.aexecute(GotoAction(url="https://www.google.com"))
+
+            _ = await session.aobserve(perception_type="fast")
+            # Fill the search box with id=I1 (Google's search input)
+            _ = await session.aexecute(FillAction(id="I1", value="test value"))
+
+            # Get the replay and extract the last frame
+            replay: WebpReplay = session.replay()
+
+            # Get the last frame from the replay
+            # The replay contains all screenshots, so we get the last one
+            last_frame = replay.frame(FRAME_INDEX)
+            assert last_frame is not None, f"No frames found in replay for screenshot_type={screenshot_type}"
+
+            # Store the screenshot data
+            screenshots[screenshot_type] = last_frame
+
+    # Verify we have screenshots for all three types
+    assert len(screenshots) == 3, f"Expected 3 screenshots, got {len(screenshots)}"
+    assert all(screenshot_type in screenshots for screenshot_type in screenshot_types)
+
+    # Verify that all screenshots are different from each other
+    screenshot_values = list(screenshots.values())
+
+    # Check that all screenshots are different
+    for i, screenshot_type_1 in enumerate(screenshot_types):
+        for j, screenshot_type_2 in enumerate(screenshot_types):
+            if i != j:
+                screenshot_1 = screenshot_values[i]
+                screenshot_2 = screenshot_values[j]
+
+                assert screenshot_1 != screenshot_2, (
+                    f"Screenshots for types '{screenshot_type_1}' and '{screenshot_type_2}' are identical"
+                )

--- a/tests/browser/test_screenshot_types.py
+++ b/tests/browser/test_screenshot_types.py
@@ -16,18 +16,18 @@ async def test_different_screenshot_types_produce_different_screenshots() -> Non
     screenshots: dict[ScreenshotType, Image.Image] = {}
     FRAME_INDEX = -2
 
-    for screenshot_type in screenshot_types:
-        # Create a new session for each screenshot type
-        async with NotteSession(screenshot_type=screenshot_type) as session:
-            # Navigate to Google
-            _ = await session.aexecute(GotoAction(url="https://www.google.com"))
+    # Create a new session for each screenshot type
+    async with NotteSession() as session:
+        # Navigate to Google
+        _ = await session.aexecute(GotoAction(url="https://www.google.com"))
 
-            _ = await session.aobserve(perception_type="fast")
-            # Fill the search box with id=I1 (Google's search input)
-            _ = await session.aexecute(FillAction(id="I1", value="test value"))
+        _ = await session.aobserve(perception_type="fast")
+        # Fill the search box with id=I1 (Google's search input)
+        _ = await session.aexecute(FillAction(id="I1", value="test value"))
 
-            # Get the replay and extract the last frame
-            replay: WebpReplay = session.replay()
+        # Get the replay and extract the last frame
+        for screenshot_type in screenshot_types:
+            replay: WebpReplay = session.replay(screenshot_type=screenshot_type)
 
             # Get the last frame from the replay
             # The replay contains all screenshots, so we get the last one

--- a/tests/integration/sdk/test_personas.py
+++ b/tests/integration/sdk/test_personas.py
@@ -13,14 +13,13 @@ def test_persona_id() -> str:
     return "7abb4f37-25a1-4409-98d9-c4c916918254"
 
 
-@pytest.mark.skip(reason="This test is not working as expected")
 def test_persona_in_local_agent():
     _ = load_dotenv()
     client = NotteClient(api_key=os.getenv("NOTTE_API_KEY"))
 
     with client.Persona(create_vault=True) as persona:
         with notte.Session() as session:
-            agent = notte.Agent(session=session, max_steps=5, vault=persona.vault)
+            agent = notte.Agent(session=session, max_steps=5, persona=persona)
             _ = agent.run(task="Go to the persona's email and check for any new messages")
 
 

--- a/tests/mock/mock_browser.py
+++ b/tests/mock/mock_browser.py
@@ -161,6 +161,10 @@ class MockBrowserDriver(AsyncResource):
         """Mock browser reset"""
         pass
 
+    async def screenshot(self) -> bytes:
+        """Mock browser screenshot"""
+        return b""
+
     async def goto(self, url: str) -> BrowserSnapshot:
         """Mock navigation action"""
         self.url = url

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -4,7 +4,7 @@ import pytest
 from notte_agent.falco.agent import FalcoAgent
 from notte_core.actions import ClickAction, FillAction
 from notte_core.agent_types import AgentCompletion
-from notte_core.browser.observation import ExecutionResult, Observation
+from notte_core.browser.observation import ExecutionResult, Observation, Screenshot
 from notte_core.trajectory import StepBundle, TrajectoryHoldee
 
 import notte
@@ -157,12 +157,16 @@ def test_trajectory_callback_from_session():
         def comp_call(comp: AgentCompletion):
             callback_calls["comp"] += 1
 
+        def screenshot_call(screen: Screenshot):
+            callback_calls["screen"] += 1
+
         def any_call(elem: TrajectoryHoldee):
             callback_calls["any"] += 1
 
         view.set_callback("observation", observe_call)
         view.set_callback("execution_result", exec_call)
         view.set_callback("agent_completion", comp_call)
+        view.set_callback("screenshot", screenshot_call)
         view.set_callback("any", any_call)
 
         _ = session.observe()
@@ -174,7 +178,8 @@ def test_trajectory_callback_from_session():
 
         assert callback_calls["obs"] == 3
         assert callback_calls["exec"] == 3
-        assert callback_calls["any"] == 6
+        assert callback_calls["screen"] == 3
+        assert callback_calls["any"] == 9
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- add screenshot to trajectory after each execution
- set screenshot_type directly in session, so it can be used in sdk
- fix last_action_id missing in observes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - New synchronous and asynchronous screenshot capture APIs; screenshots are now recorded automatically after actions and exposed via trajectory.
  - Replays are reconstructed from collected screenshots and support a per-request screenshot type to produce consistent frames.

- **Tests**
  - Added tests for screenshot types producing distinct frames, updated trajectory screenshot callbacks, and a mock browser screenshot helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->