### PR TITLE
Replace local sphinx_mintlify with PyPI package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,12 @@ repos:
         types: [python, text]
         files: ^(examples/|docs/src/|packages/notte-sdk/src/).*\.(py|mdx)$
         pass_filenames: false
+      - id: docs-sdk-generate
+        name: Regenerate SDK reference docs
+        entry: bash -c "make docs-sdk"
+        language: system
+        files: ^(packages/notte-sdk/src/|docs/sphinx/conf\.py)
+        pass_filenames: false
       - id: no-loguru-logger-import
         name: Check for loguru logger imports
         entry: 'from loguru import logger'

--- a/docs/src/sdk-reference/manual/session.mdx
+++ b/docs/src/sdk-reference/manual/session.mdx
@@ -47,7 +47,7 @@ You can use the default parameters to create your session, or customize them:
   File Storage to attach to the session
 </ParamField>
 
-<ParamField path="perception_type" type="Literal[fast, deep]" default="fast">
+<ParamField path="perception_type" type="Literal['fast', 'deep']" default="fast">
 </ParamField>
 
 <ParamField path="cookie_file" type="UnionType[str, Path, None]" default="None">

--- a/docs/src/sdk-reference/misc/captchasolveaction.mdx
+++ b/docs/src/sdk-reference/misc/captchasolveaction.mdx
@@ -22,7 +22,7 @@ session.execute(type="captcha_solve")  # Auto-detect captcha type
 <ParamField path="description" type="str" default="Solve a CAPTCHA challenge on the current page. CRITICAL: Use this action as soon as you notice a captcha">
 </ParamField>
 
-<ParamField path="captcha_type" type="Optional[Literal['recaptcha', 'hcaptcha', 'image', 'text', 'auth0', 'cloudflare', 'datadome', 'arkose labs', 'geetest', 'press&hold', 'unknown']]">
+<ParamField path="captcha_type" type="Literal['recaptcha', 'hcaptcha', 'image', 'text', 'auth0', 'cloudflare', 'datadome', 'arkose labs', 'geetest', 'press&hold', 'unknown'] | None">
 </ParamField>
 
 

--- a/docs/src/sdk-reference/misc/formfillaction.mdx
+++ b/docs/src/sdk-reference/misc/formfillaction.mdx
@@ -21,7 +21,7 @@ session.execute(type="form_fill", value={"email": "user@example.com", "first_nam
 <ParamField path="description" type="str" default="Fill a form with multiple values. Important: If you detect a form requesting personal information, try to use this action at first, and otherwise use the regular fill action. CRITICAL: If this action fails once, use the regular form fill instead.">
 </ParamField>
 
-<ParamField path="value" type="Dict[Literal[title, first_name, middle_name, last_name, full_name, email, company, address1, address2, address3, city, state, postal_code, country, phone, cc_name, cc_number, cc_exp_month, cc_exp_year, cc_exp, cc_cvv, username, password, current_password, new_password, totp], UnionType[str, ValueWithPlaceholder]]" required>
+<ParamField path="value" type="Dict[Literal['title', 'first_name', 'middle_name', 'last_name', 'full_name', 'email', 'company', 'address1', 'address2', 'address3', 'city', 'state', 'postal_code', 'country', 'phone', 'cc_name', 'cc_number', 'cc_exp_month', 'cc_exp_year', 'cc_exp', 'cc_cvv', 'username', 'password', 'current_password', 'new_password', 'totp'], UnionType[str, ValueWithPlaceholder]]" required>
 </ParamField>
 
 

--- a/docs/src/sdk-reference/misc/rootmodel.mdx
+++ b/docs/src/sdk-reference/misc/rootmodel.mdx
@@ -1,0 +1,16 @@
+---
+title: "RootModel"
+description: ""
+---
+
+
+
+## Fields
+
+<ParamField path="root" type="Dict[str, Any] | list[Dict[str, Any]]" required>
+</ParamField>
+
+
+## Module
+
+`pydantic.root_model`

--- a/docs/src/sdk-reference/misc/structureddata.mdx
+++ b/docs/src/sdk-reference/misc/structureddata.mdx
@@ -15,7 +15,7 @@ description: ""
   Error message if the data was not extracted successfully
 </ParamField>
 
-<ParamField path="data" type="Union[pydantic.main.BaseModel, pydantic.root_model.RootModel[Union[dict[str, Any], list[dict[str, Any]]]], NoneType]">
+<ParamField path="data" type="BaseModel | RootModel[Union[dict[str, Any], list[dict[str, Any]]]] | None">
   Structured data extracted from the page in JSON format
 </ParamField>
 

--- a/docs/src/sdk-reference/misc/websocketservice.mdx
+++ b/docs/src/sdk-reference/misc/websocketservice.mdx
@@ -10,7 +10,7 @@ description: "WebSocket client for receiving session recording data in binary fo
 <ParamField path="wss_url" type="str" required>
 </ParamField>
 
-<ParamField path="process" type="Callable" required>
+<ParamField path="process" type="Callable[[bytes], Any]" required>
 </ParamField>
 
 

--- a/docs/src/sdk-reference/nottefunction/run.mdx
+++ b/docs/src/sdk-reference/nottefunction/run.mdx
@@ -41,7 +41,7 @@ function.run(variable1="value1", variable2="value2")
 <ParamField path="workflow_run_id" type="UnionType[str, None]" default="None">
 </ParamField>
 
-<ParamField path="log_callback" type="UnionType[Callable[[<class 'str'>], None], None]" default="None">
+<ParamField path="log_callback" type="UnionType[Callable[[str], None], None]" default="None">
 </ParamField>
 
 <ParamField path="variables" type="Any" required>

--- a/docs/src/sdk-reference/nottevault/patch_structured_completion.mdx
+++ b/docs/src/sdk-reference/nottevault/patch_structured_completion.mdx
@@ -11,5 +11,5 @@ description: "No description available"
 <ParamField path="arg_index" type="int" required>
 </ParamField>
 
-<ParamField path="replacement_map_fn" type="Callable[Ellipsis, Dict[str, str]]" required>
+<ParamField path="replacement_map_fn" type="Callable[..., Dict[str, str]]" required>
 </ParamField>

--- a/docs/src/sdk-reference/remotesession/__init__.mdx
+++ b/docs/src/sdk-reference/remotesession/__init__.mdx
@@ -19,7 +19,7 @@ RemoteSession instance configured with the specified parameters.
   File Storage to attach to the session
 </ParamField>
 
-<ParamField path="perception_type" type="Literal[fast, deep]" default="fast">
+<ParamField path="perception_type" type="Literal['fast', 'deep']" default="fast">
 </ParamField>
 
 <ParamField path="cookie_file" type="UnionType[str, Path, None]" default="None">

--- a/makefile
+++ b/makefile
@@ -107,7 +107,6 @@ profile-imports:
 
 .PHONY: docs-sdk
 docs-sdk:
-	@uv pip install -e ../sphinx_mintlify
 	cd docs && uv run sphinx-build -b mdx sphinx _build
 	rm -rf docs/src/sdk-reference/baseaction
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dev = [
     "pytest-timeout>=2.4.0",
     "pytest-xdist[psutil]>=3.8.0",
     "sphinx>=8.2.3",
+    "sphinx-mintlify>=0.1.0",
     "twine>=6.1.0",
 ]
 lint = [

--- a/uv.lock
+++ b/uv.lock
@@ -7804,16 +7804,16 @@ wheels = [
 
 [[package]]
 name = "sphinx-mintlify"
-version = "0.1.0"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "sphinx" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/8e/7f126175cf1352c8f8382bbb11a14fbe61ed35b735e2e99e9665f3ed9f30/sphinx_mintlify-0.1.0.tar.gz", hash = "sha256:ae18ee42407d0ab66d33a7ca7ea0fd7c10d5d0210d6124bf3efcd89ed20055a7", size = 19273, upload-time = "2026-04-15T22:42:13.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/a1/6eb6cfbd41e520f746c762bdc0373bf6b4853b4db4a2dd635c54daf32ae5/sphinx_mintlify-0.1.1.tar.gz", hash = "sha256:e04fd6bba69c198c2965992664f2808830070839afdfa539d885fbe73d1c20e0", size = 20295, upload-time = "2026-04-15T23:02:37.958Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/19/6d930cdab3c8f10b1f51a4d53bc837860c91fbc742a902fc2d222799348b/sphinx_mintlify-0.1.0-py3-none-any.whl", hash = "sha256:32655b1cfbd90fc257c15d7831ff7bd54805ece80f60cfa5646117afa84448fb", size = 20049, upload-time = "2026-04-15T22:42:11.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/30f62774e9f9bd2c63b97c5834173f612970a8a56389f605f3d6c15b85fb/sphinx_mintlify-0.1.1-py3-none-any.whl", hash = "sha256:618bc2ee32deb350169d6310d9b4dca6533de3dec438943368de4f9762a958cb", size = 21100, upload-time = "2026-04-15T23:02:36.781Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2861,6 +2861,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist", extra = ["psutil"] },
     { name = "sphinx" },
+    { name = "sphinx-mintlify" },
     { name = "twine" },
 ]
 lint = [
@@ -2904,6 +2905,7 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.8.0" },
     { name = "sphinx", specifier = ">=8.2.3" },
+    { name = "sphinx-mintlify", specifier = ">=0.1.0" },
     { name = "twine", specifier = ">=6.1.0" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.9.7" }]
@@ -7798,6 +7800,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741, upload-time = "2025-03-02T22:31:56.836Z" },
+]
+
+[[package]]
+name = "sphinx-mintlify"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "sphinx" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/8e/7f126175cf1352c8f8382bbb11a14fbe61ed35b735e2e99e9665f3ed9f30/sphinx_mintlify-0.1.0.tar.gz", hash = "sha256:ae18ee42407d0ab66d33a7ca7ea0fd7c10d5d0210d6124bf3efcd89ed20055a7", size = 19273, upload-time = "2026-04-15T22:42:13.176Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/19/6d930cdab3c8f10b1f51a4d53bc837860c91fbc742a902fc2d222799348b/sphinx_mintlify-0.1.0-py3-none-any.whl", hash = "sha256:32655b1cfbd90fc257c15d7831ff7bd54805ece80f60cfa5646117afa84448fb", size = 20049, upload-time = "2026-04-15T22:42:11.767Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Published `sphinx-mintlify` to PyPI and replaced the local editable install (`uv pip install -e ../sphinx_mintlify`) with a proper dev dependency
- Removed the local install step from the `docs-sdk` Makefile target
- Added `docs-sdk-generate` pre-commit hook that regenerates SDK reference docs when SDK source files or Sphinx config change, ensuring docs stay in sync

## Test plan
- [x] `sphinx-mintlify` published and installable from PyPI (`pip install sphinx-mintlify==0.1.0`)
- [x] `uv lock` resolves the package successfully
- [x] Pre-commit hooks pass
- [ ] Run `make docs-sdk` to verify SDK docs generate correctly without local package
- [ ] Modify an SDK docstring and verify the pre-commit hook catches the drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-commit hook to run automated SDK docs generation.
  * Simplified the docs build target and adjusted build cleanup.

* **Documentation**
  * Added a new RootModel reference page.
  * Standardized and clarified several SDK type annotations and callback signatures.
  * Added a dev dependency to support enhanced documentation formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates `sphinx-mintlify` from a local editable install (`uv pip install -e ../sphinx_mintlify`) to a proper PyPI package (`sphinx-mintlify==0.1.0`) pinned in dev dependencies, and adds a `docs-sdk-generate` pre-commit hook to keep SDK reference docs in sync with source changes. The dependency migration and lock file look correct. The only notable concern is that `check-sdk-docs` is ordered before `docs-sdk-generate` in `.pre-commit-config.yaml`, which can require two commit attempts when SDK source and docs are both out of sync.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/workflow suggestions with no correctness or data-integrity risk.

The dependency migration is straightforward and the lock file hashes are verified. Both comments are P2: hook ordering is a developer UX concern (not a broken workflow), and the missing smoke test is a best-practice note for a tooling-only change.

.pre-commit-config.yaml — hook ordering between check-sdk-docs and docs-sdk-generate is worth revisiting.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .pre-commit-config.yaml | Adds docs-sdk-generate hook that runs make docs-sdk on SDK source/conf changes; hook ordering places it after check-sdk-docs, which can cause a two-step commit cycle when docs are stale. |
| makefile | Removes the local editable install step (uv pip install -e ../sphinx_mintlify) from docs-sdk target; now relies on the PyPI package in dev dependencies. |
| pyproject.toml | Adds sphinx-mintlify>=0.1.0 as a dev dependency, replacing the previous local editable install. |
| uv.lock | Locks sphinx-mintlify 0.1.0 from PyPI with verified hashes; dependencies (docutils, sphinx, typing-extensions) look appropriate. |
| docs/src/sdk-reference/remotesession/__init__.mdx | Auto-generated file updated to add vault_id parameter field, consistent with surrounding ParamField patterns. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.pre-commit-config.yaml%3A73-78%0A**Hook%20ordering%20may%20produce%20confusing%20two-step%20commit%20cycle**%0A%0A%60check-sdk-docs%60%20%28line%2066%29%20runs%20before%20%60docs-sdk-generate%60%20%28line%2073%29.%20When%20SDK%20source%20files%20change%20and%20the%20generated%20docs%20are%20stale%2C%20%60check-sdk-docs%60%20can%20fail%20first%2C%20then%20%60docs-sdk-generate%60%20regenerates%20the%20docs%20and%20causes%20a%20file-modification%20failure%20%E2%80%94%20requiring%20the%20developer%20to%20restage%20and%20commit%20twice%20before%20both%20hooks%20pass.%0A%0ASwapping%20the%20two%20hooks%20%28generate%20first%2C%20then%20check%29%20would%20let%20regeneration%20happen%20before%20the%20check%20runs%2C%20reducing%20the%20typical%20workflow%20to%20a%20single%20extra%20commit%20instead%20of%20two.%0A%0A%23%23%23%20Issue%202%20of%202%0Apyproject.toml%3A73%0A**No%20tests%20added**%0A%0AThis%20PR%20introduces%20a%20new%20pre-commit%20hook%20that%20runs%20%60make%20docs-sdk%60%20automatically.%20There%20are%20no%20tests%20verifying%20that%20the%20hook%20triggers%20correctly%20or%20that%20%60make%20docs-sdk%60%20produces%20consistent%20output%20with%20the%20published%20PyPI%20package.%20While%20this%20is%20primarily%20a%20tooling%2Fdependency%20migration%2C%20a%20smoke%20test%20%28e.g.%2C%20running%20%60make%20docs-sdk%60%20in%20CI%20against%20the%20pinned%20version%29%20would%20confirm%20the%20PyPI%20package%20behaves%20identically%20to%20the%20previous%20local%20editable%20install.%0A%0A**Context%20Used%3A**%20%23%20Test%20guidelines%0A-%20Add%20a%20comment%20if%20the%20PR%20does%20n...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0A&repo=nottelabs%2Fnotte"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .pre-commit-config.yaml
Line: 73-78

Comment:
**Hook ordering may produce confusing two-step commit cycle**

`check-sdk-docs` (line 66) runs before `docs-sdk-generate` (line 73). When SDK source files change and the generated docs are stale, `check-sdk-docs` can fail first, then `docs-sdk-generate` regenerates the docs and causes a file-modification failure — requiring the developer to restage and commit twice before both hooks pass.

Swapping the two hooks (generate first, then check) would let regeneration happen before the check runs, reducing the typical workflow to a single extra commit instead of two.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: pyproject.toml
Line: 73

Comment:
**No tests added**

This PR introduces a new pre-commit hook that runs `make docs-sdk` automatically. There are no tests verifying that the hook triggers correctly or that `make docs-sdk` produces consistent output with the published PyPI package. While this is primarily a tooling/dependency migration, a smoke test (e.g., running `make docs-sdk` in CI against the pinned version) would confirm the PyPI package behaves identically to the previous local editable install.

**Context Used:** # Test guidelines
- Add a comment if the PR does n... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Replace local sphinx\_mintlify install wi..."](https://github.com/nottelabs/notte/commit/c6ab5bca7d7faa09286cc6ffcb0987c95b8c4169) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28562065)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - # Test guidelines
- Add a comment if the PR does n... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->