### PR TITLE
standardize timeouts

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/base.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/base.py
@@ -73,7 +73,7 @@ class NotteEndpoint(BaseModel, Generic[TResponse]):
 
 class BaseClient(ABC):
     DEFAULT_NOTTE_API_URL: ClassVar[str] = "https://api.notte.cc"
-    DEFAULT_REQUEST_TIMEOUT_SECONDS: ClassVar[int] = 30
+    DEFAULT_REQUEST_TIMEOUT_SECONDS: ClassVar[int] = 60
     DEFAULT_FILE_CHUNK_SIZE: ClassVar[int] = 8192
 
     HEALTH_CHECK_ENDPOINT: ClassVar[str] = "health"
@@ -324,6 +324,7 @@ class BaseClient(ABC):
         with requests.get(
             url=url,
             stream=True,
+            timeout=self.DEFAULT_REQUEST_TIMEOUT_SECONDS,
         ) as r:
             r.raise_for_status()
 

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -647,7 +647,7 @@ class RemoteWorkflow:
 
         file_url = self.get_url(version=version)
         try:
-            response = requests.get(file_url, timeout=30)
+            response = requests.get(file_url, timeout=self.client.DEFAULT_REQUEST_TIMEOUT_SECONDS)
             response.raise_for_status()
         except requests.RequestException as e:
             raise ValueError(f"Failed to download workflow from {file_url} in 30 seconds: {e}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Increased the default HTTP request timeout from 30s to 60s across the SDK to improve reliability on slower networks.
  * Workflow downloads now inherit the SDK’s default timeout for consistent behavior with other requests.
* **Chores**
  * Standardized timeout usage in download operations to align with the global default, reducing the need for per-call configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->