### PR TITLE
remove unnecessary param

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -370,7 +370,7 @@ class WorkflowsClient(BaseClient):
         return self.request(self._list_workflows_endpoint().with_params(params))
 
     def create_run(self, workflow_id: str, local: bool = False) -> CreateWorkflowRunResponse:
-        request = CreateWorkflowRunRequest(workflow_id=workflow_id, local=local)
+        request = CreateWorkflowRunRequest(local=local)
         return self.request(self._create_workflow_run_endpoint(workflow_id).with_request(request))
 
     def stop_run(self, workflow_id: str, run_id: str) -> UpdateWorkflowRunResponse:

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1729,7 +1729,6 @@ class ListWorkflowsResponse(SdkBaseModel):
 
 
 class CreateWorkflowRunRequest(SdkBaseModel):
-    workflow_id: Annotated[str, Field(description="The ID of the workflow")]
     local: Annotated[bool, Field(description="Whether to run the workflow locally, or in cloud")] = False
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Creating a workflow run no longer accepts workflow_id in the request body. Provide the workflow ID via the URL/endpoint as before; only the local flag is sent in the payload.
  * The request model for creating a workflow run now requires only local. Update any integrations that previously constructed a payload with workflow_id.
* **Refactor**
  * Simplified workflow run creation payload to reduce redundancy and align ID handling with the endpoint path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->