### PR TITLE
fix: info tailscale

### DIFF
--- a/docs/src/features/sessions/proxies.mdx
+++ b/docs/src/features/sessions/proxies.mdx
@@ -53,15 +53,16 @@ Notte supports custom proxy configurations, allowing you to route traffic throug
 
 Notte can join your [Tailscale](https://tailscale.com) tailnet directly from within a cloud session, letting the browser reach any private service exposed on your tailnet (internal dashboards, staging environments, MagicDNS hosts) without exposing them to the public internet.
 
-Authentication uses [Tailscale OAuth client credentials](https://tailscale.com/kb/1215/oauth-clients). Create an OAuth client in your tailnet admin console with the `devices:core` scope and pass the credentials when creating the session.
+Authentication uses [Tailscale OAuth client credentials](https://tailscale.com/kb/1215/oauth-clients). In your Tailscale admin console:
+
+1. Under **Settings → Trust credentials**, create an OAuth client with write access to the `auth_keys` scope and tag it with `tag:notte`.
+2. In the **Access controls** tab, grant `tag:notte` access to the resources you want to reach from the session.
+
+Pass the client ID and secret when creating the session:
 
 <TailnetProxy/>
 
 Once the session is created, you can navigate to any hostname reachable on your tailnet — for example a MagicDNS name like `https://grafana.your-tailnet.ts.net/`.
-
-<Note>
-  Tailnet proxies are only supported in cloud browser sessions. The `oauth_client_secret` can be omitted if it is configured server-side for your workspace.
-</Note>
 
 ## Usage Measurement
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Tailscale proxy authentication setup guide with detailed workflow instructions for OAuth client creation, permission configuration, and credential provisioning in proxy sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Tailscale proxy documentation to reflect the correct OAuth client setup: the required scope is now `auth_keys` (not `devices:core`) and the client must be tagged with `tag:notte`, with an additional step to grant that tag access in **Access controls**. It also removes the `<Note>` block that previously stated tailnet proxies are only supported in cloud browser sessions and that `oauth_client_secret` can be omitted if configured server-side.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; safe to merge.

The PR only modifies a .mdx doc file, correcting OAuth scope details and restructuring setup steps. No code or logic is affected. All remaining findings are P2.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/src/features/sessions/proxies.mdx | Documentation update: replaces the Tailscale OAuth setup instructions (scope changed from `devices:core` to `auth_keys` with `tag:notte`), reformats steps as a numbered list, and removes the Note callout about cloud-only support and server-side secret omission. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsrc%2Ffeatures%2Fsessions%2Fproxies.mdx%3A62%0A**Removed%20note%20may%20still%20be%20useful**%0A%0AThe%20deleted%20%60%3CNote%3E%60%20contained%20two%20pieces%20of%20user-facing%20information%3A%20that%20tailnet%20proxies%20are%20only%20supported%20in%20cloud%20browser%20sessions%2C%20and%20that%20%60oauth_client_secret%60%20can%20be%20omitted%20when%20configured%20server-side.%20If%20either%20of%20these%20is%20still%20true%2C%20users%20who%20try%20to%20use%20tailnet%20proxies%20in%20local%20sessions%20%28or%20who%20are%20unsure%20whether%20to%20supply%20the%20secret%29%20will%20have%20no%20guidance.%20Consider%20re-adding%20whichever%20clauses%20remain%20accurate.%0A%0A&repo=nottelabs%2Fnotte&pr=781&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/src/features/sessions/proxies.mdx
Line: 62

Comment:
**Removed note may still be useful**

The deleted `<Note>` contained two pieces of user-facing information: that tailnet proxies are only supported in cloud browser sessions, and that `oauth_client_secret` can be omitted when configured server-side. If either of these is still true, users who try to use tailnet proxies in local sessions (or who are unsure whether to supply the secret) will have no guidance. Consider re-adding whichever clauses remain accurate.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["better tailscale info"](https://github.com/nottelabs/notte/commit/b6050884366e58ef0801461a6eebd84112757135) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29353072)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates the Tailscale proxy authentication documentation to replace a vague single-line OAuth setup description with a numbered step-by-step guide covering OAuth client creation, scope/tag configuration, and ACL setup.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b6050884366e58ef0801461a6eebd84112757135.</sup>
<!-- /MENDRAL_SUMMARY -->