### PR TITLE
add workflow run name

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1670,6 +1670,7 @@ class GetWorkflowResponse(SdkBaseModel):
     latest_version: Annotated[str, Field(description="The version of the workflow")]
     versions: Annotated[list[str], Field(description="The versions of the workflow")]
     status: Annotated[str, Field(description="The status of the workflow")]
+    name: Annotated[str | None, Field(description="The name of the workflow")] = None
 
 
 class GetWorkflowWithLinkResponse(GetWorkflowResponse, FileLinkResponse):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow responses in the SDK now include an optional “name” field, allowing clients to retrieve a workflow’s name when available.
  * Backward-compatible addition: existing integrations continue to work; the field may be null if a name is not set.
  * Developers can start displaying or logging workflow names without additional API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->