### PR TITLE
correct disable restricted python

### DIFF
--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -56,6 +56,7 @@ class ScriptValidator(RestrictingNodeTransformer):
         # Safe third-party
         "pydantic",  # Data validation library
         "loguru",  # Logging library
+        "requests",
         # Safe standard library modules - data processing and utilities
         "json",  # JSON parsing
         "datetime",  # Date/time handling
@@ -365,6 +366,11 @@ class SecureScriptRunner:
                 "_getitem_": self.safe_getitem,
                 "_getiter_": self.safe_getiter,
                 "_write_": self.safe_write,
+                # RestrictedPython requires these variables to be defined
+                "__metaclass__": type,  # Required for RestrictedPython compiled code
+                "_iter_unpack_sequence_": iter,  # Iterator unpacking guard
+                "__name__": "__main__",  # Standard module name
+                "__file__": "<user_script.py>",  # Standard filename
                 # Import handling
                 # Additional safe built-ins that might be useful
                 "len": len,
@@ -472,9 +478,10 @@ class SecureScriptRunner:
             restricted: If True, use RestrictedPython for safety (default: False)
                    If False, use regular Python execution (full access)
         """
+
         if restricted:
             # Use RestrictedPython for strict mode
-            code = ScriptValidator.parse_script(code_string, restricted=True)
+            code = ScriptValidator.parse_script(code_string, restricted=restricted)
             execution_globals = self.get_safe_globals()
             result: Mapping[str, object] = {}
 
@@ -494,7 +501,7 @@ class SecureScriptRunner:
                 raise RuntimeError(f"Python script execution failed in restricted mode: {traceback.format_exc()}")
         else:
             # Use regular Python execution for non-strict mode
-            # First check that run function exists
+            # First check that run function exists in original script
             tree = ast.parse(code_string)
             if not self._check_run_function_exists_static(tree):
                 raise MissingRunFunctionError("Python script must contain a 'run' function")
@@ -506,8 +513,8 @@ class SecureScriptRunner:
             }
 
             try:
-                # Execute the script in regular Python
-                exec(code_string, execution_globals)
+                # Execute the modified script in regular Python
+                exec(code_string, execution_globals, execution_globals)
 
                 # Call the run function
                 run_ft = execution_globals.get("run")

--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -501,7 +501,7 @@ class SecureScriptRunner:
                 raise RuntimeError(f"Python script execution failed in restricted mode: {traceback.format_exc()}")
         else:
             # Use regular Python execution for non-strict mode
-            # First check that run function exists in original script
+            # First check that run function exists
             tree = ast.parse(code_string)
             if not self._check_run_function_exists_static(tree):
                 raise MissingRunFunctionError("Python script must contain a 'run' function")
@@ -513,8 +513,8 @@ class SecureScriptRunner:
             }
 
             try:
-                # Execute the modified script in regular Python
-                exec(code_string, execution_globals, execution_globals)
+                # Execute the script in regular Python
+                exec(code_string, execution_globals)
 
                 # Call the run function
                 run_ft = execution_globals.get("run")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - You can now import and use the “requests” library in user scripts, including in restricted mode.
  - Cloud workflow runs support per-run timeout overrides so individual runs can specify a custom timeout.

- Bug Fixes
  - Restricted mode is now correctly respected during script parsing and execution.
  - Improved compatibility of scripts in restricted mode by exposing required safe globals, reducing unexpected runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->