### PR TITLE
Add Mintlify docs deployment to release workflow and fix missing vault_id param

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -85,3 +85,28 @@ jobs:
           uv pip show notte-sdk
           uv pip show notte-browser
           uv pip show notte-agent
+
+  deploy-docs:
+    needs: build
+    name: Trigger Mintlify docs deployment
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Trigger Mintlify deployment
+        run: |
+          response=$(curl -s -w "\n%{http_code}" -X POST \
+            "https://api.mintlify.com/v1/project/update/67325cb675ec6a1a358ff41d" \
+            -H "Authorization: Bearer ${{ secrets.MINTLIFY_API_KEY }}")
+
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          echo "Response: $body"
+          echo "HTTP Status: $http_code"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::Mintlify deployment trigger failed with status $http_code"
+            exit 1
+          fi
+
+          echo "Mintlify docs deployment queued successfully"

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -88,6 +88,7 @@ jobs:
 
   deploy-docs:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     name: Trigger Mintlify docs deployment
     runs-on: blacksmith-4vcpu-ubuntu-2404
 


### PR DESCRIPTION
## Summary

- Add a `deploy-docs` job to the PyPI release workflow that triggers Mintlify docs deployment after a successful build
- Add missing `vault_id` parameter to `session.mdx` and `remotesession/__init__.mdx` SDK reference docs
- Regenerate docs to reflect the updated SDK reference

## Testing

- Verify the `deploy-docs` job runs after `build` completes successfully in the release workflow
- Confirm the Mintlify API call correctly handles success and failure HTTP status codes
- Check that `vault_id` parameter appears in the rendered SDK reference for both `Session` and `RemoteSession`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated documentation deployment added to the release pipeline for versioned releases.
  * Deployment now reports detailed success/failure status and fails the release step when docs deployment returns an error, improving visibility and reliability of published docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `deploy-docs` job to the PyPI release workflow that POST-triggers Mintlify after a successful build, and adds the missing `vault_id` `ParamField` to both `session.mdx` and `remotesession/__init__.mdx`. The HTTP status-checking logic and secret handling in the workflow are correct, and the doc changes are consistent with the existing style.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the workflow addition is correct and the doc updates are straightforward.

All findings are P2 style suggestions; no logic errors, security issues, or broken behavior were identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/pypi-release.yml | Adds a `deploy-docs` job that calls the Mintlify API after a successful build; HTTP status checking and secret handling look correct. |
| docs/src/sdk-reference/manual/session.mdx | Adds `vault_id` ParamField entry, consistent with existing empty-description style. |
| docs/src/sdk-reference/remotesession/__init__.mdx | Adds `vault_id` ParamField entry, consistent with existing empty-description style. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpypi-release.yml%3A89-92%0A**Missing%20%60if%60%20guard%20mirroring%20the%20%60build%60%20job**%0A%0AThe%20%60build%60%20job%20has%20%60if%3A%20startsWith%28github.ref%2C%20'refs%2Ftags%2Fv'%29%60%2C%20but%20%60deploy-docs%60%20has%20no%20such%20condition.%20In%20practice%20the%20workflow%20trigger%20%28%60push%3A%20tags%3A%20%22v*%22%60%29%20makes%20the%20%60build%60%20condition%20always%20true%2C%20but%20adding%20the%20same%20guard%20makes%20the%20intent%20explicit%20and%20prevents%20accidental%20doc%20deployments%20if%20the%20trigger%20ever%20broadens.%0A%0A%60%60%60suggestion%0A%20%20deploy-docs%3A%0A%20%20%20%20needs%3A%20build%0A%20%20%20%20if%3A%20startsWith%28github.ref%2C%20'refs%2Ftags%2Fv'%29%0A%20%20%20%20name%3A%20Trigger%20Mintlify%20docs%20deployment%0A%20%20%20%20runs-on%3A%20blacksmith-4vcpu-ubuntu-2404%0A%60%60%60%0A%0A&repo=nottelabs%2Fnotte"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/pypi-release.yml
Line: 89-92

Comment:
**Missing `if` guard mirroring the `build` job**

The `build` job has `if: startsWith(github.ref, 'refs/tags/v')`, but `deploy-docs` has no such condition. In practice the workflow trigger (`push: tags: "v*"`) makes the `build` condition always true, but adding the same guard makes the intent explicit and prevents accidental doc deployments if the trigger ever broadens.

```suggestion
  deploy-docs:
    needs: build
    if: startsWith(github.ref, 'refs/tags/v')
    name: Trigger Mintlify docs deployment
    runs-on: blacksmith-4vcpu-ubuntu-2404
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Mintlify docs deployment step to rel..."](https://github.com/nottelabs/notte/commit/ec7213839a9d0de78623360001740b4da379754a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28560306)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->