### PR TITLE
fix(browser): retry CDP screenshots and log failures with context

### DIFF
--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -342,19 +342,37 @@ class BrowserWindow(BaseModel):
                 return data
             finally:
                 t_detach = time.monotonic()
+                url = self.page.url
                 # Shield detach from outer wait_for cancellation — otherwise a timeout here
                 # would skip detach and leak the CDP session, which is the exact contention
                 # this path is trying to surface. Inner wait_for bounds detach itself so a
-                # hung detach can't live forever in the background task set.
+                # hung detach can't live forever in the background task set. Attach a done
+                # callback so the task's result is still logged if the outer await is
+                # cancelled and leaves it running unobserved.
+                detach_task: asyncio.Task[None] = asyncio.ensure_future(
+                    asyncio.wait_for(cdp_session.detach(), timeout=2.0)
+                )
+
+                def _log_detach(task: "asyncio.Task[None]") -> None:
+                    elapsed_ms = (time.monotonic() - t_detach) * 1000
+                    if task.cancelled():
+                        logger.warning(f"CDP session detach for {url} was cancelled after {elapsed_ms:.0f}ms")
+                        return
+                    exc = task.exception()
+                    if exc is not None:
+                        logger.warning(
+                            f"CDP session detach for {url} failed after {elapsed_ms:.0f}ms: {type(exc).__name__}: {exc}"
+                        )
+                    elif elapsed_ms > 500:
+                        logger.warning(
+                            f"CDP session detach for {url} took {elapsed_ms:.0f}ms (attach={attach_ms:.0f}ms)"
+                        )
+
+                detach_task.add_done_callback(_log_detach)
                 try:
-                    await asyncio.shield(asyncio.wait_for(cdp_session.detach(), timeout=2.0))
-                except Exception as e:
-                    logger.warning(f"CDP session detach for {self.page.url} failed: {type(e).__name__}: {e}")
-                detach_ms = (time.monotonic() - t_detach) * 1000
-                if detach_ms > 500:
-                    logger.warning(
-                        f"CDP session detach for {self.page.url} took {detach_ms:.0f}ms (attach={attach_ms:.0f}ms)"
-                    )
+                    await asyncio.shield(detach_task)
+                except Exception:
+                    pass  # _log_detach handles logging via the done callback
 
         return await asyncio.wait_for(_run(), timeout=self.CDP_SCREENSHOT_TIMEOUT_S)
 

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -348,8 +348,6 @@ class BrowserWindow(BaseModel):
                 # hung detach can't live forever in the background task set.
                 try:
                     await asyncio.shield(asyncio.wait_for(cdp_session.detach(), timeout=2.0))
-                except asyncio.CancelledError:
-                    pass
                 except Exception as e:
                     logger.warning(f"CDP session detach for {self.page.url} failed: {type(e).__name__}: {e}")
                 detach_ms = (time.monotonic() - t_detach) * 1000

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -377,12 +377,13 @@ class BrowserWindow(BaseModel):
         return await asyncio.wait_for(_run(), timeout=self.CDP_SCREENSHOT_TIMEOUT_S)
 
     @profiler.profiled(service_name="observation")
-    async def screenshot(self, retries: int = config.empty_page_max_retry) -> bytes:
+    async def screenshot(self, retries: int = config.empty_page_max_retry, *, _skip_cdp: bool = False) -> bytes:
         if retries <= 0:
             raise EmptyPageContentError(url=self.page.url, nb_retries=config.empty_page_max_retry)
+        cdp_exhausted = _skip_cdp
         try:
             # Use CDP screenshot when no mask is needed and browser supports CDP (faster)
-            if self.screenshot_mask is None and self.is_chromium_based:
+            if not _skip_cdp and self.screenshot_mask is None and self.is_chromium_based:
                 cdp_start = time.monotonic()
                 for attempt in range(1, self.CDP_SCREENSHOT_MAX_ATTEMPTS + 1):
                     attempt_start = time.monotonic()
@@ -406,6 +407,7 @@ class BrowserWindow(BaseModel):
                 logger.warning(
                     f"CDP screenshot exhausted {self.CDP_SCREENSHOT_MAX_ATTEMPTS} attempts ({total_ms:.0f}ms total) for {self.page.url}, falling back to Playwright"
                 )
+                cdp_exhausted = True
 
             # Fall back to Playwright screenshot when mask is needed, CDP failed, or browser doesn't support CDP
             # Retry up to 2 times - DOM may change between mask creation and screenshot
@@ -442,7 +444,9 @@ class BrowserWindow(BaseModel):
                 f"Playwright screenshot timeout for {self.page.url}, retrying (remaining outer retries: {retries - 1})"
             )
             await self.short_wait()
-            return await self.screenshot(retries=retries - 1)
+            # Skip CDP on recursion if already exhausted — otherwise up to 30s of CDP retries
+            # compound on every outer retry (5 × 30s = 150s worst case).
+            return await self.screenshot(retries=retries - 1, _skip_cdp=cdp_exhausted)
 
     async def a11y(self) -> A11yTree | None:
         a11y_simple: A11yNode | None = await profiler.profiled(service_name="observation")(

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -315,18 +315,43 @@ class BrowserWindow(BaseModel):
             tabs=[await self.tab_metadata(i) for i, _ in enumerate(self.tabs)],
         )
 
+    # Per-attempt timeout for a single CDP screenshot (attach + capture + detach).
+    # Bounds hangs so the retry loop can actually retry instead of blocking on a stuck session.
+    CDP_SCREENSHOT_TIMEOUT_S: ClassVar[float] = 10.0
+    CDP_SCREENSHOT_MAX_ATTEMPTS: ClassVar[int] = 3
+
     @profiler.profiled(service_name="observation")
     async def _cdp_screenshot(self) -> bytes:
         """Take a screenshot using CDP protocol (faster than Playwright, but no mask support)."""
-        cdp_session = await self.get_cdp_session()
-        try:
-            result: dict[str, Any] = await cdp_session.send(  # pyright: ignore [reportUnknownMemberType]
-                "Page.captureScreenshot",
-                {"format": "jpeg", "quality": 85},
-            )
-            return base64.b64decode(result["data"])
-        finally:
-            await cdp_session.detach()
+
+        async def _run() -> bytes:
+            t_attach = time.monotonic()
+            cdp_session = await self.get_cdp_session()
+            attach_ms = (time.monotonic() - t_attach) * 1000
+            try:
+                t_send = time.monotonic()
+                result: dict[str, Any] = await cdp_session.send(  # pyright: ignore [reportUnknownMemberType]
+                    "Page.captureScreenshot",
+                    {"format": "jpeg", "quality": 85},
+                )
+                send_ms = (time.monotonic() - t_send) * 1000
+                data = base64.b64decode(result["data"])
+                logger.trace(
+                    f"CDP screenshot for {self.page.url}: attach={attach_ms:.0f}ms send={send_ms:.0f}ms size={len(data)}B"
+                )
+                return data
+            finally:
+                t_detach = time.monotonic()
+                await cdp_session.detach()
+                detach_ms = (time.monotonic() - t_detach) * 1000
+                # Detach is normally <5ms — log anything slower so we can spot contention
+                # between concurrent CDP sessions sharing the same page.
+                if detach_ms > 500:
+                    logger.warning(
+                        f"CDP session detach for {self.page.url} took {detach_ms:.0f}ms (attach={attach_ms:.0f}ms)"
+                    )
+
+        return await asyncio.wait_for(_run(), timeout=self.CDP_SCREENSHOT_TIMEOUT_S)
 
     @profiler.profiled(service_name="observation")
     async def screenshot(self, retries: int = config.empty_page_max_retry) -> bytes:
@@ -335,30 +360,64 @@ class BrowserWindow(BaseModel):
         try:
             # Use CDP screenshot when no mask is needed and browser supports CDP (faster)
             if self.screenshot_mask is None and self.is_chromium_based:
-                try:
-                    return await self._cdp_screenshot()
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    logger.debug(f"CDP screenshot failed for {self.page.url}, falling back to Playwright")
-                    pass  # Fall back to Playwright if CDP fails
+                cdp_start = time.monotonic()
+                for attempt in range(1, self.CDP_SCREENSHOT_MAX_ATTEMPTS + 1):
+                    attempt_start = time.monotonic()
+                    try:
+                        return await self._cdp_screenshot()
+                    except asyncio.CancelledError:
+                        raise
+                    except asyncio.TimeoutError:
+                        attempt_ms = (time.monotonic() - attempt_start) * 1000
+                        logger.warning(
+                            f"CDP screenshot timed out after {attempt_ms:.0f}ms for {self.page.url} (attempt {attempt}/{self.CDP_SCREENSHOT_MAX_ATTEMPTS}, budget={self.CDP_SCREENSHOT_TIMEOUT_S}s)"
+                        )
+                    except Exception as e:
+                        attempt_ms = (time.monotonic() - attempt_start) * 1000
+                        logger.opt(exception=True).warning(
+                            f"CDP screenshot failed after {attempt_ms:.0f}ms for {self.page.url} (attempt {attempt}/{self.CDP_SCREENSHOT_MAX_ATTEMPTS}): {type(e).__name__}: {e}"
+                        )
+                    if attempt < self.CDP_SCREENSHOT_MAX_ATTEMPTS:
+                        await self.short_wait()
+                total_ms = (time.monotonic() - cdp_start) * 1000
+                logger.warning(
+                    f"CDP screenshot exhausted {self.CDP_SCREENSHOT_MAX_ATTEMPTS} attempts ({total_ms:.0f}ms total) for {self.page.url}, falling back to Playwright"
+                )
 
             # Fall back to Playwright screenshot when mask is needed, CDP failed, or browser doesn't support CDP
             # Retry up to 2 times - DOM may change between mask creation and screenshot
             last_error: Exception | None = None
-            for _ in range(3):
+            for pw_attempt in range(1, 4):
+                pw_start = time.monotonic()
                 try:
+                    t_mask = time.monotonic()
                     mask = await self.screenshot_mask.mask(self.page) if self.screenshot_mask is not None else None
-                    return await self.page.screenshot(mask=mask, type="jpeg", quality=85)
+                    mask_ms = (time.monotonic() - t_mask) * 1000
+                    t_shot = time.monotonic()
+                    data = await self.page.screenshot(mask=mask, type="jpeg", quality=85)
+                    shot_ms = (time.monotonic() - t_shot) * 1000
+                    logger.trace(
+                        f"Playwright screenshot for {self.page.url}: mask={mask_ms:.0f}ms shot={shot_ms:.0f}ms size={len(data)}B attempt={pw_attempt}"
+                    )
+                    return data
                 except PlaywrightTimeoutError:
+                    pw_ms = (time.monotonic() - pw_start) * 1000
+                    logger.warning(
+                        f"Playwright screenshot timed out after {pw_ms:.0f}ms for {self.page.url} (attempt {pw_attempt}/3)"
+                    )
                     raise  # Let outer handler deal with timeouts
                 except Exception as e:
+                    pw_ms = (time.monotonic() - pw_start) * 1000
+                    logger.opt(exception=True).warning(
+                        f"Playwright screenshot failed after {pw_ms:.0f}ms for {self.page.url} (attempt {pw_attempt}/3): {type(e).__name__}: {e}"
+                    )
                     last_error = e
             raise last_error  # type: ignore[misc]
 
         except PlaywrightTimeoutError:
-            if config.verbose:
-                logger.debug(f"Timeout while taking screenshot for {self.page.url}. Retrying...")
+            logger.warning(
+                f"Playwright screenshot timeout for {self.page.url}, retrying (remaining outer retries: {retries - 1})"
+            )
             await self.short_wait()
             return await self.screenshot(retries=retries - 1)
 

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -342,10 +342,17 @@ class BrowserWindow(BaseModel):
                 return data
             finally:
                 t_detach = time.monotonic()
-                await cdp_session.detach()
+                # Shield detach from outer wait_for cancellation — otherwise a timeout here
+                # would skip detach and leak the CDP session, which is the exact contention
+                # this path is trying to surface. Inner wait_for bounds detach itself so a
+                # hung detach can't live forever in the background task set.
+                try:
+                    await asyncio.shield(asyncio.wait_for(cdp_session.detach(), timeout=2.0))
+                except asyncio.CancelledError:
+                    pass
+                except Exception as e:
+                    logger.warning(f"CDP session detach for {self.page.url} failed: {type(e).__name__}: {e}")
                 detach_ms = (time.monotonic() - t_detach) * 1000
-                # Detach is normally <5ms — log anything slower so we can spot contention
-                # between concurrent CDP sessions sharing the same page.
                 if detach_ms > 500:
                     logger.warning(
                         f"CDP session detach for {self.page.url} took {detach_ms:.0f}ms (attach={attach_ms:.0f}ms)"


### PR DESCRIPTION
CDP screenshot previously had one shot before silently falling back to Playwright on debug-level logs, so hangs and transient failures were invisible in production. Add a bounded retry loop (3 attempts, 10s each) with per-stage timing (attach/send/detach), full exception info on failure, and slow-detach warnings to surface CDP-session contention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable screenshot captures with bounded timeouts and capped retry attempts
  * Distinguishes timeout failures from other errors, waits between retries, and logs per-attempt timings
  * Stronger fallback behavior to alternate capture method when primary capture fails
  * Clearer, more informative warnings and diagnostics to reduce hangs and aid troubleshooting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the single-shot CDP screenshot with a bounded retry loop (up to 3 attempts at 10 s each), adds per-stage timing diagnostics (attach/send/detach), and shields the session detach from `asyncio.wait_for` cancellation to prevent CDP session leaks that the prior implementation was vulnerable to. The previously flagged P1 (dangling sessions on timeout) is resolved by `asyncio.shield(asyncio.wait_for(detach, 2.0))`; the no-tests concern was explicitly deferred by the team.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the prior P1 (CDP session leak on timeout) is addressed and no new P0/P1 issues are introduced.

All remaining findings are P2. The previously raised CDP session-leak concern is resolved with asyncio.shield. There is one minor P2: if the shielded background detach task itself times out, nobody awaits the resulting TimeoutError, which can produce a Python 'Task exception was never retrieved' warning in pathological cases. This does not affect correctness or crash anything.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/notte-browser/src/notte_browser/window.py | Adds CDP screenshot retry loop (3 attempts, 10s each), per-stage timing logs, and shielded detach to prevent session leaks on timeout. Previously flagged P1 (session leak on cancellation) is addressed. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fnotte-browser%2Fsrc%2Fnotte_browser%2Fwindow.py%3A349-352%0A**Unhandled%20exception%20in%20shielded%20background%20task**%0A%0AWhen%20the%20outer%20%60wait_for%60%20cancels%20%60_run%60%2C%20%60asyncio.shield%60%20raises%20%60CancelledError%60%20here%20%28caught%20by%20%60pass%60%29%2C%20but%20the%20inner%20%60wait_for%28detach%2C%202.0%29%60%20continues%20running%20as%20an%20independent%20background%20task.%20If%20%60detach%60%20then%20stalls%20past%202%20s%2C%20that%20inner%20%60wait_for%60%20raises%20%60TimeoutError%60%20inside%20the%20background%20task%20%E2%80%94%20and%20since%20nobody%20ever%20awaits%20the%20shielded%20task%20after%20%60CancelledError%60%20is%20caught%2C%20Python%20will%20emit%20a%20%22Task%20exception%20was%20never%20retrieved%22%20warning.%20To%20suppress%20it%2C%20you%20can%20attach%20a%20no-op%20callback%20to%20the%20shielded%20task%3A%0A%0A%60%60%60python%0Ainner%20%3D%20asyncio.ensure_future%28asyncio.wait_for%28cdp_session.detach%28%29%2C%20timeout%3D2.0%29%29%0Ainner.add_done_callback%28lambda%20t%3A%20t.exception%28%29%20if%20not%20t.cancelled%28%29%20else%20None%29%0Atry%3A%0A%20%20%20%20await%20asyncio.shield%28inner%29%0Aexcept%20asyncio.CancelledError%3A%0A%20%20%20%20pass%0Aexcept%20Exception%20as%20e%3A%0A%20%20%20%20logger.warning%28f%22CDP%20session%20detach%20for%20%7Bself.page.url%7D%20failed%3A%20%7Btype%28e%29.__name__%7D%3A%20%7Be%7D%22%29%0A%60%60%60%0A%0A&repo=nottelabs%2Fnotte&pr=782&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/notte-browser/src/notte_browser/window.py
Line: 349-352

Comment:
**Unhandled exception in shielded background task**

When the outer `wait_for` cancels `_run`, `asyncio.shield` raises `CancelledError` here (caught by `pass`), but the inner `wait_for(detach, 2.0)` continues running as an independent background task. If `detach` then stalls past 2 s, that inner `wait_for` raises `TimeoutError` inside the background task — and since nobody ever awaits the shielded task after `CancelledError` is caught, Python will emit a "Task exception was never retrieved" warning. To suppress it, you can attach a no-op callback to the shielded task:

```python
inner = asyncio.ensure_future(asyncio.wait_for(cdp_session.detach(), timeout=2.0))
inner.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
try:
    await asyncio.shield(inner)
except asyncio.CancelledError:
    pass
except Exception as e:
    logger.warning(f"CDP session detach for {self.page.url} failed: {type(e).__name__}: {e}")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(browser): shield CDP detach from wai..."](https://github.com/nottelabs/notte/commit/ad0a1f49585df7334542fd30d86a179807248bce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29361182)</sub>

<!-- /greptile_comment -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the single-shot CDP screenshot with a bounded retry loop (3 attempts, 10s each), adds per-stage timing diagnostics (attach/send/detach), shields CDP session detach from `asyncio.wait_for` cancellation to prevent session leaks, and propagates a `_skip_cdp` flag through recursion to prevent compounding retry budgets on `PlaywrightTimeoutError`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4d3dcf76cd89a0f7e055fbc3fa88b77e54e4d69f.</sup>
<!-- /MENDRAL_SUMMARY -->