### PR TITLE
fix small workflow bugs isuses

### DIFF
--- a/makefile
+++ b/makefile
@@ -92,7 +92,6 @@ release-clean:
 	@rm -rf .pytest_cache
 	@git checkout pyproject.toml uv.lock packages/*/pyproject.toml
 
-
 .PHONY: mcp
 mcp:
 	uv run python -m notte_mcp.server
@@ -121,3 +120,17 @@ docs:
 .PHONY: docs-tests
 docs-tests:
 	cd docs/src && sh tests.sh
+
+%:
+	@:
+
+.PHONY: release
+release:
+	@if [ -z "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
+			echo "\033[0;31mError: No word specified. Usage: make hash <word>\033[0m"; \
+			echo "Example: make hash nottelabs"; \
+			exit 1; \
+	fi
+	@echo "\033[0;35mBuilding version: $(filter-out $@,$(MAKECMDGOALS))\033[0m"
+	sh build.sh $(filter-out $@,$(MAKECMDGOALS))
+	@git checkout pyproject.toml uv.lock packages/*/pyproject.toml

--- a/makefile
+++ b/makefile
@@ -127,8 +127,8 @@ docs-tests:
 .PHONY: release
 release:
 	@if [ -z "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
-			echo "\033[0;31mError: No word specified. Usage: make hash <word>\033[0m"; \
-			echo "Example: make hash nottelabs"; \
+			echo "\033[0;31mError: No word specified. Usage: make release <release_tag>\033[0m"; \
+			echo "Example: make release 1.6.6"; \
 			exit 1; \
 	fi
 	@echo "\033[0;35mBuilding version: $(filter-out $@,$(MAKECMDGOALS))\033[0m"

--- a/packages/notte-core/src/notte_core/browser/dom_tree.py
+++ b/packages/notte-core/src/notte_core/browser/dom_tree.py
@@ -88,9 +88,6 @@ class NodeSelectors(BaseModel):
             text = unique_selector.replace("~", "").strip()
             keys["playwright_selector"] = f'internal:text="{text}"'
         else:
-            logger.warning(
-                f"Action selector should start with xpath=, css=, internal:, or ~ (text) but got {unique_selector}"
-            )
             keys["playwright_selector"] = unique_selector
 
         return NodeSelectors(

--- a/packages/notte-sdk/src/notte_sdk/endpoints/base.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/base.py
@@ -170,7 +170,7 @@ class BaseClient(ABC):
 
     def _request(
         self, endpoint: NotteEndpoint[TResponse], headers: dict[str, str] | None = None, timeout: int | None = None
-    ) -> requests.Response:
+    ) -> dict[str, Any]:
         """
         Executes an HTTP request for the given API endpoint.
 

--- a/packages/notte-sdk/src/notte_sdk/endpoints/base.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/base.py
@@ -72,7 +72,7 @@ class NotteEndpoint(BaseModel, Generic[TResponse]):
 
 class BaseClient(ABC):
     DEFAULT_NOTTE_API_URL: ClassVar[str] = "https://api.notte.cc"
-    DEFAULT_REQUEST_TIMEOUT_SECONDS: ClassVar[int] = 60
+    DEFAULT_REQUEST_TIMEOUT_SECONDS: ClassVar[int] = 30
     DEFAULT_FILE_CHUNK_SIZE: ClassVar[int] = 8192
 
     HEALTH_CHECK_ENDPOINT: ClassVar[str] = "health"
@@ -168,7 +168,9 @@ class BaseClient(ABC):
         path = urljoin(path, endpoint_path)
         return path
 
-    def _request(self, endpoint: NotteEndpoint[TResponse], headers: dict[str, str] | None = None) -> requests.Response:
+    def _request(
+        self, endpoint: NotteEndpoint[TResponse], headers: dict[str, str] | None = None, timeout: int | None = None
+    ) -> requests.Response:
         """
         Executes an HTTP request for the given API endpoint.
 
@@ -200,7 +202,7 @@ class BaseClient(ABC):
                     url=url,
                     headers=headers,
                     params=params,
-                    timeout=self.DEFAULT_REQUEST_TIMEOUT_SECONDS,
+                    timeout=timeout or self.DEFAULT_REQUEST_TIMEOUT_SECONDS,
                 )
             case "POST" | "PATCH":
                 if endpoint.request is None and endpoint.files is None:
@@ -216,7 +218,7 @@ class BaseClient(ABC):
                     headers=headers,
                     data=data,
                     params=params,
-                    timeout=self.DEFAULT_REQUEST_TIMEOUT_SECONDS,
+                    timeout=timeout or self.DEFAULT_REQUEST_TIMEOUT_SECONDS,
                     files=files,
                 )
             case "DELETE":
@@ -224,7 +226,7 @@ class BaseClient(ABC):
                     url=url,
                     headers=headers,
                     params=params,
-                    timeout=self.DEFAULT_REQUEST_TIMEOUT_SECONDS,
+                    timeout=timeout or self.DEFAULT_REQUEST_TIMEOUT_SECONDS,
                 )
         if response.status_code != 200:
             if response.headers.get("x-error-class") == "NotteApiExecutionError":
@@ -236,7 +238,9 @@ class BaseClient(ABC):
             raise NotteAPIError(path=f"{self.base_endpoint_path}/{endpoint.path}", response=response)
         return response_dict
 
-    def request(self, endpoint: NotteEndpoint[TResponse], headers: dict[str, str] | None = None) -> TResponse:
+    def request(
+        self, endpoint: NotteEndpoint[TResponse], headers: dict[str, str] | None = None, timeout: int | None = None
+    ) -> TResponse:
         """
         Requests the specified API endpoint and returns the validated response.
 
@@ -255,7 +259,7 @@ class BaseClient(ABC):
         Raises:
             NotteAPIError: If the API response is not a dictionary.
         """
-        response: Any = self._request(endpoint, headers=headers)
+        response: Any = self._request(endpoint, headers=headers, timeout=timeout)
         if not isinstance(response, dict):
             raise NotteAPIError(path=f"{self.base_endpoint_path}/{endpoint.path}", response=response)
 

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import traceback
-from typing import TYPE_CHECKING, Any, Unpack, final, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Unpack, final, overload
 
 import requests
 from loguru import logger
@@ -85,6 +85,8 @@ class WorkflowsClient(BaseClient):
     LIST_WORKFLOW_RUNS = "{workflow_id}/runs"
     UPDATE_WORKFLOW_RUN = "{workflow_id}/runs/{run_id}"
     RUN_WORKFLOW_ENDPOINT = "{workflow_id}/runs/{run_id}"
+
+    WORKFLOW_RUN_TIMEOUT: ClassVar[int] = 60 * 5  # 5 minutes
 
     def __init__(
         self,
@@ -347,7 +349,7 @@ class WorkflowsClient(BaseClient):
         endpoint = self._start_workflow_run_endpoint(
             workflow_id=request.workflow_id, run_id=workflow_run_id
         ).with_request(request)
-        return self.request(endpoint, headers={"x-notte-api-key": self.token})
+        return self.request(endpoint, headers={"x-notte-api-key": self.token}, timeout=self.WORKFLOW_RUN_TIMEOUT)
 
 
 class RemoteWorkflow:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-request timeout option for SDK calls.
  - Set workflow run timeout to 5 minutes.
- Changes
  - Reduced default SDK request timeout from 60s to 30s.
- Refactor
  - Removed noisy warning logs for unknown selectors to reduce log clutter.
- Chores
  - Added a release make target with input validation.
  - Undefined make targets now no-op instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->