### PR TITLE
docs: don't exec() LLM-generated workflow code in test snippet

### DIFF
--- a/docs/src/features/agents/workflows.mdx
+++ b/docs/src/features/agents/workflows.mdx
@@ -72,6 +72,10 @@ Copy and run the generated Python:
 
 <ExecuteGeneratedCode />
 
+<Warning>
+  Never execute LLM-generated Python with <code>exec()</code> or without review. Save generated code to a file, inspect it, and only run it manually after human approval in an isolated environment.
+</Warning>
+
 ### Use Function API
 
 Run via the function endpoint:

--- a/docs/src/snippets/agents/workflows/test-generated-functions.mdx
+++ b/docs/src/snippets/agents/workflows/test-generated-functions.mdx
@@ -7,7 +7,9 @@
     # Generate function code
     code = agent.workflow.code()
 
-# Test in fresh session
-with client.Session() as session:
-    exec(code.python_script)
+# Save for review before testing in a fresh session
+with open("generated_function.py", "w") as generated_file:
+    generated_file.write(code.python_script)
+
+print("Saved generated_function.py. Review the code before running it in a fresh session.")
 ```

--- a/docs/src/testers/agents/workflows/test-generated-functions.py
+++ b/docs/src/testers/agents/workflows/test-generated-functions.py
@@ -1,5 +1,5 @@
 # @sniptest filename=test-generated-functions.py
-# @sniptest show=6-13
+# @sniptest show=6-17
 from notte_sdk import NotteClient
 
 client = NotteClient()
@@ -10,7 +10,8 @@ with client.Session() as session:
     # Generate function code
     code = agent.workflow.code()
 
-# Test in fresh session
-with client.Session() as session:
-    exec(code.python_script)
-    # Verify it works
+# Save for review before testing in a fresh session
+with open("generated_function.py", "w") as generated_file:
+    generated_file.write(code.python_script)
+
+print("Saved generated_function.py. Review the code before running it in a fresh session.")


### PR DESCRIPTION
## Summary

The documentation snippet that teaches users how to test agent-generated workflow code uses `exec()` on a Python string returned by `agent.workflow.code()`. Because that string is produced by an LLM whose inputs include attacker-controllable web content, copy-pasting and running the snippet can lead to arbitrary code execution on the user's machine.

This PR replaces the `exec()` call in the docs example with a write-to-file pattern and adds a `<Warning>` admonition reminding users to review LLM-generated code before running it.

## Vulnerability details

- **Class:** CWE-94 (Improper Control of Generation of Code — 'Code Injection') via LLM output
- **Affected files:**
  - `docs/src/snippets/agents/workflows/test-generated-functions.mdx`
  - `docs/src/testers/agents/workflows/test-generated-functions.py`
  - `docs/src/features/agents/workflows.mdx` (added warning)
- **Data flow:** A page visited by the agent → captured into the agent's reasoning context → influences `agent.workflow.code()` output → `exec(code.python_script)` in the user's local Python process.

The relevant lines previously read:

```python
# Test in fresh session
with client.Session() as session:
    exec(code.python_script)
```

Anyone following the documented quickstart for "test generated functions" would be running unreviewed LLM-generated code in their own interpreter.

## Fix

Replace the `exec()` with a save-to-file step and prompt the user to review before running:

```python
# Save for review before testing in a fresh session
with open("generated_function.py", "w") as generated_file:
    generated_file.write(code.python_script)

print("Saved generated_function.py. Review the code before running it in a fresh session.")
```

A `<Warning>` block is also added to `workflows.mdx` next to the `<ExecuteGeneratedCode />` snippet so the guidance is visible inline with the example.

## Why this is exploitable

The workflow code generator's prompts incorporate page content the agent has observed during recording. Indirect prompt injection from any visited site (a comment field, a search result, a fake error message in a screenshot, etc.) can steer the model into emitting Python that does whatever the attacker wants — file exfiltration, reverse shell, credential theft from `~/.config`, etc. Users following the docs literally would execute that payload in their own shell with their own privileges.

Preconditions:
1. User copy-pastes the documented snippet (the explicit purpose of the page is to demonstrate the pattern).
2. The recorded workflow's page content can influence the generated script — this is the standard attack surface for any agent that browses untrusted sites.

No additional auth or network position is required beyond the agent visiting attacker-controlled content, which is the normal operating mode.

## What I tested

- `grep -R "exec(code" docs/ packages/` — confirmed no remaining instances of the pattern in the repo after the change.
- Verified the `@sniptest show=` line range was updated (6-13 → 6-17) so the rendered snippet still matches the tester file.
- Diff is minimal and confined to documentation/snippet files; no runtime code is affected.

## Adversarial review

Before submitting, I tried to talk myself out of this. Possible counter-arguments: (a) "it's only docs, not shipped code" — true, but the docs are the canonical instruction set users follow, and the snippet is a complete copy-paste recipe; (b) "users should know not to `exec()` LLM output" — many won't, especially when the official example does exactly that; (c) "there's a sandboxing layer somewhere" — there isn't; the snippet runs in the user's local Python process. None of these neutralize the issue, and the fix has zero functional cost — it just defers execution one manual step.

cc @lewiswigmore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added prominent warnings against direct execution of AI-generated code
  * Updated code examples to demonstrate safer practices: saving generated code to files, manual review, and execution in isolated environments
  * Reinforced importance of human code review and approval before running LLM-generated workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes `exec(code.python_script)` from the "test generated functions" documentation snippet and replaces it with a write-to-file pattern. Adds a `<Warning>` admonition in `workflows.mdx` advising users to review LLM-generated code before running it. Updates the `@sniptest show=` line range to match the new snippet length.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a330e5ba1cc982ceedf27ba9ebf17e10d812318a.</sup>
<!-- /MENDRAL_SUMMARY -->