### PR TITLE
fix captach error pydantic

### DIFF
--- a/packages/notte-browser/src/notte_browser/errors.py
+++ b/packages/notte-browser/src/notte_browser/errors.py
@@ -351,7 +351,7 @@ class FailedToDownloadFileError(NotteBaseError):
 
 
 class CaptchaSolverNotAvailableError(NotteBaseError):
-    message: str = "Captcha solving isn't implemented in the open repo. Please use the sdk client: `client.Session(solve_captchas=True)` to enable captcha solving."
+    message: str = "Captcha solving isn't implemented in the open source version. Please use the sdk client: `client.Session(solve_captchas=True)` to enable captcha solving."
 
     def __init__(self) -> None:
         super().__init__(

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -533,7 +533,9 @@ class SessionStartRequest(SdkRequest):
     @model_validator(mode="after")
     def check_solve_captchas(self) -> "SessionStartRequest":
         if self.solve_captchas and self.browser_type != "firefox":
-            raise ValueError("Solve captchas is currently only supported for `browser_type='firefox'`.")
+            raise ValueError(
+                "`solve_captchas=True` is currently only supported for cloud sessions with `browser_type='firefox'`."
+            )
         return self
 
     @model_validator(mode="after")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -193,8 +193,8 @@ async def test_step_with_empty_action_id_should_fail_validation_pydantic():
 
 def test_captcha_solver_not_available_error():
     with pytest.raises(CaptchaSolverNotAvailableError):
-        _ = NotteSession(solve_captchas=True)
+        _ = NotteSession(solve_captchas=True, browser_type="firefox")
 
     CaptchaHandler.is_available = True
-    _ = NotteSession(solve_captchas=True)
+    _ = NotteSession(solve_captchas=True, browser_type="firefox")
     CaptchaHandler.is_available = False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session initialization now supports a browser_type parameter. When enabling captcha solving, set browser_type to "firefox" for cloud sessions.
  * Error messages have been clarified to reference the “open source version” and to specify that captcha solving is supported only for cloud sessions with browser_type="firefox".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->