### PR TITLE
increase ws size

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
@@ -255,6 +255,7 @@ class AgentsClient(BaseClient):
                 ping_interval=5,
                 ping_timeout=40,
                 close_timeout=5,
+                max_size=5 * (2**20),  # 5MB max size
             ) as websocket:
                 try:
                     async for message in websocket:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Log streaming now enforces a 5 MB maximum size per incoming message. Messages exceeding this limit may not be delivered during real-time log viewing. Typical log entries are unaffected. No changes to public APIs or settings. Users sending oversized log entries may need to adjust payload sizes to ensure delivery within the new limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->