### PR TITLE
docs: add Anything API product page

### DIFF
--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -323,7 +323,8 @@
                 "pages": [
                   "product/agent-mode",
                   "product/demonstrate-mode",
-                  "product/studio"
+                  "product/studio",
+                  "product/anything-api"
                 ]
               }
             ]

--- a/docs/src/product/anything-api.mdx
+++ b/docs/src/product/anything-api.mdx
@@ -1,0 +1,183 @@
+---
+title: Anything API
+description: Build and run web automations from a single API call
+---
+
+The Anything API lets you describe a task in plain English, and Notte will build, deploy, and run a web automation function for you -- all through a single HTTP request. The response is an SSE stream so you can follow the agent's progress in real time.
+
+<CardGroup cols={2}>
+  <Card title="Try it now" icon="arrow-up-right-from-square" href="https://anything.notte.cc">
+    Open the Anything API web app.
+  </Card>
+  <Card title="Get your API key" icon="key" href="https://console.notte.cc">
+    Create an account on the Console to get started.
+  </Card>
+</CardGroup>
+
+## Quick start
+
+```bash
+curl -N -X POST https://anything.notte.cc/api/anything/start \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NOTTE_API_KEY" \
+  -d '{"query": "fetch the top 3 hacker news posts"}'
+```
+
+The API streams back SSE events as the agent works. When it's done, the final `done` event contains the `function_id` of the created function, which you can re-run later via the [Notte CLI](/cli) or [SDK](/quickstart).
+
+## Request
+
+<ParamField path="query" type="string" required>
+  A natural-language description of the task you want automated.
+</ParamField>
+
+```json POST /api/anything/start
+{
+  "query": "fetch the top 3 hacker news posts"
+}
+```
+
+**Headers**
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Authorization` | Yes | `Bearer <NOTTE_API_KEY>` |
+| `Content-Type` | Yes | `application/json` |
+
+## Response
+
+The response is a `text/event-stream`. Each line follows the [SSE spec](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events):
+
+```
+data: {"type":"<event_type>", ...}
+```
+
+### Event types
+
+| Type | Description | Key fields |
+|------|-------------|------------|
+| `status` | Agent lifecycle updates | `status` |
+| `thinking_delta` | Agent reasoning (streamed) | `delta` |
+| `text_delta` | Agent response text (streamed) | `delta` |
+| `tool_start` | Agent started using a tool | `name` |
+| `tool_result` | Tool execution result | `content` |
+| `message_complete` | An assistant message was persisted | `role` |
+| `notte_session_data` | Browser session info | `viewer_url` |
+| `function_uploaded` | A Notte Function was created | `function_id`, `function_name`, `created_at` |
+| `done` | Agent finished | `total_cost_usd`, `function_id`, `metadata` |
+| `error` | Something went wrong | `error`, `detail` |
+| `timeout` | Agent timed out | `reason`, `detail` |
+| `cancelled` | Agent was cancelled | `reason` |
+
+### Terminal events
+
+The stream ends after one of these events: `done`, `error`, `timeout`, or `cancelled`.
+
+### Example: done event
+
+```json
+{
+  "type": "done",
+  "metadata": {
+    "thread_id": "820a7cff-613b-4529-9ba4-52c7a6777713"
+  },
+  "total_cost_usd": 0.43,
+  "function_id": "d3c31289-f28b-49bd-a340-95e071cfef7e"
+}
+```
+
+## Re-running the created function
+
+Once the agent finishes, it typically creates a reusable **Notte Function**. Use the `function_id` from the `done` event to run it again:
+
+<CodeGroup>
+```bash CLI
+notte functions run \
+  --function-id d3c31289-f28b-49bd-a340-95e071cfef7e \
+  --vars '{"count": "3"}' \
+  -o json
+```
+
+```python Python SDK
+from notte import NotteClient
+
+client = NotteClient()
+result = client.functions.run(
+    function_id="d3c31289-f28b-49bd-a340-95e071cfef7e",
+    variables={"count": "3"},
+)
+print(result)
+```
+</CodeGroup>
+
+## Consuming the SSE stream
+
+### Python
+
+```python
+import requests
+
+response = requests.post(
+    "https://anything.notte.cc/api/anything/start",
+    headers={
+        "Authorization": f"Bearer {NOTTE_API_KEY}",
+        "Content-Type": "application/json",
+    },
+    json={"query": "fetch the top 3 hacker news posts"},
+    stream=True,
+)
+
+for line in response.iter_lines():
+    if line:
+        decoded = line.decode("utf-8")
+        if decoded.startswith("data: "):
+            print(decoded[6:])
+```
+
+### TypeScript
+
+```typescript
+const response = await fetch("https://anything.notte.cc/api/anything/start", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${NOTTE_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({ query: "fetch the top 3 hacker news posts" }),
+});
+
+const reader = response.body!.getReader();
+const decoder = new TextDecoder();
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+
+  const text = decoder.decode(value, { stream: true });
+  for (const line of text.split("\n")) {
+    if (line.startsWith("data: ")) {
+      const event = JSON.parse(line.slice(6));
+      console.log(event.type, event);
+
+      if (event.type === "done") {
+        console.log("Function ID:", event.function_id);
+        console.log("Cost:", event.total_cost_usd);
+      }
+    }
+  }
+}
+```
+
+## Error handling
+
+| Status | Meaning |
+|--------|---------|
+| `401` | Missing or invalid API key |
+| `400` | Missing `query` field or invalid JSON |
+| `502` | Agent failed to start or SSE stream unavailable |
+
+If the stream connects successfully but the agent encounters an error, you will receive an `error` event in the SSE stream instead of an HTTP error status.
+
+## Pricing
+
+Each request is billed based on the LLM usage incurred by the agent. The `total_cost_usd` field in the `done` event reports the exact cost for that run.

--- a/docs/src/product/anything-api.mdx
+++ b/docs/src/product/anything-api.mdx
@@ -3,6 +3,9 @@ title: Anything API
 description: Build and run web automations from a single API call
 ---
 
+import RunFunction from '/snippets/anything-api/run_function.mdx';
+import ConsumeSSE from '/snippets/anything-api/consume_sse.mdx';
+
 The Anything API lets you describe a task in plain English, and Notte will build, deploy, and run a web automation function for you -- all through a single HTTP request. The response is an SSE stream so you can follow the agent's progress in real time.
 
 <CardGroup cols={2}>
@@ -98,41 +101,14 @@ notte functions run \
   -o json
 ```
 
-```python Python SDK
-from notte import NotteClient
-
-client = NotteClient()
-result = client.functions.run(
-    function_id="d3c31289-f28b-49bd-a340-95e071cfef7e",
-    variables={"count": "3"},
-)
-print(result)
-```
+<RunFunction />
 </CodeGroup>
 
 ## Consuming the SSE stream
 
 ### Python
 
-```python
-import requests
-
-response = requests.post(
-    "https://anything.notte.cc/api/anything/start",
-    headers={
-        "Authorization": f"Bearer {NOTTE_API_KEY}",
-        "Content-Type": "application/json",
-    },
-    json={"query": "fetch the top 3 hacker news posts"},
-    stream=True,
-)
-
-for line in response.iter_lines():
-    if line:
-        decoded = line.decode("utf-8")
-        if decoded.startswith("data: "):
-            print(decoded[6:])
-```
+<ConsumeSSE />
 
 ### TypeScript
 
@@ -146,15 +122,27 @@ const response = await fetch("https://anything.notte.cc/api/anything/start", {
   body: JSON.stringify({ query: "fetch the top 3 hacker news posts" }),
 });
 
-const reader = response.body!.getReader();
+if (!response.ok) {
+  throw new Error(`HTTP ${response.status}`);
+}
+if (!response.body) {
+  throw new Error("ReadableStream not available");
+}
+
+const reader = response.body.getReader();
 const decoder = new TextDecoder();
+const terminal = new Set(["done", "error", "timeout", "cancelled"]);
+let buffer = "";
 
 while (true) {
   const { done, value } = await reader.read();
   if (done) break;
 
-  const text = decoder.decode(value, { stream: true });
-  for (const line of text.split("\n")) {
+  buffer += decoder.decode(value, { stream: true });
+  const lines = buffer.split("\n");
+  buffer = lines.pop()!;
+
+  for (const line of lines) {
     if (line.startsWith("data: ")) {
       const event = JSON.parse(line.slice(6));
       console.log(event.type, event);
@@ -162,6 +150,11 @@ while (true) {
       if (event.type === "done") {
         console.log("Function ID:", event.function_id);
         console.log("Cost:", event.total_cost_usd);
+      }
+
+      if (terminal.has(event.type)) {
+        reader.cancel();
+        break;
       }
     }
   }

--- a/docs/src/product/anything-api.mdx
+++ b/docs/src/product/anything-api.mdx
@@ -26,7 +26,7 @@ curl -N -X POST https://anything.notte.cc/api/anything/start \
   -d '{"query": "fetch the top 3 hacker news posts"}'
 ```
 
-The API streams back SSE events as the agent works. When it's done, the final `done` event contains the `function_id` of the created function, which you can re-run later via the [Notte CLI](/cli) or [SDK](/quickstart).
+The API streams back SSE events as the agent works. When it's done, the final `done` event contains the `function_id` of the created function, which you can re-run later via the [Notte CLI](https://github.com/nottelabs/notte-cli) or [SDK](/quickstart).
 
 ## Request
 

--- a/docs/src/snippets/anything-api/consume_sse.mdx
+++ b/docs/src/snippets/anything-api/consume_sse.mdx
@@ -24,5 +24,11 @@ for line in response.iter_lines():
     if line:
         decoded = line.decode("utf-8")
         if decoded.startswith("data: "):
-            print(decoded[6:])
+            import json
+
+            event = json.loads(decoded[6:])
+            print(event["type"], event)
+            if event["type"] == "done":
+                print("Function ID:", event.get("function_id"))
+                print("Cost:", event.get("total_cost_usd"))
 ```

--- a/docs/src/snippets/anything-api/consume_sse.mdx
+++ b/docs/src/snippets/anything-api/consume_sse.mdx
@@ -1,0 +1,27 @@
+{/* Auto-generated mdx file. Do not edit! */}
+{/* @sniptest testers/anything-api/consume_sse.py */}
+
+```python consume_sse.py
+import os
+
+import requests
+
+NOTTE_API_KEY = os.environ["NOTTE_API_KEY"]
+
+response = requests.post(
+    "https://anything.notte.cc/api/anything/start",
+    headers={
+        "Authorization": f"Bearer {NOTTE_API_KEY}",
+        "Content-Type": "application/json",
+    },
+    json={"query": "fetch the top 3 hacker news posts"},
+    stream=True,
+)
+response.raise_for_status()
+
+for line in response.iter_lines():
+    if line:
+        decoded = line.decode("utf-8")
+        if decoded.startswith("data: "):
+            print(decoded[6:])
+```

--- a/docs/src/snippets/anything-api/consume_sse.mdx
+++ b/docs/src/snippets/anything-api/consume_sse.mdx
@@ -16,6 +16,7 @@ response = requests.post(
     },
     json={"query": "fetch the top 3 hacker news posts"},
     stream=True,
+    timeout=(10, 300),
 )
 response.raise_for_status()
 

--- a/docs/src/snippets/anything-api/run_function.mdx
+++ b/docs/src/snippets/anything-api/run_function.mdx
@@ -1,0 +1,13 @@
+{/* Auto-generated mdx file. Do not edit! */}
+{/* @sniptest testers/anything-api/run_function.py */}
+
+```python run_function.py
+from notte_sdk import NotteClient
+
+client = NotteClient()
+result = client.functions.run(
+    function_id="d3c31289-f28b-49bd-a340-95e071cfef7e",
+    variables={"count": "3"},
+)
+print(result)
+```

--- a/docs/src/testers/anything-api/consume_sse.py
+++ b/docs/src/testers/anything-api/consume_sse.py
@@ -22,4 +22,10 @@ for line in response.iter_lines():
     if line:
         decoded = line.decode("utf-8")
         if decoded.startswith("data: "):
-            print(decoded[6:])
+            import json
+
+            event = json.loads(decoded[6:])
+            print(event["type"], event)
+            if event["type"] == "done":
+                print("Function ID:", event.get("function_id"))
+                print("Cost:", event.get("total_cost_usd"))

--- a/docs/src/testers/anything-api/consume_sse.py
+++ b/docs/src/testers/anything-api/consume_sse.py
@@ -14,6 +14,7 @@ response = requests.post(
     },
     json={"query": "fetch the top 3 hacker news posts"},
     stream=True,
+    timeout=(10, 300),
 )
 response.raise_for_status()
 

--- a/docs/src/testers/anything-api/consume_sse.py
+++ b/docs/src/testers/anything-api/consume_sse.py
@@ -1,0 +1,24 @@
+# @sniptest filename=consume_sse.py
+# @sniptest typecheck_only=true
+import os
+
+import requests
+
+NOTTE_API_KEY = os.environ["NOTTE_API_KEY"]
+
+response = requests.post(
+    "https://anything.notte.cc/api/anything/start",
+    headers={
+        "Authorization": f"Bearer {NOTTE_API_KEY}",
+        "Content-Type": "application/json",
+    },
+    json={"query": "fetch the top 3 hacker news posts"},
+    stream=True,
+)
+response.raise_for_status()
+
+for line in response.iter_lines():
+    if line:
+        decoded = line.decode("utf-8")
+        if decoded.startswith("data: "):
+            print(decoded[6:])

--- a/docs/src/testers/anything-api/run_function.py
+++ b/docs/src/testers/anything-api/run_function.py
@@ -1,0 +1,10 @@
+# @sniptest filename=run_function.py
+# @sniptest typecheck_only=true
+from notte_sdk import NotteClient
+
+client = NotteClient()
+result = client.functions.run(
+    function_id="d3c31289-f28b-49bd-a340-95e071cfef7e",
+    variables={"count": "3"},
+)
+print(result)


### PR DESCRIPTION
## Summary
- Adds a new product documentation page for the Anything API (`docs/src/product/anything-api.mdx`)
- Documents the API request/response format, SSE event types, error handling, and pricing
- Includes Python and TypeScript code snippets for consuming the SSE stream and re-running created functions
- Adds corresponding snippet MDX files and tester scripts

## Test plan
- [ ] Verify the docs page renders correctly on the docs site
- [ ] Confirm all code snippets are syntactically correct
- [ ] Check that navigation entry in `docs.json` links properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Anything API docs and a new Products navigation entry
  * Includes quick-start, API request spec, SSE streaming format, event types, error meanings, re-run guidance, and pricing notes
  * Provides Python and TypeScript consumption examples and embedded runnable snippets

* **Tests**
  * Added snippet test scripts demonstrating streaming consumption and function run examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `Anything API` product documentation page covering the request/response format, SSE event types, error handling, pricing, and code snippets in Python and TypeScript. The navigation entry, MDX structure, and tester scripts are all consistent and correct.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only PR with no backend changes and no blocking issues.

All findings are P2 style suggestions. The only notable gap is that the Python snippet doesn't show JSON parsing or `function_id` extraction the way the TypeScript example does, but this doesn't block correctness or functionality.

docs/src/snippets/anything-api/consume_sse.mdx could be improved to match the completeness of the TypeScript example.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/src/docs.json | Adds `product/anything-api` navigation entry to the existing product pages list — straightforward change. |
| docs/src/product/anything-api.mdx | New product documentation page covering request/response format, SSE event types, error handling, pricing, and code examples. Well-structured and accurate to the described API. |
| docs/src/snippets/anything-api/consume_sse.mdx | Auto-generated Python snippet for consuming the SSE stream; prints raw JSON strings without parsing events, so users can't see how to extract `function_id` — unlike the TypeScript example in the main doc. |
| docs/src/snippets/anything-api/run_function.mdx | Auto-generated Python snippet for re-running a created function via `NotteClient`; correct and concise. |
| docs/src/testers/anything-api/consume_sse.py | Tester script (typecheck only) for SSE consumption; correctly decodes bytes from `iter_lines()` and filters `data:` prefixed lines. |
| docs/src/testers/anything-api/run_function.py | Tester script (typecheck only) for running a function via the SDK; minimal and correct. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsrc%2Fsnippets%2Fanything-api%2Fconsume_sse.mdx%3A22-27%0A**Python%20snippet%20missing%20JSON%20parsing%20and%20%60function_id%60%20extraction**%0A%0AThe%20Python%20example%20prints%20the%20raw%20JSON%20string%20but%20never%20parses%20it%2C%20so%20users%20can't%20see%20how%20to%20extract%20the%20%60function_id%60%20highlighted%20in%20the%20surrounding%20documentation.%20The%20TypeScript%20example%20in%20the%20same%20page%20already%20demonstrates%20this%20pattern%20%E2%80%94%20consider%20bringing%20the%20Python%20snippet%20to%20the%20same%20level%3A%0A%0A%60%60%60suggestion%0Afor%20line%20in%20response.iter_lines%28%29%3A%0A%20%20%20%20if%20line%3A%0A%20%20%20%20%20%20%20%20decoded%20%3D%20line.decode%28%22utf-8%22%29%0A%20%20%20%20%20%20%20%20if%20decoded.startswith%28%22data%3A%20%22%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20import%20json%0A%20%20%20%20%20%20%20%20%20%20%20%20event%20%3D%20json.loads%28decoded%5B6%3A%5D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20print%28event%5B%22type%22%5D%2C%20event%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20event%5B%22type%22%5D%20%3D%3D%20%22done%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20print%28%22Function%20ID%3A%22%2C%20event.get%28%22function_id%22%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20print%28%22Cost%3A%22%2C%20event.get%28%22total_cost_usd%22%29%29%0A%60%60%60%0A%0A&repo=nottelabs%2Fnotte"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/src/snippets/anything-api/consume_sse.mdx
Line: 22-27

Comment:
**Python snippet missing JSON parsing and `function_id` extraction**

The Python example prints the raw JSON string but never parses it, so users can't see how to extract the `function_id` highlighted in the surrounding documentation. The TypeScript example in the same page already demonstrates this pattern — consider bringing the Python snippet to the same level:

```suggestion
for line in response.iter_lines():
    if line:
        decoded = line.decode("utf-8")
        if decoded.startswith("data: "):
            import json
            event = json.loads(decoded[6:])
            print(event["type"], event)
            if event["type"] == "done":
                print("Function ID:", event.get("function_id"))
                print("Cost:", event.get("total_cost_usd"))
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add timeout to Python SSE example"](https://github.com/nottelabs/notte/commit/cd94fadc8474d14b222506be5adb187ea7e3e68d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28554807)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->