### PR TITLE
fix: agent fallback validator

### DIFF
--- a/packages/notte-agent/src/notte_agent/common/validator.py
+++ b/packages/notte-agent/src/notte_agent/common/validator.py
@@ -17,6 +17,11 @@ If the task is unclear defined, you can let it pass.
 But if something is missing or the image does not show what was requested dont let it pass.
 Try to understand the page and help the model with suggestions like scroll, do x, ... to get the solution right.
 
+IMPORTANT: The agent navigates through multiple pages. Actions in the history were executed
+on previous pages (check the URL in each action). The current page observation shows the
+RESULT of navigation, not where actions were performed. Element IDs (L1, L2, etc.) reset
+on each page - do not assume IDs in action history match current page elements.
+
 Task to validate: {{task}}.
 
 Return a JSON object with 2 keys: `is_valid` and `reason`:

--- a/packages/notte-agent/src/notte_agent/falco/perception.py
+++ b/packages/notte-agent/src/notte_agent/falco/perception.py
@@ -103,10 +103,13 @@ Data scraped from current page view:
         include_data: bool = True,
     ) -> str:
         id_str = f" with id={result.action.id}" if include_ids and isinstance(result.action, InteractionAction) else ""
+        url_str = f" (on {result.url})" if result.url else ""
         if not result.success:
             err_msg = trim_message(result.message)
-            return f"❌ action '{result.action.name()}'{id_str} failed with error: {err_msg}"
-        success_msg = f"✅ action '{result.action.name()}'{id_str} succeeded: '{result.action.execution_message()}'"
+            return f"❌ action '{result.action.name()}'{id_str} failed{url_str}: {err_msg}"
+        success_msg = (
+            f"✅ action '{result.action.name()}'{id_str} succeeded{url_str}: '{result.action.execution_message()}'"
+        )
         if include_data:
             return f"{success_msg}{self.perceive_data(result.data, only_structured=True)}"
         return success_msg

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -575,6 +575,7 @@ class NotteSession(AsyncResource, SyncResource):
         exception = None
         scraped_data = None
         resolved_action = None
+        action_url = self.page.url  # Capture URL BEFORE action execution
 
         with TimedSpan.capture() as span:
             try:
@@ -707,6 +708,7 @@ class NotteSession(AsyncResource, SyncResource):
             action=resolved_action,
             success=success,
             message=message,
+            url=action_url,
             data=scraped_data,
             exception=exception,
             started_at=span.started_at,
@@ -921,6 +923,7 @@ class NotteSession(AsyncResource, SyncResource):
 
         exception: Exception | None = None
         data: DataSpace | None = None
+        scrape_url = self.page.url  # Capture URL BEFORE scrape execution
         with TimedSpan.capture() as span:
             try:
                 data = await self._ascrape(**params)
@@ -931,6 +934,7 @@ class NotteSession(AsyncResource, SyncResource):
                     action=scrape_action,
                     success=False,
                     message=scrape_action.execution_message(),
+                    url=scrape_url,
                     data=None,
                     exception=exception,
                     started_at=span.started_at,
@@ -957,6 +961,7 @@ class NotteSession(AsyncResource, SyncResource):
             # success is True if structured_scrape_failed is False, otherwise False
             success=not data.structured_scrape_failed if is_structured_scrape else True,
             message=scrape_action.execution_message(),
+            url=scrape_url,
             data=data,
             exception=data.structured_scrape_exception if is_structured_scrape else None,
             started_at=span.started_at,

--- a/packages/notte-core/src/notte_core/browser/observation.py
+++ b/packages/notte-core/src/notte_core/browser/observation.py
@@ -320,6 +320,7 @@ class ExecutionResult(FilledTimedSpan):
     action: ActionUnion
     success: bool
     message: str
+    url: str | None = None  # URL at time of action execution
     data: DataSpace | None = None
     exception: NotteBaseError | Exception | None = Field(default=None)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ timeout_method = "thread"
 asyncio_mode = "strict"
 log_cli = true
 log_cli_level = "INFO"
+markers = [
+    "integration: marks tests as integration tests (requires browser, LLM, network access)",
+]
 filterwarnings = [
     "ignore::DeprecationWarning:sklearn.utils.fixes:",
     "ignore::DeprecationWarning:pandas.core.common:",

--- a/tests/agent/test_validator.py
+++ b/tests/agent/test_validator.py
@@ -124,3 +124,206 @@ def test_agent_with_schema():
         )
     assert valid.success, f"Failed to validate output: {valid.answer}"
     _ = Product.model_validate_json(valid.answer)
+
+
+def test_execution_result_includes_url():
+    """Test that ExecutionResult now includes URL context for actions."""
+    from notte_core.actions import ClickAction
+    from notte_core.browser.observation import ExecutionResult, TimedSpan
+
+    span = TimedSpan.empty()
+
+    # Test with URL
+    result_with_url = ExecutionResult(
+        action=ClickAction(id="L1"),
+        success=True,
+        message="Clicked on element",
+        url="https://example.com",
+        started_at=span.started_at,
+        ended_at=span.ended_at,
+    )
+    assert result_with_url.url == "https://example.com"
+
+    # Test without URL (backwards compatible)
+    result_without_url = ExecutionResult(
+        action=ClickAction(id="L1"),
+        success=True,
+        message="Clicked on element",
+        started_at=span.started_at,
+        ended_at=span.ended_at,
+    )
+    assert result_without_url.url is None
+
+
+def test_perceive_action_result_includes_url():
+    """Test that perceive_action_result includes URL in the output string."""
+    from notte_agent.falco.perception import FalcoPerception
+    from notte_core.actions import ClickAction
+    from notte_core.browser.observation import ExecutionResult, TimedSpan
+
+    perception = FalcoPerception()
+    span = TimedSpan.empty()
+
+    # Test success with URL
+    result_success = ExecutionResult(
+        action=ClickAction(id="L1"),
+        success=True,
+        message="Clicked on element with text label: Learn more",
+        url="https://example.com",
+        started_at=span.started_at,
+        ended_at=span.ended_at,
+    )
+    output_success = perception.perceive_action_result(result_success)
+    assert "(on https://example.com)" in output_success
+    assert "succeeded" in output_success
+
+    # Test failure with URL
+    result_failure = ExecutionResult(
+        action=ClickAction(id="L1"),
+        success=False,
+        message="Element not found",
+        url="https://example.com/page",
+        started_at=span.started_at,
+        ended_at=span.ended_at,
+    )
+    output_failure = perception.perceive_action_result(result_failure)
+    assert "(on https://example.com/page)" in output_failure
+    assert "failed" in output_failure
+
+    # Test without URL (backwards compatible)
+    result_no_url = ExecutionResult(
+        action=ClickAction(id="L1"),
+        success=True,
+        message="Clicked",
+        started_at=span.started_at,
+        ended_at=span.ended_at,
+    )
+    output_no_url = perception.perceive_action_result(result_no_url)
+    assert "(on " not in output_no_url  # No URL prefix should appear
+
+
+def test_validator_system_prompt_has_multipage_context():
+    """Test that the validator system prompt includes multi-page context explanation."""
+    from notte_agent.common.validator import system_rules
+
+    # Check that the system prompt contains the multi-page context explanation
+    assert "IMPORTANT:" in system_rules
+    assert "multiple pages" in system_rules.lower()
+    assert "Element IDs" in system_rules or "element ids" in system_rules.lower()
+    assert "reset" in system_rules.lower()
+
+
+def test_validator_receives_url_in_action_history():
+    """
+    Integration test: Verify that when the validator receives action history,
+    each action includes the URL where it was executed.
+
+    This tests the fix for the bug where the validator would incorrectly reject
+    valid completions because actions executed on previous pages appeared to
+    reference non-existent elements on the current page.
+    """
+    from unittest.mock import MagicMock
+
+    from notte_agent.common.validator import CompletionValidator
+    from notte_agent.falco.perception import FalcoPerception
+    from notte_core.actions import ClickAction, CompletionAction
+    from notte_core.browser.observation import ExecutionResult, Observation, TimedSpan, TrajectoryProgress
+    from notte_core.trajectory import Trajectory
+
+    # Create a mock trajectory that simulates:
+    # 1. Click on "Learn more" link on example.com
+    # 2. Page navigates to iana.org
+    span = TimedSpan.empty()
+
+    # Simulate click action that was executed on example.com
+    click_result = ExecutionResult(
+        action=ClickAction(id="L1"),
+        success=True,
+        message="Clicked on element with text label: Learn more",
+        url="https://example.com",  # KEY: This URL shows where the action was executed
+        started_at=span.started_at,
+        ended_at=span.ended_at,
+    )
+
+    trajectory = Trajectory()
+
+    import asyncio
+
+    asyncio.run(trajectory.append(click_result))
+
+    # Create perception and verify it includes URL in output
+    perception = FalcoPerception()
+    action_result_str = perception.perceive_action_result(click_result)
+
+    # Verify URL is included in the action result string
+    assert "(on https://example.com)" in action_result_str, (
+        f"URL should be included in action result. Got: {action_result_str}"
+    )
+
+    # Verify the format shows what happened
+    assert "succeeded" in action_result_str
+    assert "click" in action_result_str.lower()
+
+    # Create validation message and verify URL context is present
+    # Use a mock LLM since we only need to test validation_message() method
+    mock_llm = MagicMock()
+    validator = CompletionValidator(llm=mock_llm, perception=perception, use_vision=False)
+
+    completion = CompletionAction(success=True, answer="Successfully clicked the Learn more link")
+
+    # Create a minimal observation (simulating we're now on iana.org)
+    progress = TrajectoryProgress(current_step=2, max_steps=5)
+    mock_obs = Observation.empty()
+
+    validation_msg = validator.validation_message(completion, trajectory, progress, mock_obs)
+
+    # The validation message should contain the URL context
+    assert "https://example.com" in validation_msg, (
+        f"Validation message should include the URL where the action was executed. Got: {validation_msg}"
+    )
+
+
+def test_validator_accepts_completion_after_page_navigation():
+    """
+    End-to-end test with real LLM and AgentFallback: Verify that the validator
+    correctly accepts a completion after the agent navigated away from the page
+    where actions were executed.
+
+    This is the exact scenario that was broken before the fix:
+    1. Agent on example.com, user triggers invalid action
+    2. AgentFallback kicks in and clicks "Learn more" link (L1)
+    3. Page navigates to iana.org
+    4. Agent tries to complete: "Successfully clicked the Learn more link"
+    5. OLD behavior: Validator rejects because iana.org has no "Learn more" element
+    6. NEW behavior: Validator accepts because action history shows the click
+       happened on example.com (via URL context)
+    """
+    with notte.Session(headless=True) as session:
+        # Step 1: Navigate to example.com
+        session.execute(type="goto", url="https://example.com")
+        obs = session.observe()
+        assert "example" in obs.metadata.url.lower()
+
+        # Step 2: Use AgentFallback - trigger with invalid action, agent should click the link
+        with notte.AgentFallback(
+            session,
+            task="Click on the 'Learn more' link",
+            max_steps=3,
+            use_vision=False,
+        ) as fallback:
+            # Trigger fallback with invalid action
+            session.execute(type="click", id="B999999", raise_on_failure=False)
+
+        # Verify we navigated to iana.org (the click worked)
+        obs_after = session.observe()
+        assert "iana" in obs_after.metadata.url.lower(), (
+            f"Expected to navigate to iana.org, but on: {obs_after.metadata.url}"
+        )
+
+        # The key assertion: AgentFallback should have succeeded
+        # This was the bug - the validator would reject because it saw iana.org elements
+        # but the action history said "clicked Learn more" without URL context
+        assert fallback.success, (
+            "AgentFallback should succeed. Validator should accept completion because "
+            "action history now includes URL context showing click was on example.com."
+        )

--- a/tests/agent/test_validator.py
+++ b/tests/agent/test_validator.py
@@ -213,7 +213,8 @@ def test_validator_system_prompt_has_multipage_context():
     assert "reset" in system_rules.lower()
 
 
-def test_validator_receives_url_in_action_history():
+@pytest.mark.asyncio
+async def test_validator_receives_url_in_action_history():
     """
     Integration test: Verify that when the validator receives action history,
     each action includes the URL where it was executed.
@@ -246,10 +247,7 @@ def test_validator_receives_url_in_action_history():
     )
 
     trajectory = Trajectory()
-
-    import asyncio
-
-    asyncio.run(trajectory.append(click_result))
+    await trajectory.append(click_result)
 
     # Create perception and verify it includes URL in output
     perception = FalcoPerception()
@@ -283,6 +281,7 @@ def test_validator_receives_url_in_action_history():
     )
 
 
+@pytest.mark.integration
 def test_validator_accepts_completion_after_page_navigation():
     """
     End-to-end test with real LLM and AgentFallback: Verify that the validator

--- a/tests/integration/sdk/test_agent_fallback.py
+++ b/tests/integration/sdk/test_agent_fallback.py
@@ -57,3 +57,14 @@ def test_agent_fallback_scrape_should_raise_error():
         with pytest.raises(ValueError):
             with client.AgentFallback(session, task="add the Cap product to cart", max_steps=1):
                 _ = session.scrape()
+
+
+def test_agent_fallback_validator_with_page_navigation():
+    """
+    Test that the validator correctly handles page navigation scenarios.
+
+    NOTE: This test uses the remote SDK client. The fix for this bug is in the local
+    notte-agent package. Use test_agent_fallback_validator_with_page_navigation_local
+    for testing the local fix.
+    """
+    pytest.skip("This test uses remote SDK - use the local test instead for validating the fix")

--- a/tests/integration/sdk/test_agent_fallback.py
+++ b/tests/integration/sdk/test_agent_fallback.py
@@ -64,7 +64,7 @@ def test_agent_fallback_validator_with_page_navigation():
     Test that the validator correctly handles page navigation scenarios.
 
     NOTE: This test uses the remote SDK client. The fix for this bug is in the local
-    notte-agent package. Use test_agent_fallback_validator_with_page_navigation_local
-    for testing the local fix.
+    notte-agent package. Use test_validator_accepts_completion_after_page_navigation
+    in tests/agent/test_validator.py for testing the local fix.
     """
     pytest.skip("This test uses remote SDK - use the local test instead for validating the fix")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action execution and scrape results now include URL context so outputs show which page an action or scrape ran on.
  * Enhanced system guidance clarifying behavior across multi-page navigation and element ID resets.

* **Tests**
  * Added comprehensive tests for URL tracking and multi-page navigation, plus an integration-marked placeholder test.

* **Chores**
  * Test config updated to support an "integration" marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the `CompletionValidator` would incorrectly reject a valid agent completion after page navigation. When an agent clicked a link that navigated to a new page, the validator saw the new page's elements but the action history referenced elements from the previous page — leading to false negatives. The fix threads the page URL at time of execution through the data model (`ExecutionResult.url`), surfaces it in the agent's perception layer (`FalcoPerception.perceive_action_result`), and adds a clear multi-page context explanation to the validator system prompt.

**Key changes:**
- `observation.py` — adds an optional `url` field to `ExecutionResult` (backward compatible, defaults to `None`).
- `session.py` — captures `self.page.url` before both action execution and scrape execution, and passes it to every newly created `ExecutionResult`.
- `perception.py` — appends `(on <url>)` to the formatted action-result string when a URL is available, giving the LLM provenance for each action in the history.
- `validator.py` — extends the system prompt with an `IMPORTANT` block explaining that element IDs reset per page and that action history URLs reflect where actions were actually performed.
- New tests cover `ExecutionResult` URL population, `perceive_action_result` output format, system prompt content, and end-to-end validation after page navigation.

**Concerns:**
- `test_validator_accepts_completion_after_page_navigation` in `tests/agent/test_validator.py` is a full end-to-end test (real browser, LLM, and external network calls to `example.com`/`iana.org`) with no `pytest.mark.integration` guard or skip condition. It will run with the unit-test suite in any environment and fail in offline/resource-constrained CI.
- Inside `test_validator_receives_url_in_action_history`, `asyncio.run()` is called inside a synchronous test to append to a trajectory. This can conflict with an already-running event loop in some pytest configurations.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the core fix is correct, backward compatible, and well-tested; only the test hygiene concerns need attention.
- The data-model change (`url` field with `None` default) is fully backward compatible. URL capture happens at exactly the right moment (before execution) in both the action and scrape code paths. The perception and validator prompt changes are additive. The only risks are a fragile end-to-end test placed outside the integration folder (no `pytest.mark` guard) and potential `asyncio.run` conflicts in the test suite — neither affects production behaviour.
- tests/agent/test_validator.py — the new end-to-end test `test_validator_accepts_completion_after_page_navigation` should be guarded with `pytest.mark.integration` or moved to `tests/integration/`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/notte-core/src/notte_core/browser/observation.py | Adds an optional `url: str | None = None` field to `ExecutionResult` to record the page URL at the time of action execution. Backward compatible with a `None` default. |
| packages/notte-browser/src/notte_browser/session.py | Captures `self.page.url` before both action execution and scrape execution, then passes it to all created `ExecutionResult` objects via the new `url` field. Correctly covers both the action path and the scrape path. |
| packages/notte-agent/src/notte_agent/falco/perception.py | Adds `(on <url>)` to the success and failure action-result strings when a URL is present, providing the LLM with provenance context for each action in the history. |
| packages/notte-agent/src/notte_agent/common/validator.py | Adds an IMPORTANT block to the validator system prompt explaining that actions were performed on previous pages, that the current observation is the result of navigation, and that element IDs reset per page. |
| tests/agent/test_validator.py | Adds several unit tests for the new URL field and one end-to-end test (`test_validator_accepts_completion_after_page_navigation`) that requires a real browser, LLM, and external network access; this test is placed in the non-integration test folder without a marker and without a skip guard, making it potentially fragile in offline/CI environments. |
| tests/integration/sdk/test_agent_fallback.py | Adds a stub test that immediately calls `pytest.skip`, redirecting testers to the local test in `test_validator.py`. Clean placeholder with a useful message. |

</details>

<sub>Last reviewed commit: 3e35d68</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->