### PR TITLE
feat: aspect ratio

### DIFF
--- a/docs/src/sdk-reference/manual/session.mdx
+++ b/docs/src/sdk-reference/manual/session.mdx
@@ -100,6 +100,10 @@ You can use the default parameters to create your session, or customize them:
   The height of the viewport
 </ParamField>
 
+<ParamField path="aspect_ratio" type="typing.Optional[typing.Literal['5:4', '16:9']]">
+  Viewport shape preset ("5:4" or "16:9"). Cannot be combined with viewport_width/viewport_height.
+</ParamField>
+
 <ParamField path="cdp_url" type="str | None">
   The CDP URL of another remote session provider.
 </ParamField>

--- a/docs/src/sdk-reference/remotesession/__init__.mdx
+++ b/docs/src/sdk-reference/remotesession/__init__.mdx
@@ -72,6 +72,10 @@ RemoteSession instance configured with the specified parameters.
   The height of the viewport
 </ParamField>
 
+<ParamField path="aspect_ratio" type="typing.Optional[typing.Literal['5:4', '16:9']]">
+  Viewport shape preset ("5:4" or "16:9"). Cannot be combined with viewport_width/viewport_height.
+</ParamField>
+
 <ParamField path="cdp_url" type="str | None">
   The CDP URL of another remote session provider.
 </ParamField>

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -5,7 +5,7 @@ import re
 from enum import StrEnum
 from pathlib import Path
 from types import NoneType
-from typing import Annotated, Any, ClassVar, Literal, Required, cast
+from typing import Annotated, Any, ClassVar, Literal, Required, cast, get_args
 
 from notte_core.actions import (
     ActionUnion,
@@ -57,11 +57,6 @@ DEFAULT_VIEWPORT_WIDTH = config.viewport_width
 DEFAULT_VIEWPORT_HEIGHT = config.viewport_height
 
 AspectRatio = Literal["5:4", "16:9"]
-
-ASPECT_RATIO_VIEWPORTS: dict[AspectRatio, tuple[int, int]] = {
-    "5:4": (1280, 1024),
-    "16:9": (1920, 1080),
-}
 
 DEFAULT_BROWSER_TYPE = config.browser_type
 DEFAULT_USER_AGENT = config.user_agent
@@ -792,7 +787,7 @@ class SessionStartRequest(SdkRequest):
     aspect_ratio: Annotated[
         AspectRatio | None,
         Field(
-            description="Viewport shape preset. When set, populates viewport_width/viewport_height with sensible defaults. Cannot be combined with explicit viewport_width/viewport_height.",
+            description="Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.",
         ),
     ] = None
 
@@ -831,7 +826,7 @@ class SessionStartRequest(SdkRequest):
 
     @model_validator(mode="before")
     @classmethod
-    def expand_aspect_ratio(cls, values: Any) -> Any:
+    def check_aspect_ratio(cls, values: Any) -> Any:
         if not isinstance(values, dict):
             return values
         data = cast(dict[str, Any], values)
@@ -840,11 +835,9 @@ class SessionStartRequest(SdkRequest):
             return data
         if data.get("viewport_width") is not None or data.get("viewport_height") is not None:
             raise ValueError("aspect_ratio cannot be set together with viewport_width or viewport_height")
-        if aspect not in ASPECT_RATIO_VIEWPORTS:
-            raise ValueError(f"Unsupported aspect_ratio {aspect!r}; expected one of {list(ASPECT_RATIO_VIEWPORTS)}")
-        width, height = ASPECT_RATIO_VIEWPORTS[aspect]
-        data["viewport_width"] = width
-        data["viewport_height"] = height
+        allowed = get_args(AspectRatio)
+        if aspect not in allowed:
+            raise ValueError(f"Unsupported aspect_ratio {aspect!r}; expected one of {list(allowed)}")
         return data
 
     @model_validator(mode="after")

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -5,7 +5,7 @@ import re
 from enum import StrEnum
 from pathlib import Path
 from types import NoneType
-from typing import Annotated, Any, ClassVar, Literal, Required
+from typing import Annotated, Any, ClassVar, Literal, Required, cast
 
 from notte_core.actions import (
     ActionUnion,
@@ -55,6 +55,14 @@ DEFAULT_HEADLESS_VIEWPORT_HEIGHT = 1080
 
 DEFAULT_VIEWPORT_WIDTH = config.viewport_width
 DEFAULT_VIEWPORT_HEIGHT = config.viewport_height
+
+AspectRatio = Literal["5:4", "16:9"]
+
+ASPECT_RATIO_VIEWPORTS: dict[AspectRatio, tuple[int, int]] = {
+    "5:4": (1280, 1024),
+    "16:9": (1920, 1080),
+}
+
 DEFAULT_BROWSER_TYPE = config.browser_type
 DEFAULT_USER_AGENT = config.user_agent
 DEFAULT_CHROME_ARGS = config.chrome_args
@@ -710,6 +718,7 @@ class SessionStartRequestDict(TypedDict, total=False):
         chrome_args: Overwrite the chrome instance arguments
         viewport_width: The width of the viewport
         viewport_height: The height of the viewport
+        aspect_ratio: Viewport shape preset ("5:4" or "16:9"). Cannot be combined with viewport_width/viewport_height.
         cdp_url: The CDP URL of another remote session provider.
         use_file_storage: Whether FileStorage should be attached to the session.
         screenshot_type: The type of screenshot to use for the session.
@@ -728,6 +737,7 @@ class SessionStartRequestDict(TypedDict, total=False):
     chrome_args: list[str] | None
     viewport_width: int | None
     viewport_height: int | None
+    aspect_ratio: AspectRatio | None
     cdp_url: str | None
     use_file_storage: bool
     screenshot_type: ScreenshotType
@@ -779,6 +789,12 @@ class SessionStartRequest(SdkRequest):
     )
     viewport_width: Annotated[int | None, Field(description="The width of the viewport")] = DEFAULT_VIEWPORT_WIDTH
     viewport_height: Annotated[int | None, Field(description="The height of the viewport")] = DEFAULT_VIEWPORT_HEIGHT
+    aspect_ratio: Annotated[
+        AspectRatio | None,
+        Field(
+            description="Viewport shape preset. When set, populates viewport_width/viewport_height with sensible defaults. Cannot be combined with explicit viewport_width/viewport_height.",
+        ),
+    ] = None
 
     cdp_url: Annotated[str | None, Field(description="The CDP URL of another remote session provider.")] = (
         config.cdp_url
@@ -812,6 +828,24 @@ class SessionStartRequest(SdkRequest):
             if "max_duration_minutes" not in values:
                 values["max_duration_minutes"] = DEFAULT_SESSION_MAX_DURATION_IN_MINUTES
         return values  # pyright: ignore[reportUnknownVariableType]
+
+    @model_validator(mode="before")
+    @classmethod
+    def expand_aspect_ratio(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+        data = cast(dict[str, Any], values)
+        aspect = data.get("aspect_ratio")
+        if aspect is None:
+            return data
+        if data.get("viewport_width") is not None or data.get("viewport_height") is not None:
+            raise ValueError("aspect_ratio cannot be set together with viewport_width or viewport_height")
+        if aspect not in ASPECT_RATIO_VIEWPORTS:
+            raise ValueError(f"Unsupported aspect_ratio {aspect!r}; expected one of {list(ASPECT_RATIO_VIEWPORTS)}")
+        width, height = ASPECT_RATIO_VIEWPORTS[aspect]
+        data["viewport_width"] = width
+        data["viewport_height"] = height
+        return data
 
     @model_validator(mode="after")
     def check_viewport(self) -> "SessionStartRequest":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an aspect_ratio session option offering preset viewport shapes ("5:4" or "16:9"); not usable with explicit viewport_width/viewport_height.

* **Documentation**
  * Updated SDK reference and manual docs to describe the new aspect_ratio option and its usage constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds an `aspect_ratio` field (`"5:4"` | `"16:9"`) to `SessionStartRequest` and its `TypedDict` counterpart. A `mode="before"` validator rejects the field when combined with explicit `viewport_width`/`viewport_height`. The backend now consumes the raw ratio instead of the client expanding it to hardcoded pixel pairs. Docs updated accordingly.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ab29a762b7b74e250517452b76ebc24f634fcd43.</sup>
<!-- /MENDRAL_SUMMARY -->