### PR TITLE
regenerate docs

### DIFF
--- a/docs/src/sdk-reference/manual/session.mdx
+++ b/docs/src/sdk-reference/manual/session.mdx
@@ -121,3 +121,6 @@ You can use the default parameters to create your session, or customize them:
 
 <ParamField path="extra_http_headers" type="dict[str, str] | None">
 </ParamField>
+
+<ParamField path="vault_id" type="str | None">
+</ParamField>

--- a/docs/src/sdk-reference/remotesession/__init__.mdx
+++ b/docs/src/sdk-reference/remotesession/__init__.mdx
@@ -94,6 +94,9 @@ RemoteSession instance configured with the specified parameters.
 <ParamField path="extra_http_headers" type="dict[str, str] | None">
 </ParamField>
 
+<ParamField path="vault_id" type="str | None">
+</ParamField>
+
 ## Returns
 
 `None`: A new RemoteSession instance configured with the specified parameters.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated RemoteSession SDK reference to document the newly available optional parameter `vault_id` (string or null).
  * Added the same `vault_id` parameter documentation to the Session manual pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR regenerates the `RemoteSession.__init__` SDK reference to expose the newly-added `vault_id` parameter. The change is a single three-line addition to the Mintlify MDX file, consistent with the auto-generated doc style used throughout the file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no logic impact.

The change is a minimal, auto-generated docs update that adds a single parameter entry. No logic, tests, or configuration are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/src/sdk-reference/remotesession/__init__.mdx | Adds `vault_id: str | None` ParamField to the RemoteSession `__init__` docs — consistent with the existing parameter style and appears auto-generated. |

</details>

<sub>Reviews (1): Last reviewed commit: ["regenerate docs"](https://github.com/nottelabs/notte/commit/dc3567df601202a4b968143c0ab6d1812b154fb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28557996)</sub>

<!-- /greptile_comment -->