### PR TITLE
add local to create workflow

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -333,8 +333,8 @@ class WorkflowsClient(BaseClient):
         params = ListWorkflowsRequest.model_validate(data)
         return self.request(self._list_workflows_endpoint().with_params(params))
 
-    def create_run(self, workflow_id: str) -> CreateWorkflowRunResponse:
-        request = CreateWorkflowRunRequest(workflow_id=workflow_id)
+    def create_run(self, workflow_id: str, local: bool) -> CreateWorkflowRunResponse:
+        request = CreateWorkflowRunRequest(workflow_id=workflow_id, local=local)
         return self.request(self._create_workflow_run_endpoint(workflow_id).with_request(request))
 
     def get_run(self, workflow_id: str, run_id: str) -> GetWorkflowRunResponse:
@@ -688,7 +688,7 @@ class RemoteWorkflow:
         """
         # first create the run on DB
         if workflow_run_id is None:
-            create_run_response = self.client.create_run(self.workflow_id)
+            create_run_response = self.client.create_run(self.workflow_id, local=local)
             workflow_run_id = create_run_response.workflow_run_id
 
         if log_callback is not None and not local:

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -356,17 +356,6 @@ class WorkflowsClient(BaseClient):
         return self.request(self._list_workflow_runs_endpoint(workflow_id).with_params(request))
 
     @staticmethod
-    def extract_session_id(s: str) -> str | None:
-        """
-        Extracts the session ID (UUID) from a log line containing
-        '[Session] <uuid> started with request'.
-        Returns None if no match is found.
-        """
-        pattern = r"\[Session\]\s+([0-9a-fA-F-]{36})\s+started with request"
-        match = re.search(pattern, s)
-        return match.group(1) if match else None
-
-    @staticmethod
     def decode_message(text: str):
         # Convert ANSI color codes to loguru color tags
         colored_text = WorkflowsClient._ansi_to_loguru_colors(text)
@@ -464,6 +453,7 @@ class WorkflowsClient(BaseClient):
 
         result: Any | None = None
 
+        session_id = None
         with requests.post(url=url, headers=headers, data=req_data, timeout=timeout, stream=True) as res:
             res.raise_for_status()
             for line in res.iter_lines():
@@ -482,10 +472,9 @@ class WorkflowsClient(BaseClient):
                             logger.opt(colors=True).info(decoded)
                         elif message["type"] == "result":
                             result = log_msg
+                        elif message["type"] == "session_start":
+                            session_id = log_msg
 
-                        session_id = WorkflowsClient.extract_session_id(log_msg)
-
-                        if session_id is not None:
                             logger.info(
                                 f"Live viewer for session available at: https://api.notte.cc/sessions/viewer/index.html?ws=wss://api.notte.cc/sessions/{session_id}/debug/recording?token={self.token}"
                             )

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -333,7 +333,7 @@ class WorkflowsClient(BaseClient):
         params = ListWorkflowsRequest.model_validate(data)
         return self.request(self._list_workflows_endpoint().with_params(params))
 
-    def create_run(self, workflow_id: str, local: bool) -> CreateWorkflowRunResponse:
+    def create_run(self, workflow_id: str, local: bool = False) -> CreateWorkflowRunResponse:
         request = CreateWorkflowRunRequest(workflow_id=workflow_id, local=local)
         return self.request(self._create_workflow_run_endpoint(workflow_id).with_request(request))
 

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1723,6 +1723,14 @@ class StartWorkflowRunRequest(SdkBaseModel):
 WorkflowRunStatus = Literal["closed", "active", "failed"]
 
 
+class WorkflowRunResponse(SdkBaseModel):
+    workflow_id: Annotated[str, Field(description="The ID of the workflow")]
+    workflow_run_id: Annotated[str, Field(description="The ID of the workflow run")]
+    session_id: Annotated[str | None, Field(description="The ID of the session")]
+    result: Annotated[Any, Field(description="The result of the workflow run")]
+    status: Annotated[WorkflowRunStatus, Field(description="The status of the workflow run (closed, active, failed)")]
+
+
 class GetWorkflowRunResponse(SdkBaseModel):
     workflow_id: str
     workflow_run_id: str

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1723,14 +1723,6 @@ class StartWorkflowRunRequest(SdkBaseModel):
 WorkflowRunStatus = Literal["closed", "active", "failed"]
 
 
-class WorkflowRunResponse(SdkBaseModel):
-    workflow_id: Annotated[str, Field(description="The ID of the workflow")]
-    workflow_run_id: Annotated[str, Field(description="The ID of the workflow run")]
-    session_id: Annotated[str | None, Field(description="The ID of the session")]
-    result: Annotated[Any, Field(description="The result of the workflow run")]
-    status: Annotated[WorkflowRunStatus, Field(description="The status of the workflow run (closed, active, failed)")]
-
-
 class GetWorkflowRunResponse(SdkBaseModel):
     workflow_id: str
     workflow_run_id: str
@@ -1743,6 +1735,7 @@ class GetWorkflowRunResponse(SdkBaseModel):
         default_factory=dict
     )
     result: Annotated[str | None, Field(description="The result of the workflow run (if any)")] = None
+    local: Annotated[bool, Field(description="Whether the workflow has been run locally or on the cloud")] = False
 
 
 class WorkflowRunUpdateRequestDict(TypedDict, total=False):

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1710,7 +1710,7 @@ class ListWorkflowsResponse(SdkBaseModel):
 
 class CreateWorkflowRunRequest(SdkBaseModel):
     workflow_id: Annotated[str, Field(description="The ID of the workflow")]
-    local: Annotated[bool, Field(description="Whether to run the workflow locally, or in cloud")]
+    local: Annotated[bool, Field(description="Whether to run the workflow locally, or in cloud")] = False
 
 
 class StartWorkflowRunRequest(SdkBaseModel):

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1710,6 +1710,7 @@ class ListWorkflowsResponse(SdkBaseModel):
 
 class CreateWorkflowRunRequest(SdkBaseModel):
     workflow_id: Annotated[str, Field(description="The ID of the workflow")]
+    local: Annotated[bool, Field(description="Whether to run the workflow locally, or in cloud")]
 
 
 class StartWorkflowRunRequest(SdkBaseModel):

--- a/tests/integration/sdk/test_workflow_runs.py
+++ b/tests/integration/sdk/test_workflow_runs.py
@@ -373,7 +373,7 @@ def run(**kwargs):
             assert result.status == "closed"
 
             # Verify create_run was called
-            mock_create_run.assert_called_once_with(test_remote_workflow.workflow_id)
+            mock_create_run.assert_called_once_with(test_remote_workflow.workflow_id, local=False)
 
     def test_remote_workflow_run_with_version(self, test_remote_workflow: RemoteWorkflow):
         """Test running a RemoteWorkflow with specific version."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose where a workflow runs (local or cloud) when starting a run; new runs respect this choice.
  * Live session-based viewer links are now always reported during runs as session IDs are captured from session_start events.

* **Developer Experience**
  * SDK surfaces a locality flag that’s accepted and propagated when creating workflow runs.

* **Tests**
  * Integration tests updated to verify the locality flag is passed for cloud runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->