### PR TITLE
docs: add Anything API product page

### DIFF
--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -323,7 +323,8 @@
                 "pages": [
                   "product/agent-mode",
                   "product/demonstrate-mode",
-                  "product/studio"
+                  "product/studio",
+                  "product/anything-api"
                 ]
               }
             ]

--- a/docs/src/product/anything-api.mdx
+++ b/docs/src/product/anything-api.mdx
@@ -1,0 +1,183 @@
+---
+title: Anything API
+description: Build and run web automations from a single API call
+---
+
+The Anything API lets you describe a task in plain English, and Notte will build, deploy, and run a web automation function for you -- all through a single HTTP request. The response is an SSE stream so you can follow the agent's progress in real time.
+
+<CardGroup cols={2}>
+  <Card title="Try it now" icon="arrow-up-right-from-square" href="https://anything.notte.cc">
+    Open the Anything API web app.
+  </Card>
+  <Card title="Get your API key" icon="key" href="https://console.notte.cc">
+    Create an account on the Console to get started.
+  </Card>
+</CardGroup>
+
+## Quick start
+
+```bash
+curl -N -X POST https://anything.notte.cc/api/anything/start \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NOTTE_API_KEY" \
+  -d '{"query": "fetch the top 3 hacker news posts"}'
+```
+
+The API streams back SSE events as the agent works. When it's done, the final `done` event contains the `function_id` of the created function, which you can re-run later via the [Notte CLI](/cli) or [SDK](/quickstart).
+
+## Request
+
+<ParamField path="query" type="string" required>
+  A natural-language description of the task you want automated.
+</ParamField>
+
+```json POST /api/anything/start
+{
+  "query": "fetch the top 3 hacker news posts"
+}
+```
+
+**Headers**
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Authorization` | Yes | `Bearer <NOTTE_API_KEY>` |
+| `Content-Type` | Yes | `application/json` |
+
+## Response
+
+The response is a `text/event-stream`. Each line follows the [SSE spec](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events):
+
+```
+data: {"type":"<event_type>", ...}
+```
+
+### Event types
+
+| Type | Description | Key fields |
+|------|-------------|------------|
+| `status` | Agent lifecycle updates | `status` |
+| `thinking_delta` | Agent reasoning (streamed) | `delta` |
+| `text_delta` | Agent response text (streamed) | `delta` |
+| `tool_start` | Agent started using a tool | `name` |
+| `tool_result` | Tool execution result | `content` |
+| `message_complete` | An assistant message was persisted | `role` |
+| `notte_session_data` | Browser session info | `viewer_url` |
+| `function_uploaded` | A Notte Function was created | `function_id`, `function_name`, `created_at` |
+| `done` | Agent finished | `total_cost_usd`, `function_id`, `metadata` |
+| `error` | Something went wrong | `error`, `detail` |
+| `timeout` | Agent timed out | `reason`, `detail` |
+| `cancelled` | Agent was cancelled | `reason` |
+
+### Terminal events
+
+The stream ends after one of these events: `done`, `error`, `timeout`, or `cancelled`.
+
+### Example: done event
+
+```json
+{
+  "type": "done",
+  "metadata": {
+    "thread_id": "820a7cff-613b-4529-9ba4-52c7a6777713"
+  },
+  "total_cost_usd": 0.43,
+  "function_id": "d3c31289-f28b-49bd-a340-95e071cfef7e"
+}
+```
+
+## Re-running the created function
+
+Once the agent finishes, it typically creates a reusable **Notte Function**. Use the `function_id` from the `done` event to run it again:
+
+<CodeGroup>
+```bash CLI
+notte functions run \
+  --function-id d3c31289-f28b-49bd-a340-95e071cfef7e \
+  --vars '{"count": "3"}' \
+  -o json
+```
+
+```python Python SDK
+from notte import NotteClient
+
+client = NotteClient()
+result = client.functions.run(
+    function_id="d3c31289-f28b-49bd-a340-95e071cfef7e",
+    variables={"count": "3"},
+)
+print(result)
+```
+</CodeGroup>
+
+## Consuming the SSE stream
+
+### Python
+
+```python
+import requests
+
+response = requests.post(
+    "https://anything.notte.cc/api/anything/start",
+    headers={
+        "Authorization": f"Bearer {NOTTE_API_KEY}",
+        "Content-Type": "application/json",
+    },
+    json={"query": "fetch the top 3 hacker news posts"},
+    stream=True,
+)
+
+for line in response.iter_lines():
+    if line:
+        decoded = line.decode("utf-8")
+        if decoded.startswith("data: "):
+            print(decoded[6:])
+```
+
+### TypeScript
+
+```typescript
+const response = await fetch("https://anything.notte.cc/api/anything/start", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${NOTTE_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({ query: "fetch the top 3 hacker news posts" }),
+});
+
+const reader = response.body!.getReader();
+const decoder = new TextDecoder();
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+
+  const text = decoder.decode(value, { stream: true });
+  for (const line of text.split("\n")) {
+    if (line.startsWith("data: ")) {
+      const event = JSON.parse(line.slice(6));
+      console.log(event.type, event);
+
+      if (event.type === "done") {
+        console.log("Function ID:", event.function_id);
+        console.log("Cost:", event.total_cost_usd);
+      }
+    }
+  }
+}
+```
+
+## Error handling
+
+| Status | Meaning |
+|--------|---------|
+| `401` | Missing or invalid API key |
+| `400` | Missing `query` field or invalid JSON |
+| `502` | Agent failed to start or SSE stream unavailable |
+
+If the stream connects successfully but the agent encounters an error, you will receive an `error` event in the SSE stream instead of an HTTP error status.
+
+## Pricing
+
+Each request is billed based on the LLM usage incurred by the agent. The `total_cost_usd` field in the `done` event reports the exact cost for that run.

--- a/docs/src/product/anything-api.mdx
+++ b/docs/src/product/anything-api.mdx
@@ -3,6 +3,9 @@ title: Anything API
 description: Build and run web automations from a single API call
 ---
 
+import RunFunction from '/snippets/anything-api/run_function.mdx';
+import ConsumeSSE from '/snippets/anything-api/consume_sse.mdx';
+
 The Anything API lets you describe a task in plain English, and Notte will build, deploy, and run a web automation function for you -- all through a single HTTP request. The response is an SSE stream so you can follow the agent's progress in real time.
 
 <CardGroup cols={2}>
@@ -98,41 +101,14 @@ notte functions run \
   -o json
 ```
 
-```python Python SDK
-from notte import NotteClient
-
-client = NotteClient()
-result = client.functions.run(
-    function_id="d3c31289-f28b-49bd-a340-95e071cfef7e",
-    variables={"count": "3"},
-)
-print(result)
-```
+<RunFunction />
 </CodeGroup>
 
 ## Consuming the SSE stream
 
 ### Python
 
-```python
-import requests
-
-response = requests.post(
-    "https://anything.notte.cc/api/anything/start",
-    headers={
-        "Authorization": f"Bearer {NOTTE_API_KEY}",
-        "Content-Type": "application/json",
-    },
-    json={"query": "fetch the top 3 hacker news posts"},
-    stream=True,
-)
-
-for line in response.iter_lines():
-    if line:
-        decoded = line.decode("utf-8")
-        if decoded.startswith("data: "):
-            print(decoded[6:])
-```
+<ConsumeSSE />
 
 ### TypeScript
 
@@ -146,15 +122,27 @@ const response = await fetch("https://anything.notte.cc/api/anything/start", {
   body: JSON.stringify({ query: "fetch the top 3 hacker news posts" }),
 });
 
-const reader = response.body!.getReader();
+if (!response.ok) {
+  throw new Error(`HTTP ${response.status}`);
+}
+if (!response.body) {
+  throw new Error("ReadableStream not available");
+}
+
+const reader = response.body.getReader();
 const decoder = new TextDecoder();
+const terminal = new Set(["done", "error", "timeout", "cancelled"]);
+let buffer = "";
 
 while (true) {
   const { done, value } = await reader.read();
   if (done) break;
 
-  const text = decoder.decode(value, { stream: true });
-  for (const line of text.split("\n")) {
+  buffer += decoder.decode(value, { stream: true });
+  const lines = buffer.split("\n");
+  buffer = lines.pop()!;
+
+  for (const line of lines) {
     if (line.startsWith("data: ")) {
       const event = JSON.parse(line.slice(6));
       console.log(event.type, event);
@@ -162,6 +150,11 @@ while (true) {
       if (event.type === "done") {
         console.log("Function ID:", event.function_id);
         console.log("Cost:", event.total_cost_usd);
+      }
+
+      if (terminal.has(event.type)) {
+        reader.cancel();
+        break;
       }
     }
   }

--- a/docs/src/snippets/anything-api/consume_sse.mdx
+++ b/docs/src/snippets/anything-api/consume_sse.mdx
@@ -1,0 +1,27 @@
+{/* Auto-generated mdx file. Do not edit! */}
+{/* @sniptest testers/anything-api/consume_sse.py */}
+
+```python consume_sse.py
+import os
+
+import requests
+
+NOTTE_API_KEY = os.environ["NOTTE_API_KEY"]
+
+response = requests.post(
+    "https://anything.notte.cc/api/anything/start",
+    headers={
+        "Authorization": f"Bearer {NOTTE_API_KEY}",
+        "Content-Type": "application/json",
+    },
+    json={"query": "fetch the top 3 hacker news posts"},
+    stream=True,
+)
+response.raise_for_status()
+
+for line in response.iter_lines():
+    if line:
+        decoded = line.decode("utf-8")
+        if decoded.startswith("data: "):
+            print(decoded[6:])
+```

--- a/docs/src/snippets/anything-api/consume_sse.mdx
+++ b/docs/src/snippets/anything-api/consume_sse.mdx
@@ -16,6 +16,7 @@ response = requests.post(
     },
     json={"query": "fetch the top 3 hacker news posts"},
     stream=True,
+    timeout=(10, 300),
 )
 response.raise_for_status()
 

--- a/docs/src/snippets/anything-api/run_function.mdx
+++ b/docs/src/snippets/anything-api/run_function.mdx
@@ -1,0 +1,13 @@
+{/* Auto-generated mdx file. Do not edit! */}
+{/* @sniptest testers/anything-api/run_function.py */}
+
+```python run_function.py
+from notte_sdk import NotteClient
+
+client = NotteClient()
+result = client.functions.run(
+    function_id="d3c31289-f28b-49bd-a340-95e071cfef7e",
+    variables={"count": "3"},
+)
+print(result)
+```

--- a/docs/src/testers/anything-api/consume_sse.py
+++ b/docs/src/testers/anything-api/consume_sse.py
@@ -14,6 +14,7 @@ response = requests.post(
     },
     json={"query": "fetch the top 3 hacker news posts"},
     stream=True,
+    timeout=(10, 300),
 )
 response.raise_for_status()
 

--- a/docs/src/testers/anything-api/consume_sse.py
+++ b/docs/src/testers/anything-api/consume_sse.py
@@ -1,0 +1,24 @@
+# @sniptest filename=consume_sse.py
+# @sniptest typecheck_only=true
+import os
+
+import requests
+
+NOTTE_API_KEY = os.environ["NOTTE_API_KEY"]
+
+response = requests.post(
+    "https://anything.notte.cc/api/anything/start",
+    headers={
+        "Authorization": f"Bearer {NOTTE_API_KEY}",
+        "Content-Type": "application/json",
+    },
+    json={"query": "fetch the top 3 hacker news posts"},
+    stream=True,
+)
+response.raise_for_status()
+
+for line in response.iter_lines():
+    if line:
+        decoded = line.decode("utf-8")
+        if decoded.startswith("data: "):
+            print(decoded[6:])

--- a/docs/src/testers/anything-api/run_function.py
+++ b/docs/src/testers/anything-api/run_function.py
@@ -1,0 +1,10 @@
+# @sniptest filename=run_function.py
+# @sniptest typecheck_only=true
+from notte_sdk import NotteClient
+
+client = NotteClient()
+result = client.functions.run(
+    function_id="d3c31289-f28b-49bd-a340-95e071cfef7e",
+    variables={"count": "3"},
+)
+print(result)


### PR DESCRIPTION
## Summary
- Adds a new docs page for the Anything API under Products
- Documents the `/api/anything/start` SSE endpoint: request format, all event types, terminal events
- Includes code examples for consuming the stream in Python and TypeScript
- Shows how to re-run created functions via CLI and SDK
- Adds link to https://anything.notte.cc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Anything API docs and updated site navigation to include the new page.
  * Documents single-call SSE workflow, event types, terminal events, auth, HTTP error handling, and billing (done.total_cost_usd).
  * Includes curl, TypeScript, and Python quick-starts, plus runnable snippets and tester scripts demonstrating streaming consumption and re-running functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Anything API documentation page under Products, covering the `/api/anything/start` SSE endpoint with event types, error handling, pricing, and code examples in curl, Python, and TypeScript. All issues flagged in the previous review round (inline Python blocks, missing `raise_for_status`, and TypeScript chunk-boundary splits) have been fully addressed — Python examples now use imported snippets, the SSE snippet calls `raise_for_status()`, and the TypeScript reader uses proper buffer accumulation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no logic regressions and all prior review concerns resolved.

No P0 or P1 findings remain. All three previously flagged issues have been corrected in this revision, and the new code follows the project's sniptest conventions correctly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/src/docs.json | Adds `product/anything-api` to the navigation sidebar — clean, no issues. |
| docs/src/product/anything-api.mdx | New docs page for the Anything API; Python examples correctly use imported snippets, TypeScript SSE reader uses proper buffer accumulation, HTTP error check present in snippet — all previously flagged issues addressed. |
| docs/src/snippets/anything-api/consume_sse.mdx | Auto-generated snippet from tester; includes `raise_for_status()` and streaming with correct SSE line parsing. |
| docs/src/snippets/anything-api/run_function.mdx | Auto-generated snippet for re-running a Notte Function via SDK — clean. |
| docs/src/testers/anything-api/consume_sse.py | Source tester with `@sniptest typecheck_only=true`; correctly calls `raise_for_status()` before streaming. |
| docs/src/testers/anything-api/run_function.py | Source tester for SDK function re-run with `typecheck_only=true`; example function ID is clearly illustrative. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: add timeout to Python SSE example"](https://github.com/nottelabs/notte/commit/dcecfaa38f4bb001e389d43c20f85abbbeeea98e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28199184)</sub>

<!-- /greptile_comment -->