### PR TITLE
remove old viewer mention

### DIFF
--- a/docs/src/snippets/agents/replay/share_with_team.mdx
+++ b/docs/src/snippets/agents/replay/share_with_team.mdx
@@ -11,5 +11,5 @@ replay.download(f"feature_test_{agent.agent_id}.mp4")
 
 # Share file with team
 # Or share console link
-print(f"Console replay: https://console.notte.cc/agents/{agent.agent_id}")
+print(f"Console replay: https://console.notte.cc/sessions/{session.session_id}")
 ```

--- a/docs/src/snippets/agents/replay/view_in_browser.mdx
+++ b/docs/src/snippets/agents/replay/view_in_browser.mdx
@@ -5,5 +5,5 @@
 result = agent.run(task="Complete task")
 
 # Get replay URL
-print(f"View replay: https://console.notte.cc/agents/{result.agent_id}/replay")
+print(f"View replay: https://console.notte.cc/sessions/{session.session_id}")
 ```

--- a/docs/src/testers/agents/replay/share_with_team.py
+++ b/docs/src/testers/agents/replay/share_with_team.py
@@ -12,4 +12,4 @@ replay.download(f"feature_test_{agent.agent_id}.mp4")
 
 # Share file with team
 # Or share console link
-print(f"Console replay: https://console.notte.cc/agents/{agent.agent_id}")
+print(f"Console replay: https://console.notte.cc/sessions/{session.session_id}")

--- a/docs/src/testers/agents/replay/view_in_browser.py
+++ b/docs/src/testers/agents/replay/view_in_browser.py
@@ -8,4 +8,4 @@ with client.Session() as session:
     result = agent.run(task="Complete task")
 
     # Get replay URL
-    print(f"View replay: https://console.notte.cc/agents/{result.agent_id}/replay")
+    print(f"View replay: https://console.notte.cc/sessions/{session.session_id}")

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -3,7 +3,6 @@ from collections.abc import Sequence
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Unpack, overload
-from urllib.parse import urljoin
 from webbrowser import open as open_browser
 
 from notte_core.actions import BaseAction, InteractionActionUnion
@@ -88,7 +87,9 @@ _GENERIC_UNEXPECTED_MESSAGES: frozenset[str] = frozenset(
 
 # Retry configuration constants
 CLUSTER_OVERLOAD_RETRY_DELAY = 30  # seconds to wait before retrying on 529 errors
-
+CONSOLE_VIEWER_URL = (
+    "https://console.notte.cc/static/viewer?ws=wss://api.notte.cc/sessions/{session_id}/debug/recording?token={token}"
+)
 _playwright_available = False
 _async_playwright_available = False
 
@@ -519,14 +520,14 @@ class SessionsClient(BaseClient):
                 time.sleep(poll_interval)
 
     @track_usage("cloud.session.viewer.browser")
-    def viewer_browser(self, session_id: str, _viewer_url: str | None = None) -> None:
+    def viewer_browser(self, session_id: str, _viewer_url: str | None) -> None:
         """
         Opens live session replay in browser (frame by frame)
         """
         if _viewer_url is None:
-            debug_info = self.debug_info(session_id=session_id)
-            base_url = urljoin(self.server_url + "/", f"{self.base_endpoint_path}/{self.SESSION_VIEWER}/")
-            _viewer_url = urljoin(base_url, f"index.html?ws={debug_info.ws.recording}")
+            _viewer_url = self.status(session_id=session_id).viewer_url
+            if _viewer_url is None:
+                raise ValueError("Viewer URL is not available. Session might be stopped.")
         _ = open_browser(_viewer_url, new=1)
 
     @track_usage("cloud.session.viewer.notebook")
@@ -557,13 +558,13 @@ class SessionsClient(BaseClient):
         _ = open_browser(debug_info.debug_url)
 
     @track_usage("cloud.session.viewer")
-    def viewer(self, session_id: str) -> None:
+    def viewer(self, session_id: str, _viewer_url: str | None = None) -> None:
         """
         Open the viewer for the session based on the viewer_type.
         """
         match self.viewer_type:
             case SessionViewerType.BROWSER:
-                self.viewer_browser(session_id=session_id)
+                self.viewer_browser(session_id=session_id, _viewer_url=_viewer_url)
             case SessionViewerType.JUPYTER:
                 _ = self.viewer_notebook(session_id=session_id)
             case SessionViewerType.CDP:

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -16,6 +16,7 @@ from notte_core.utils.encryption import Encryption
 from typing_extensions import deprecated
 
 from notte_sdk.endpoints.base import BaseClient, NotteEndpoint
+from notte_sdk.endpoints.sessions import CONSOLE_VIEWER_URL
 from notte_sdk.types import (
     CreateFunctionRequest,
     CreateFunctionRequestDict,
@@ -521,9 +522,8 @@ class WorkflowsClient(BaseClient):
                             result = log_msg
                         elif message["type"] == "session_start":
                             session_id = log_msg
-
                             logger.info(
-                                f"Live viewer for session available at: https://api.notte.cc/sessions/viewer/index.html?ws=wss://api.notte.cc/sessions/{session_id}/debug/recording?token={self.token}"
+                                f"Live viewer for session available at: {CONSOLE_VIEWER_URL.format(session_id=session_id, token=self.token)}"
                             )
 
                 except json.JSONDecodeError:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated replay examples (Python and MDX) to use session-based console and browser URLs instead of agent-based links.
* **Bug Fixes / Behavior**
  * Standardized how replay/viewer URLs are resolved and used when starting sessions, improving consistency and error handling for opening replays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates URL references throughout the SDK and docs from the old `/agents/{agent_id}` viewer pattern to the new `/sessions/{session_id}` console paths. The `SessionsClient.viewer_browser` logic is also simplified to fetch `viewer_url` directly from `status()` instead of constructing it via `debug_info` + `urljoin`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are minor style/organisation suggestions with no runtime impact.

The logic change in `viewer_browser` is correct: `RemoteSession` always supplies `_viewer_url`, `viewer()` passes it through, and the fallback to `status().viewer_url` is guarded. Both P2 comments are non-blocking.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/notte-sdk/src/notte_sdk/endpoints/sessions.py | Replaces the old debug-info-based viewer URL construction with `status().viewer_url`; extracts `CONSOLE_VIEWER_URL` constant; removes `urljoin`; removes the default value for `_viewer_url` in `viewer_browser`, making it a required positional argument. |
| packages/notte-sdk/src/notte_sdk/endpoints/workflows.py | Imports `CONSOLE_VIEWER_URL` from sessions and uses it in the live-viewer log message, replacing the hardcoded old URL. |
| docs/src/snippets/agents/replay/view_in_browser.mdx | Auto-generated snippet updated to use `session.session_id`; the `with`-block context that defines `session` is no longer visible in the shown line range, making `session` appear undefined to readers. |
| docs/src/snippets/agents/replay/share_with_team.mdx | Updated console replay URL from `/agents/{agent_id}` to `/sessions/{session_id}`; full `with`-block context is visible so the variable is unambiguous. |
| docs/src/testers/agents/replay/view_in_browser.py | Python tester updated to use `session.session_id`; `session` is correctly in scope from the enclosing `with client.Session() as session:` block. |
| docs/src/testers/agents/replay/share_with_team.py | Python tester updated to use `session.session_id` in the console URL; straightforward and correct. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Fsrc%2Fsnippets%2Fagents%2Freplay%2Fview_in_browser.mdx%3A8%0A**%60session%60%20not%20visible%20in%20shown%20snippet%20range**%0A%0AThe%20rendered%20snippet%20%28driven%20by%20%60%40sniptest%20show%3D6-9%60%20in%20the%20tester%29%20begins%20inside%20the%20%60with%60%20block%20but%20omits%20the%20%60with%20client.Session%28%29%20as%20session%3A%60%20line%2C%20so%20%60session%60%20appears%20undeclared%20to%20readers.%20The%20previous%20approach%20used%20%60result.agent_id%60%2C%20where%20%60result%60%20was%20defined%20on%20the%20first%20visible%20line.%20Consider%20widening%20the%20%60show%60%20range%20to%20include%20the%20%60with%60%20line%2C%20or%20re-centering%20the%20example%20on%20a%20%60result%60-derived%20attribute%20so%20the%20variable%20origin%20is%20self-evident%20in%20the%20snippet.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fnotte-sdk%2Fsrc%2Fnotte_sdk%2Fendpoints%2Fsessions.py%3A87-91%0A**%60CONSOLE_VIEWER_URL%60%20defined%20but%20not%20used%20in%20this%20module**%0A%0AThe%20constant%20is%20imported%20and%20used%20exclusively%20in%20%60workflows.py%60.%20Defining%20it%20here%20couples%20%60sessions.py%60%20to%20a%20URL%20it%20never%20uses.%20A%20shared%20%60constants.py%60%20%28or%20moving%20it%20to%20%60workflows.py%60%29%20would%20be%20cleaner%2C%20though%20this%20is%20a%20minor%20organisation%20concern.%0A%0A&repo=nottelabs%2Fnotte"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/src/snippets/agents/replay/view_in_browser.mdx
Line: 8

Comment:
**`session` not visible in shown snippet range**

The rendered snippet (driven by `@sniptest show=6-9` in the tester) begins inside the `with` block but omits the `with client.Session() as session:` line, so `session` appears undeclared to readers. The previous approach used `result.agent_id`, where `result` was defined on the first visible line. Consider widening the `show` range to include the `with` line, or re-centering the example on a `result`-derived attribute so the variable origin is self-evident in the snippet.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
Line: 87-91

Comment:
**`CONSOLE_VIEWER_URL` defined but not used in this module**

The constant is imported and used exclusively in `workflows.py`. Defining it here couples `sessions.py` to a URL it never uses. A shared `constants.py` (or moving it to `workflows.py`) would be cleaner, though this is a minor organisation concern.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["remove old viewer mention"](https://github.com/nottelabs/notte/commit/4cc7c517900896ed9b3a3a6c2c03726407b5a427) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28276713)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->