### PR TITLE
weird interaction with page.title

### DIFF
--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -238,7 +238,7 @@ class BrowserWindow(BaseModel):
     async def tab_metadata(self, tab_idx: int | None = None) -> TabsData:
         page = self.tabs[tab_idx] if tab_idx is not None else self.page
         try:
-            page_title = await asyncio.wait_for(page.title(), timeout=1.0)
+            page_title = await asyncio.wait_for(page.title(), timeout=5.0)
         except TimeoutError:
             page_title = page.url
 
@@ -247,12 +247,6 @@ class BrowserWindow(BaseModel):
             title=page_title,
             url=page.url,
         )
-        # page = self.tabs[tab_idx] if tab_idx is not None else self.page
-        # return TabsData(
-        #     tab_id=tab_idx if tab_idx is not None else -1,
-        #     title=await page.title(),
-        #     url=page.url,
-        # )
 
     @profiler.profiled()
     async def snapshot_metadata(self) -> SnapshotMetadata:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents freezes when loading tab titles by applying a 5-second timeout.
  * Falls back to displaying the tab’s URL if the title can’t be retrieved in time.
* **Performance**
  * Faster, more reliable tab list rendering when pages are slow or unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->