### PR TITLE
docs: curated llms.txt generator from docs.json + OpenAPI

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -1,0 +1,376 @@
+# Notte
+
+> Notte - The best place to automate the browser
+
+
+# Documentation
+
+## Getting Started
+
+- [Introduction](https://docs.notte.cc/): Notte - The best place to automate the browser
+- [Quickstart](https://docs.notte.cc/quickstart): Get started in a few seconds
+- [Concepts](https://docs.notte.cc/concepts): Core concepts in the Notte platform
+
+## Sessions
+
+- [Browser Sessions](https://docs.notte.cc/concepts/sessions): Cloud-hosted browser instances for automation
+- [Session Lifecycle](https://docs.notte.cc/features/sessions/lifecycle): Manage the lifecycle of your Notte browser sessions
+- [Session Configurations](https://docs.notte.cc/features/sessions/configuration): Learn how to create and configure Notte browser sessions
+- [Browser Controls](https://docs.notte.cc/features/sessions/browser-controls): Complete reference of all browser actions available in sessions
+- [Playwright vs Notte Controls](https://docs.notte.cc/features/sessions/playwright-vs-notte): Understanding the difference between direct Playwright control and Notte's AI-enabled SDK
+
+### Session Capabilities
+
+- [Browser Types](https://docs.notte.cc/features/sessions/browser-types): Choose between Chromium or Chrome for your sessions
+- [Browser Pools](https://docs.notte.cc/features/sessions/browser-pools): Managed pools of browser instances for high-throughput automation
+- [Stealth Mode](https://docs.notte.cc/features/sessions/stealth-mode): Configure anti-detection features for your browser sessions
+- [Proxies](https://docs.notte.cc/features/sessions/proxies): Route your automation traffic with precision & control
+- [Multi-Region Support](https://docs.notte.cc/features/sessions/multi-region): Run browser sessions across multiple geographic regions
+- [CAPTCHA Solving](https://docs.notte.cc/features/sessions/captcha-solving): Automatically detect and solve captchas during browser automation
+- [Ad Blocking](https://docs.notte.cc/features/sessions/ad-blocking): Built-in ad and tracker blocking for browser sessions
+- [Browser Profiles](https://docs.notte.cc/features/sessions/browser-profiles): Persist browser state across sessions
+- [Static IPs](https://docs.notte.cc/features/sessions/static-ips): Use dedicated static IP addresses for your browser sessions
+- [Recordings](https://docs.notte.cc/features/sessions/recordings): Record and replay your browser sessions for debugging and analysis
+- [Live View](https://docs.notte.cc/features/sessions/live-view): Watch your browser sessions in real-time as they execute
+- [Browser Extensions](https://docs.notte.cc/features/sessions/browser-extensions): Load custom browser extensions in your sessions
+- [Cookies](https://docs.notte.cc/features/sessions/cookies): Persist authentication and manage cookies across sessions
+- [Cloudflare Web Bot Auth](https://docs.notte.cc/features/sessions/cloudflare-web-bot-auth): Access Cloudflare-protected websites by cryptographically signing browser requests
+
+### Connect over CDP
+
+- [Connect with Playwright](https://docs.notte.cc/features/sessions/playwright): Use Playwright directly with Notte sessions via Chrome DevTools Protocol
+- [Connect with Puppeteer](https://docs.notte.cc/features/sessions/puppeteer): Use Puppeteer with Notte sessions via Chrome DevTools Protocol
+- [Connect with Selenium](https://docs.notte.cc/features/sessions/selenium): Use Selenium with Notte sessions via Chrome DevTools Protocol
+- [External Providers](https://docs.notte.cc/features/sessions/external-providers): Connect Notte to external browser infrastructure via Chrome DevTools Protocol
+
+## Agents
+
+- [Browser Agents](https://docs.notte.cc/concepts/agents): AI-powered agents that autonomously complete browser tasks
+- [Agent Configuration](https://docs.notte.cc/features/agents/configuration): Configure agent behavior with creation and runtime parameters
+- [Agent Lifecycle](https://docs.notte.cc/features/agents/lifecycle): Understand agent execution modes, states, and control flow
+
+### Advanced
+
+- [Structured Output](https://docs.notte.cc/features/agents/structured-output): Get type-safe, structured responses from agents using Pydantic models
+- [Replay & Debugging](https://docs.notte.cc/features/agents/replay): Debug agents with visual replays and step-by-step inspection
+- [Agent to Function Conversion](https://docs.notte.cc/features/agents/workflows): Convert agent executions into reusable function code
+- [Agent Fallback](https://docs.notte.cc/features/agents/fallback): Automatically recover from script failures with AI agents
+
+## Functions
+
+- [Functions](https://docs.notte.cc/concepts/functions): Deploy browser automations as serverless API endpoints
+- [Creating Functions](https://docs.notte.cc/features/functions/creating): Write and deploy browser automation Functions
+- [Function Invocations](https://docs.notte.cc/features/functions/invocations): Call Functions via API, SDK, cURL, or webhooks
+- [Function Schedules](https://docs.notte.cc/features/functions/schedules): Schedule Functions to run automatically with cron expressions
+- [Function Management](https://docs.notte.cc/features/functions/management): Update, version, monitor, and manage your deployed Functions
+
+## Agent Tools
+
+- [File Storage](https://docs.notte.cc/concepts/file-storage): Upload and download files for your automations
+- [Secret Vaults](https://docs.notte.cc/concepts/vaults): Enterprise-grade credential management for your Sessions & Agents
+- [Persona Identities](https://docs.notte.cc/concepts/personas): Self-service identities for web automation (account creation, 2FA,etc.)
+
+## Scraping
+
+- [Scraping](https://docs.notte.cc/concepts/scraping): Extract content and structured data from web pages
+
+## Guides
+
+- [Towards Reliable Agents](https://docs.notte.cc/guides/reliability): How to build reliable web agents
+- [Advanced Scraping](https://docs.notte.cc/guides/scraping): How to build reliable web scrapers with Notte
+- [Anti-Detection Playbook](https://docs.notte.cc/guides/stealth): How to avoid CAPTCHAs and bot detection in Notte Sessions
+- [Create accounts with Personas](https://docs.notte.cc/guides/account_creation): How to use notte personas for account creation
+
+## Integrations
+
+- [Claude Code & AI Agents](https://docs.notte.cc/integrations/claude-code-ai-agents): Use Notte with AI coding assistants like Claude Code, Cursor, and Windsurf
+
+### MCP
+
+- [MCP Server](https://docs.notte.cc/integrations/mcp): Extending AI Systems with Browser Control Capabilities
+- [Vibe Coding](https://docs.notte.cc/guides/vibe-coding): Connect documentation to your AI coding assistant with MCP
+- [Kernel.sh](https://docs.notte.cc/integrations/kernel): Integrate with Kernel browsers
+- [Steel](https://docs.notte.cc/integrations/steel): Run Notte with Steel cloud browsers (CDP)
+- [Massive](https://docs.notte.cc/integrations/massive): Use Massive residential proxies with Notte sessions
+- [OpenAI CUA](https://docs.notte.cc/integrations/openai-cua): Integrate OpenAI CUA with Notte Browser Sessions
+- [Stagehand](https://docs.notte.cc/integrations/stagehand): Use Notte cloud browsers with Stagehand browser automation
+- [Cloudflare Web Bot Auth](https://docs.notte.cc/features/sessions/cloudflare-web-bot-auth): Access Cloudflare-protected websites by cryptographically signing browser requests
+
+
+# API
+
+## Getting Started
+
+- [Authentication](https://docs.notte.cc/api-reference/authentication): Authenticate with the Notte API
+- [API Error Codes](https://docs.notte.cc/api-reference/errors): API error responses and status codes
+- [Rate Limits](https://docs.notte.cc/api-reference/rate-limits): API rate limiting and response headers
+
+## Agents
+
+- [POST Agent Start](https://docs.notte.cc/api-reference/agents/agent-start)
+- [GET Agent Status](https://docs.notte.cc/api-reference/agents/agent-status)
+- [DELETE Agent Stop](https://docs.notte.cc/api-reference/agents/agent-stop)
+- [GET Get Script](https://docs.notte.cc/api-reference/agents/get-script)
+- [GET List Agents](https://docs.notte.cc/api-reference/agents/list-agents)
+
+## Anything
+
+- [POST Anything Start](https://docs.notte.cc/api-reference/anything/anything-start)
+
+## Functions
+
+- [POST Function Create](https://docs.notte.cc/api-reference/functions/function-create)
+- [DELETE Function Delete](https://docs.notte.cc/api-reference/functions/function-delete)
+- [GET Function Download Url](https://docs.notte.cc/api-reference/functions/function-download-url)
+- [POST Function Fork](https://docs.notte.cc/api-reference/functions/function-fork)
+- [GET Function Run Get Metadata](https://docs.notte.cc/api-reference/functions/function-run-get-metadata)
+- [POST Function Run Start](https://docs.notte.cc/api-reference/functions/function-run-start)
+- [DELETE Function Run Stop](https://docs.notte.cc/api-reference/functions/function-run-stop)
+- [PATCH Function Run Update Metadata](https://docs.notte.cc/api-reference/functions/function-run-update-metadata)
+- [DELETE Function Schedule Delete](https://docs.notte.cc/api-reference/functions/function-schedule-delete)
+- [POST Function Schedule Set](https://docs.notte.cc/api-reference/functions/function-schedule-set)
+- [POST Function Update](https://docs.notte.cc/api-reference/functions/function-update)
+- [GET List Function Runs By Function Id](https://docs.notte.cc/api-reference/functions/list-function-runs-by-function-id)
+- [GET List Functions](https://docs.notte.cc/api-reference/functions/list-functions)
+
+## Health
+
+- [GET Health Check](https://docs.notte.cc/api-reference/health/health-check)
+
+## Personas
+
+- [GET List Personas](https://docs.notte.cc/api-reference/personas/list-personas)
+- [POST Persona Create](https://docs.notte.cc/api-reference/personas/persona-create)
+- [DELETE Persona Delete](https://docs.notte.cc/api-reference/personas/persona-delete)
+- [GET Persona Emails List](https://docs.notte.cc/api-reference/personas/persona-emails-list)
+- [GET Persona Get](https://docs.notte.cc/api-reference/personas/persona-get)
+- [GET Persona Sms List](https://docs.notte.cc/api-reference/personas/persona-sms-list)
+
+## Profiles
+
+- [POST Profile Create](https://docs.notte.cc/api-reference/profiles/profile-create)
+- [DELETE Profile Delete](https://docs.notte.cc/api-reference/profiles/profile-delete)
+- [GET Profile Get](https://docs.notte.cc/api-reference/profiles/profile-get)
+- [GET Profile List](https://docs.notte.cc/api-reference/profiles/profile-list)
+
+## Prompts
+
+- [POST Improve Prompt](https://docs.notte.cc/api-reference/prompts/improve-prompt)
+- [POST Nudge Prompt](https://docs.notte.cc/api-reference/prompts/nudge-prompt)
+
+## Scrape
+
+- [POST Scrape From Html](https://docs.notte.cc/api-reference/scrape/scrape-from-html)
+- [POST Scrape Webpage](https://docs.notte.cc/api-reference/scrape/scrape-webpage)
+
+## Sessions
+
+- [GET Get Session Script](https://docs.notte.cc/api-reference/sessions/get-session-script)
+- [GET List Sessions](https://docs.notte.cc/api-reference/sessions/list-sessions)
+- [POST Page Execute](https://docs.notte.cc/api-reference/sessions/page-execute)
+- [POST Page Observe](https://docs.notte.cc/api-reference/sessions/page-observe)
+- [POST Page Scrape](https://docs.notte.cc/api-reference/sessions/page-scrape)
+- [POST Page Screenshot](https://docs.notte.cc/api-reference/sessions/page-screenshot)
+- [GET Session Cookies Get](https://docs.notte.cc/api-reference/sessions/session-cookies-get)
+- [POST Session Cookies Set](https://docs.notte.cc/api-reference/sessions/session-cookies-set)
+- [GET Session Debug Info](https://docs.notte.cc/api-reference/sessions/session-debug-info)
+- [GET Session Network Logs](https://docs.notte.cc/api-reference/sessions/session-network-logs)
+- [GET Session Offset](https://docs.notte.cc/api-reference/sessions/session-offset)
+- [GET Session Replay](https://docs.notte.cc/api-reference/sessions/session-replay)
+- [POST Session Start](https://docs.notte.cc/api-reference/sessions/session-start)
+- [GET Session Status](https://docs.notte.cc/api-reference/sessions/session-status)
+- [DELETE Session Stop](https://docs.notte.cc/api-reference/sessions/session-stop)
+
+## Storage
+
+- [GET File Download](https://docs.notte.cc/api-reference/storage/file-download)
+- [GET File List Downloads](https://docs.notte.cc/api-reference/storage/file-list-downloads)
+- [GET File List Uploads](https://docs.notte.cc/api-reference/storage/file-list-uploads)
+- [POST File Upload](https://docs.notte.cc/api-reference/storage/file-upload)
+- [POST File Upload Downloaded File](https://docs.notte.cc/api-reference/storage/file-upload-downloaded-file)
+
+## Usage
+
+- [GET Get Usage](https://docs.notte.cc/api-reference/usage/get-usage)
+- [GET Get Usage Logs](https://docs.notte.cc/api-reference/usage/get-usage-logs)
+
+## Vaults
+
+- [GET List Vaults](https://docs.notte.cc/api-reference/vaults/list-vaults)
+- [POST Vault Create](https://docs.notte.cc/api-reference/vaults/vault-create)
+- [POST Vault Credentials Add](https://docs.notte.cc/api-reference/vaults/vault-credentials-add)
+- [DELETE Vault Credentials Delete](https://docs.notte.cc/api-reference/vaults/vault-credentials-delete)
+- [GET Vault Credentials Get](https://docs.notte.cc/api-reference/vaults/vault-credentials-get)
+- [GET Vault Credentials List](https://docs.notte.cc/api-reference/vaults/vault-credentials-list)
+- [DELETE Vault Credit Card Delete](https://docs.notte.cc/api-reference/vaults/vault-credit-card-delete)
+- [GET Vault Credit Card Get](https://docs.notte.cc/api-reference/vaults/vault-credit-card-get)
+- [POST Vault Credit Card Set](https://docs.notte.cc/api-reference/vaults/vault-credit-card-set)
+- [DELETE Vault Delete](https://docs.notte.cc/api-reference/vaults/vault-delete)
+- [PATCH Vault Update](https://docs.notte.cc/api-reference/vaults/vault-update)
+
+
+# SDK
+
+## Getting Started
+
+- [NotteClient](https://docs.notte.cc/sdk-reference/manual/index): The starting point for all operations
+- [Authentication](https://docs.notte.cc/sdk-reference/authentication): Authenticate with the Notte SDK
+- [Error Handling](https://docs.notte.cc/sdk-reference/errors): Handle errors in the Notte SDK
+- [Rate Limits](https://docs.notte.cc/sdk-reference/rate-limits): Handle rate limits in the Notte SDK
+
+## Core Features
+
+- [scrape](https://docs.notte.cc/sdk-reference/notteclient/scrape): Scrape the current page data
+
+### Session
+
+- [Get started](https://docs.notte.cc/sdk-reference/manual/session): Creating and using a browsing session
+- [start](https://docs.notte.cc/sdk-reference/remotesession/start): Start the session using the configured request
+- [stop](https://docs.notte.cc/sdk-reference/remotesession/stop): Stop the session and clean up resources
+- [observe](https://docs.notte.cc/sdk-reference/remotesession/observe): Observes the current session page
+- [execute](https://docs.notte.cc/sdk-reference/remotesession/execute): Executes an action on the current session page
+- [scrape](https://docs.notte.cc/sdk-reference/remotesession/scrape): Scrape the current page data
+- [replay](https://docs.notte.cc/sdk-reference/remotesession/replay): Get presigned URLs for the session replay
+- [cdp_url](https://docs.notte.cc/sdk-reference/remotesession/cdp_url): Get the Chrome DevTools Protocol WebSocket URL for the session
+- [set_cookies](https://docs.notte.cc/sdk-reference/remotesession/set_cookies): Uploads cookies to the session
+- [get_cookies](https://docs.notte.cc/sdk-reference/remotesession/get_cookies): Gets cookies from the session
+- [viewer_browser](https://docs.notte.cc/sdk-reference/remotesession/viewer_browser): Opens live session replay in browser (frame by frame) in a new browser tab
+- [viewer_cdp](https://docs.notte.cc/sdk-reference/remotesession/viewer_cdp): Open a browser tab with the debug URL for visualizing the session
+- [viewer](https://docs.notte.cc/sdk-reference/remotesession/viewer): Open the viewer for the session based on the viewer_type
+- [status](https://docs.notte.cc/sdk-reference/remotesession/status): Get the current status of the session
+
+### Actions
+
+- [GotoAction](https://docs.notte.cc/sdk-reference/misc/gotoaction): Goto to a URL (in current tab)
+- [GotoNewTabAction](https://docs.notte.cc/sdk-reference/misc/gotonewtabaction): Goto to a URL (in new tab)
+- [SwitchTabAction](https://docs.notte.cc/sdk-reference/misc/switchtabaction): Switch to a tab (identified by its index)
+- [GoBackAction](https://docs.notte.cc/sdk-reference/misc/gobackaction): Go back to the previous page (in current tab)
+- [GoForwardAction](https://docs.notte.cc/sdk-reference/misc/goforwardaction): Go forward to the next page (in current tab)
+- [ReloadAction](https://docs.notte.cc/sdk-reference/misc/reloadaction): Reload the current page
+- [WaitAction](https://docs.notte.cc/sdk-reference/misc/waitaction): Wait for a given amount of time (in milliseconds)
+- [PressKeyAction](https://docs.notte.cc/sdk-reference/misc/presskeyaction): Press a keyboard key: e
+- [ScrollUpAction](https://docs.notte.cc/sdk-reference/misc/scrollupaction): Scroll up by a given amount of pixels
+- [ScrollDownAction](https://docs.notte.cc/sdk-reference/misc/scrolldownaction): Scroll down by a given amount of pixels
+- [ClickAction](https://docs.notte.cc/sdk-reference/misc/clickaction): Click on an element of the current page
+- [FillAction](https://docs.notte.cc/sdk-reference/misc/fillaction): Fill an input field with a value
+- [CheckAction](https://docs.notte.cc/sdk-reference/misc/checkaction): Check a checkbox
+- [FormFillAction](https://docs.notte.cc/sdk-reference/misc/formfillaction): Fill a form with multiple values
+- [EvaluateJsAction](https://docs.notte.cc/sdk-reference/misc/evaluatejsaction): Evaluate JavaScript code on the current page and return the result
+- [SelectDropdownOptionAction](https://docs.notte.cc/sdk-reference/misc/selectdropdownoptionaction): Select an option from a dropdown
+- [UploadFileAction](https://docs.notte.cc/sdk-reference/misc/uploadfileaction): Upload file to interactive element with file path
+- [DownloadFileAction](https://docs.notte.cc/sdk-reference/misc/downloadfileaction): Download files from interactive elements
+- [ScrapeAction](https://docs.notte.cc/sdk-reference/misc/scrapeaction): Scrape the current page data in text format
+- [CaptchaSolveAction](https://docs.notte.cc/sdk-reference/misc/captchasolveaction): Solve a CAPTCHA challenge on the current page
+- [SmsReadAction](https://docs.notte.cc/sdk-reference/misc/smsreadaction): Read sms messages received recently
+- [EmailReadAction](https://docs.notte.cc/sdk-reference/misc/emailreadaction): Read recent emails from the mailbox
+
+### Agent
+
+- [Get started](https://docs.notte.cc/sdk-reference/manual/agent): Running agents is a breeze
+- [run](https://docs.notte.cc/sdk-reference/remoteagent/run): Run an agent with the specified request parameters and wait for completion
+- [replay](https://docs.notte.cc/sdk-reference/remoteagent/replay): Get the replay for the agent's session
+- [start](https://docs.notte.cc/sdk-reference/remoteagent/start): Start the agent with the specified request parameters
+- [stop](https://docs.notte.cc/sdk-reference/remoteagent/stop): Stop the currently running agent
+- [status](https://docs.notte.cc/sdk-reference/remoteagent/status): Get the current status of the agent
+- [Agent Fallback](https://docs.notte.cc/sdk-reference/manual/agent_fallback): Gracefully handle script execution failures with Web Agents
+
+### Function
+
+- [Get started](https://docs.notte.cc/sdk-reference/manual/workflow): Create, manage, and execute automated web functions
+- [run](https://docs.notte.cc/sdk-reference/nottefunction/run): Run the function code using the specified version and variables
+- [update](https://docs.notte.cc/sdk-reference/nottefunction/update): Update the workflow with a a new code version
+- [delete](https://docs.notte.cc/sdk-reference/nottefunction/delete): Delete the workflow from the notte console
+- [download](https://docs.notte.cc/sdk-reference/nottefunction/download): Download the function code from the notte console as a python file
+- [fork](https://docs.notte.cc/sdk-reference/nottefunction/fork): Fork a shared function into your own private function
+- [get_curl](https://docs.notte.cc/sdk-reference/nottefunction/get_curl): Convert the workflow/run to a curl request
+
+## Tooling
+
+
+### Vault
+
+- [Get started](https://docs.notte.cc/sdk-reference/manual/vault): Secure credential management made easy
+- [add_credentials](https://docs.notte.cc/sdk-reference/nottevault/add_credentials): No description available
+- [get_credentials](https://docs.notte.cc/sdk-reference/nottevault/get_credentials): No description available
+- [delete_credentials](https://docs.notte.cc/sdk-reference/nottevault/delete_credentials): No description available
+- [list_credentials](https://docs.notte.cc/sdk-reference/nottevault/list_credentials): No description available
+- [set_credit_card](https://docs.notte.cc/sdk-reference/nottevault/set_credit_card): No description available
+- [get_credit_card](https://docs.notte.cc/sdk-reference/nottevault/get_credit_card): No description available
+- [delete_credit_card](https://docs.notte.cc/sdk-reference/nottevault/delete_credit_card): No description available
+- [generate_password](https://docs.notte.cc/sdk-reference/nottevault/generate_password): Generate a secure random password
+
+### Persona
+
+- [Get started](https://docs.notte.cc/sdk-reference/manual/persona): Self-service identities for web automation (account creation, 2FA,etc.)
+- [delete](https://docs.notte.cc/sdk-reference/nottepersona/delete): Delete the persona from the notte console
+- [add_credentials](https://docs.notte.cc/sdk-reference/nottepersona/add_credentials): Add credentials to the persona (generates a password and stores it in the vault)
+- [create_number](https://docs.notte.cc/sdk-reference/nottepersona/create_number): Create a phone number to the persona
+- [delete_number](https://docs.notte.cc/sdk-reference/nottepersona/delete_number): Delete the phone number from the persona
+- [emails](https://docs.notte.cc/sdk-reference/nottepersona/emails): Read recent emails sent to the persona
+- [sms](https://docs.notte.cc/sdk-reference/nottepersona/sms): Read recent sms messages sent to the persona
+
+### File Storage
+
+- [FileStorage](https://docs.notte.cc/sdk-reference/manual/file_storage): Upload and download files for your automations
+- [download](https://docs.notte.cc/sdk-reference/remotefilestorage/download): Stores a file that has been downloaded from a website in the current session
+- [upload](https://docs.notte.cc/sdk-reference/remotefilestorage/upload): Upload a file from your local machine to storage
+- [list_downloaded_files](https://docs.notte.cc/sdk-reference/remotefilestorage/list_downloaded_files): List all files in the download_dir
+- [list_uploaded_files](https://docs.notte.cc/sdk-reference/remotefilestorage/list_uploaded_files): List all files from the upload_dir
+
+## Debug
+
+
+### Debug Methods
+
+- [health_check](https://docs.notte.cc/sdk-reference/notteclient/health_check): Health check the Notte API
+- [debug_info](https://docs.notte.cc/sdk-reference/remotesession/debug_info): Get detailed debug information for the session
+- [offset](https://docs.notte.cc/sdk-reference/remotesession/offset): Get the trajectory offset of the session
+
+
+# Products
+
+## Products
+
+- [Agent Mode](https://docs.notte.cc/product/agent-mode): Bootstrap automations from natural language prompts
+- [Demonstrate Mode](https://docs.notte.cc/product/demonstrate-mode): Record browser actions and generate automation code instantly
+- [Automation Studio](https://docs.notte.cc/product/studio): A dedicated IDE for browser agents and automations
+
+
+# Resources
+
+## Resources
+
+- [Pricing](https://docs.notte.cc/pricing): Simple usage-based pricing with included hours on every plan
+- [Rate Limits](https://docs.notte.cc/rate-limits): Feature limits and quotas by plan
+- [Vibe Coding](https://docs.notte.cc/guides/vibe-coding): Connect documentation to your AI coding assistant with MCP
+
+## Legal
+
+- [Trust Center](https://docs.notte.cc/trust-center)
+- [Terms of Service](https://docs.notte.cc/legal/terms)
+- [Privacy Policy](https://docs.notte.cc/legal/privacy)
+- [Bug Bounty](https://docs.notte.cc/legal/bug-bounty): Report security vulnerabilities responsibly
+
+## Community
+
+- [GitHub](https://docs.notte.cc/community/github)
+- [Slack](https://docs.notte.cc/community/slack)
+- [X (Twitter)](https://docs.notte.cc/community/x)
+- [LinkedIn](https://docs.notte.cc/community/linkedin)
+- [Y Combinator](https://docs.notte.cc/community/yc)
+- [Feedback](https://docs.notte.cc/community/featurebase)
+- [Trustpilot](https://docs.notte.cc/community/trustpilot)
+- [Product Hunt](https://docs.notte.cc/community/producthunt)
+- [YouTube](https://docs.notte.cc/community/youtube)
+
+
+# Updates
+
+## Updates
+
+- [Changelog](https://docs.notte.cc/changelog): Updates and improvements to Notte
+
+## Releases
+
+- [Notte Releases](https://docs.notte.cc/releases/github)
+- [Python SDK (PyPI)](https://docs.notte.cc/releases/pypi)

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -334,6 +334,7 @@
 - [Agent Mode](https://docs.notte.cc/product/agent-mode): Bootstrap automations from natural language prompts
 - [Demonstrate Mode](https://docs.notte.cc/product/demonstrate-mode): Record browser actions and generate automation code instantly
 - [Automation Studio](https://docs.notte.cc/product/studio): A dedicated IDE for browser agents and automations
+- [Anything API](https://docs.notte.cc/product/anything-api): Build and run web automations from a single API call
 
 
 # Resources

--- a/docs/src/scripts/generate_llms.py
+++ b/docs/src/scripts/generate_llms.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Generate src/llms.txt from docs.json navigation structure.
+
+Tabs become H1, top-level groups become H2, nested groups become H3.
+Each page is emitted as a bullet with title + description pulled from
+the page's YAML frontmatter.
+
+Run from anywhere:
+    python3 src/scripts/generate_llms.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+SITE_URL = "https://docs.notte.cc"
+SRC_DIR = Path(__file__).resolve().parent.parent
+DOCS_JSON = SRC_DIR / "docs.json"
+OUTPUT = SRC_DIR / "llms.txt"
+
+HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options"}
+
+
+def slugify(text: str) -> str:
+    text = re.sub(r"[^a-zA-Z0-9]+", "-", text).strip("-").lower()
+    return text
+
+
+def fetch_openapi(url: str) -> dict:
+    print(f"  fetching {url}")
+    req = urllib.request.Request(url, headers={"User-Agent": "notte-docs-llms-gen/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def render_openapi(spec: dict) -> list[str]:
+    """Group operations by first tag, emit H2 per tag, bullet per operation."""
+    by_tag: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    for path, methods in spec.get("paths", {}).items():
+        for method, op in methods.items():
+            if method.lower() not in HTTP_METHODS:
+                continue
+            tags = op.get("tags") or ["misc"]
+            tag = tags[0]
+            summary = op.get("summary") or op.get("operationId") or f"{method.upper()} {path}"
+            desc = (op.get("description") or "").strip().split("\n")[0]
+            by_tag[tag].append((method.upper(), summary, desc))
+
+    lines: list[str] = []
+    for tag in sorted(by_tag):
+        lines += [f"## {tag.title()}", ""]
+        for method, summary, desc in sorted(by_tag[tag], key=lambda x: x[1]):
+            url = f"{SITE_URL}/api-reference/{tag}/{slugify(summary)}"
+            line = f"- [{method} {summary}]({url})"
+            if desc:
+                line += f": {desc}"
+            lines.append(line)
+        lines.append("")
+    return lines
+
+
+def read_frontmatter(page_path: str) -> tuple[str, str]:
+    """Return (title, description) for a nav page path."""
+    for ext in (".mdx", ".md"):
+        file = SRC_DIR / f"{page_path}{ext}"
+        if file.exists():
+            break
+    else:
+        print(f"  warning: no file for '{page_path}'", file=sys.stderr)
+        return page_path, ""
+
+    text = file.read_text()
+    if not text.startswith("---"):
+        return page_path, ""
+
+    end = text.find("\n---", 3)
+    if end == -1:
+        return page_path, ""
+
+    fm = yaml.safe_load(text[3:end]) or {}
+    return str(fm.get("title", page_path)), str(fm.get("description", "")).strip()
+
+
+def page_url(page_path: str) -> str:
+    if page_path == "index":
+        return f"{SITE_URL}/"
+    return f"{SITE_URL}/{page_path}"
+
+
+def render_page(page_path: str) -> str:
+    title, desc = read_frontmatter(page_path)
+    line = f"- [{title}]({page_url(page_path)})"
+    if desc:
+        line += f": {desc}"
+    return line
+
+
+def render_pages(pages: list, depth: int) -> list[str]:
+    """Walk a pages array. Strings are pages; dicts are nested groups."""
+    lines: list[str] = []
+    heading = "#" * depth
+    for entry in pages:
+        if isinstance(entry, str):
+            lines.append(render_page(entry))
+        elif isinstance(entry, dict) and "group" in entry:
+            lines.append("")
+            lines.append(f"{heading} {entry['group']}")
+            lines.append("")
+            lines.extend(render_pages(entry.get("pages", []), depth + 1))
+    return lines
+
+
+def main() -> int:
+    config = json.loads(DOCS_JSON.read_text())
+    site_name = config.get("name", "Docs")
+
+    _, intro = read_frontmatter("index")
+
+    out: list[str] = [f"# {site_name}", ""]
+    if intro:
+        out += [f"> {intro}", ""]
+
+    tabs = config["navigation"]["languages"][0]["tabs"]
+    for tab in tabs:
+        out += ["", f"# {tab['tab']}", ""]
+        for group in tab.get("groups", []):
+            out += [f"## {group['group']}", ""]
+            out += render_pages(group.get("pages", []), depth=3)
+            out += [""]
+        if "openapi" in tab:
+            try:
+                spec = fetch_openapi(tab["openapi"])
+                out += render_openapi(spec)
+            except Exception as e:
+                print(f"  warning: failed to fetch openapi {tab['openapi']}: {e}", file=sys.stderr)
+                out += [f"- OpenAPI spec: {tab['openapi']}", ""]
+
+    OUTPUT.write_text("\n".join(out).rstrip() + "\n")
+    print(f"wrote {OUTPUT.relative_to(SRC_DIR.parent)} ({OUTPUT.stat().st_size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/src/scripts/generate_llms.py
+++ b/docs/src/scripts/generate_llms.py
@@ -42,23 +42,25 @@ def fetch_openapi(url: str) -> dict:
 
 def render_openapi(spec: dict) -> list[str]:
     """Group operations by first tag, emit H2 per tag, bullet per operation."""
-    by_tag: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    by_tag: dict[str, list[tuple[str, str, str, str]]] = defaultdict(list)
     for path, methods in spec.get("paths", {}).items():
         for method, op in methods.items():
             if method.lower() not in HTTP_METHODS:
                 continue
             tags = op.get("tags") or ["misc"]
             tag = tags[0]
-            summary = op.get("summary") or op.get("operationId") or f"{method.upper()} {path}"
+            op_id = op.get("operationId") or ""
+            display = op.get("summary") or op_id or f"{method.upper()} {path}"
             desc = (op.get("description") or "").strip().split("\n")[0]
-            by_tag[tag].append((method.upper(), summary, desc))
+            by_tag[tag].append((method.upper(), display, desc, op_id))
 
     lines: list[str] = []
     for tag in sorted(by_tag):
         lines += [f"## {tag.title()}", ""]
-        for method, summary, desc in sorted(by_tag[tag], key=lambda x: x[1]):
-            url = f"{SITE_URL}/api-reference/{tag}/{slugify(summary)}"
-            line = f"- [{method} {summary}]({url})"
+        for method, display, desc, op_id in sorted(by_tag[tag], key=lambda x: x[1]):
+            slug = slugify(op_id) if op_id else slugify(display)
+            url = f"{SITE_URL}/api-reference/{slugify(tag)}/{slug}"
+            line = f"- [{method} {display}]({url})"
             if desc:
                 line += f": {desc}"
             lines.append(line)
@@ -76,7 +78,7 @@ def read_frontmatter(page_path: str) -> tuple[str, str]:
         print(f"  warning: no file for '{page_path}'", file=sys.stderr)
         return page_path, ""
 
-    text = file.read_text()
+    text = file.read_text(encoding="utf-8")
     if not text.startswith("---"):
         return page_path, ""
 
@@ -84,7 +86,11 @@ def read_frontmatter(page_path: str) -> tuple[str, str]:
     if end == -1:
         return page_path, ""
 
-    fm = yaml.safe_load(text[3:end]) or {}
+    try:
+        fm = yaml.safe_load(text[3:end]) or {}
+    except yaml.YAMLError as e:
+        print(f"  warning: bad frontmatter in '{page_path}': {e}", file=sys.stderr)
+        return page_path, ""
     return str(fm.get("title", page_path)), str(fm.get("description", "")).strip()
 
 
@@ -127,7 +133,11 @@ def main() -> int:
     if intro:
         out += [f"> {intro}", ""]
 
-    tabs = config["navigation"]["languages"][0]["tabs"]
+    languages = config.get("navigation", {}).get("languages", [])
+    if not languages:
+        print("error: no languages found in docs.json navigation", file=sys.stderr)
+        return 1
+    tabs = languages[0].get("tabs", [])
     for tab in tabs:
         out += ["", f"# {tab['tab']}", ""]
         for group in tab.get("groups", []):

--- a/makefile
+++ b/makefile
@@ -106,9 +106,14 @@ profile-imports:
 
 
 .PHONY: docs-sdk
-docs-sdk:
+docs-sdk: docs-llms
 	cd docs && uv run sphinx-build -b mdx sphinx _build
 	rm -rf docs/src/sdk-reference/baseaction
+
+
+.PHONY: docs-llms
+docs-llms:
+	cd docs/src && uv run python scripts/generate_llms.py
 
 
 .PHONY: docs-check


### PR DESCRIPTION
## Summary

Mintlify's auto-generated `llms.txt` is alphabetically ordered and mixes high-signal docs (concepts, SDK reference) with low-signal entries (Slack, LinkedIn, Product Hunt, etc.). This replaces it with a curated file that mirrors the actual sidebar structure and expands the API tab from the OpenAPI spec.

- New script `docs/src/scripts/generate_llms.py` walks `docs.json` navigation:
  - Tabs → H1, top-level groups → H2, nested groups → H3
  - Each page → bullet with title + description pulled from frontmatter
  - For tabs with an `openapi` field, fetches the spec and emits operations grouped by tag (~57 endpoints)
- Generated `docs/src/llms.txt` (24 KB) is committed; Mintlify serves the manual file when present, overriding the auto-generated one
- New `make docs-llms` target; wired as a prereq of `make docs-sdk` so the existing pre-deploy regen flow picks it up automatically

Spec note: per [llmstxt.org](https://llmstxt.org/), only H1 + H2 are technically allowed. Using H3 for nested groups is non-strict but parses fine in practice.

## Test plan

- [x] `make docs-llms` runs cleanly and regenerates the file
- [ ] Verify a few page URLs in the generated `llms.txt` resolve correctly (sample-checked Sessions and API endpoints during dev)
- [ ] Confirm Mintlify serves the committed `llms.txt` instead of the auto one after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive static documentation index consolidating Getting Started, Sessions, Agents, Functions, Tools, Integrations, API reference, SDK reference, Products, Resources, Legal, Community, Updates, and Releases.
  * API/SDK sections now include enumerated endpoints, authentication/error guidance, and generated OpenAPI-based operation listings; generator emits warnings for missing or malformed page metadata.

* **Chores**
  * Documentation build now runs an automated generation step to produce the consolidated index before site build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a curated `llms.txt` generator (`docs/src/scripts/generate_llms.py`) that walks `docs.json` navigation and expands API tabs from the OpenAPI spec, replacing Mintlify's alphabetically-sorted auto-generated file. A new `make docs-llms` target is wired as a prerequisite of `make docs-sdk` so it runs automatically in the pre-deploy flow. Issues raised in the previous review round (tag slugification, `operationId`-based URL slugs, `languages` guard) are all resolved in this version.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only a minor encoding hygiene suggestion remains.

All P0/P1 findings from the previous review round have been addressed. The single remaining comment is a P2 style suggestion (missing encoding parameter) that would only surface on non-UTF-8 platforms, which are not part of this project's target environment.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/src/scripts/generate_llms.py | New script that walks docs.json navigation to produce a curated llms.txt; prior-review issues (tag slugification, operationId usage, languages guard) all resolved in this version. |
| docs/src/llms.txt | Generated output file; structure and URL patterns look correct for the current spec. |
| makefile | Adds docs-llms target and wires it as a prerequisite of docs-sdk; straightforward and correct. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsrc%2Fscripts%2Fgenerate_llms.py%3A155%0A**Missing%20encoding%20in%20%60write_text%60**%0A%0A%60read_text%60%20on%20line%2081%20explicitly%20passes%20%60encoding%3D%22utf-8%22%60%2C%20but%20the%20matching%20%60write_text%60%20call%20relies%20on%20the%20platform%20default.%20On%20any%20system%20where%20%60locale.getpreferredencoding%28%29%60%20isn't%20UTF-8%2C%20a%20%60UnicodeEncodeError%60%20would%20be%20raised%20if%20any%20page%20title%20or%20description%20contains%20non-ASCII%20characters.%0A%0A%60%60%60suggestion%0A%20%20%20%20OUTPUT.write_text%28%22%5Cn%22.join%28out%29.rstrip%28%29%20%2B%20%22%5Cn%22%2C%20encoding%3D%22utf-8%22%29%0A%60%60%60%0A%0A&repo=nottelabs%2Fnotte"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/src/scripts/generate_llms.py
Line: 155

Comment:
**Missing encoding in `write_text`**

`read_text` on line 81 explicitly passes `encoding="utf-8"`, but the matching `write_text` call relies on the platform default. On any system where `locale.getpreferredencoding()` isn't UTF-8, a `UnicodeEncodeError` would be raised if any page title or description contains non-ASCII characters.

```suggestion
    OUTPUT.write_text("\n".join(out).rstrip() + "\n", encoding="utf-8")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: address PR review feedback on llms..."](https://github.com/nottelabs/notte/commit/ae9c5f6c700713c07376ed2ec4171263e3adda9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28704034)</sub>

<!-- /greptile_comment -->