### PR TITLE
Increase agents steps

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1800,7 +1800,7 @@ class __AgentCreateRequest(SdkRequest):
     use_vision: Annotated[
         bool, Field(description="Whether to use vision for the agent. Not all reasoning models support vision.")
     ] = True
-    max_steps: Annotated[int, Field(description="The maximum number of steps the agent should take", ge=1, le=100)] = (
+    max_steps: Annotated[int, Field(description="The maximum number of steps the agent should take", ge=1, le=150)] = (
         DEFAULT_MAX_NB_STEPS
     )
     vault_id: Annotated[str | None, Field(description="The vault to use for the agent")] = None

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1800,7 +1800,7 @@ class __AgentCreateRequest(SdkRequest):
     use_vision: Annotated[
         bool, Field(description="Whether to use vision for the agent. Not all reasoning models support vision.")
     ] = True
-    max_steps: Annotated[int, Field(description="The maximum number of steps the agent should take", ge=1, le=50)] = (
+    max_steps: Annotated[int, Field(description="The maximum number of steps the agent should take", ge=1, le=100)] = (
         DEFAULT_MAX_NB_STEPS
     )
     vault_id: Annotated[str | None, Field(description="The vault to use for the agent")] = None


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR increases the upper bound on the `max_steps` field in `__AgentCreateRequest` (and its subclasses) to `le=100`, allowing SDK users to configure agents to run up to 100 steps. The default value remains `DEFAULT_MAX_NB_STEPS` (20, sourced from `config.toml`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal change that relaxes a validation upper bound with no risk to correctness.

Single-field constraint change with no logic impact; default value is unchanged at 20, and the new ceiling of 100 is a straightforward API limit increase.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/notte-sdk/src/notte_sdk/types.py | Raises the upper bound on `max_steps` in `__AgentCreateRequest` from a lower limit to `le=100`, allowing agents to run up to 100 steps instead of the previous cap. |

</details>

<sub>Reviews (1): Last reviewed commit: ["bump sessions steps"](https://github.com/nottelabs/notte/commit/1a3d0f5090bdc58384318aff8f3a8f84942acb76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28017756)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Agents can now execute longer sequences with a maximum step limit of 150 (increased from 50).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->