### PR TITLE
chore: add make docs-check target

### DIFF
--- a/makefile
+++ b/makefile
@@ -111,6 +111,24 @@ docs-sdk:
 	rm -rf docs/src/sdk-reference/baseaction
 
 
+.PHONY: docs-check
+docs-check:
+	@if ! git diff HEAD --quiet -- docs || [ -n "$$(git ls-files --others --exclude-standard -- docs)" ]; then \
+		echo "\033[0;31mError: docs/ has uncommitted changes or untracked files. Commit or stash them before running docs-check (it would overwrite them).\033[0m"; \
+		git --no-pager diff HEAD --stat -- docs; \
+		git ls-files --others --exclude-standard -- docs; \
+		exit 1; \
+	fi
+	@$(MAKE) --no-print-directory docs-sdk
+	@if ! git diff HEAD --quiet -- docs || [ -n "$$(git ls-files --others --exclude-standard -- docs)" ]; then \
+		echo "\033[0;31mError: 'make docs-sdk' produced changes. Run it locally and commit the result.\033[0m"; \
+		git --no-pager diff HEAD --stat -- docs; \
+		git ls-files --others --exclude-standard -- docs; \
+		exit 1; \
+	fi
+	@echo "\033[0;32mdocs are up to date\033[0m"
+
+
 .PHONY: docs
 docs:
 	cd docs/src && mint dev


### PR DESCRIPTION
## Summary
- Add a `docs-check` make target that runs `docs-sdk` and fails if it produces any tracked diff or new untracked files under `docs/`.
- Intended for CI / pre-merge verification that generated SDK docs are up to date.

## Test plan
- [ ] `make docs-check` passes on a clean checkout with docs already regenerated
- [ ] `make docs-check` fails (non-zero exit) when `docs-sdk` would produce changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a documentation validation check that ensures documentation is automatically up to date by verifying there are no uncommitted changes after generation, with clear error messaging if discrepancies are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `docs-check` Makefile target that guards against stale generated docs in CI, a `docs-llms` target that runs the new `generate_llms.py` script, and commits the initial `llms.txt` output. The implementation is clean: `docs-check` uses `git diff HEAD` on both sides of the generation step and checks for untracked files, making it reliable in any git checkout state.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are minor P2 style suggestions

No P0/P1 issues. The one new finding (tag not slugified in URL) is a defensive suggestion for future-proofing rather than a current bug, since all existing API tags are lowercase single words. Prior review concerns about git diff HEAD and UTF-8 encoding are both addressed in this version of the code.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| makefile | Adds docs-check, docs-llms targets and wires docs-sdk to depend on docs-llms; pre/post-gen guards correctly use `git diff HEAD` |
| docs/src/scripts/generate_llms.py | New script generating llms.txt from docs.json; encodes files with utf-8 throughout; minor fragility in render_openapi where tag name is used raw in the URL path without slugification |
| docs/src/llms.txt | New generated file; committed output of generate_llms.py representing the current state of the docs nav index |
| docs/src/concepts/personas.mdx | Trivial whitespace fix: added space before "etc." in frontmatter description |
| docs/src/sdk-reference/manual/persona.mdx | Same whitespace fix as concepts/personas.mdx – added space before "etc." in frontmatter description |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsrc%2Fscripts%2Fgenerate_llms.py%3A60%0A**Tag%20not%20slugified%20in%20API%20reference%20URL**%0A%0A%60tag%60%20is%20inserted%20into%20the%20URL%20path%20as-is.%20All%20current%20OpenAPI%20tags%20happen%20to%20be%20lowercase%20single%20words%2C%20but%20if%20a%20future%20tag%20contains%20spaces%20or%20uppercase%20letters%20%28e.g.%20%60%22File%20Storage%22%60%29%20the%20constructed%20URL%20will%20be%20invalid.%20%60slugify%60%20is%20already%20defined%20in%20this%20file%20%E2%80%94%20applying%20it%20here%20keeps%20the%20URL%20construction%20consistent%20with%20how%20%60summary%60%20is%20handled.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20url%20%3D%20f%22%7BSITE_URL%7D%2Fapi-reference%2F%7Bslugify%28tag%29%7D%2F%7Bslugify%28summary%29%7D%22%0A%60%60%60%0A%0A&repo=nottelabs%2Fnotte"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/src/scripts/generate_llms.py
Line: 60

Comment:
**Tag not slugified in API reference URL**

`tag` is inserted into the URL path as-is. All current OpenAPI tags happen to be lowercase single words, but if a future tag contains spaces or uppercase letters (e.g. `"File Storage"`) the constructed URL will be invalid. `slugify` is already defined in this file — applying it here keeps the URL construction consistent with how `summary` is handled.

```suggestion
            url = f"{SITE_URL}/api-reference/{slugify(tag)}/{slugify(summary)}"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: specify utf-8 encoding on docs.js..."](https://github.com/nottelabs/notte/commit/c1638bc4fdb61181511784e003d6cf8c08f1d565) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28708247)</sub>

<!-- /greptile_comment -->