### PR TITLE
docs: document minimal iframe embed params

### DIFF
--- a/docs/src/features/sessions/embed-iframe.mdx
+++ b/docs/src/features/sessions/embed-iframe.mdx
@@ -98,11 +98,12 @@ The viewer accepts a few query parameters you can append to `viewer_url` to tune
 
 | Param | Values | Effect |
 |-------|--------|--------|
-| `interactive` | `true` (default) / `false` | When `false`, the viewer is read-only — clicks and keypresses no longer reach the remote browser |
+| `mode` | `embed-minimal` | Shows only the CDP viewer. Without `mode=embed-minimal`, the iframe shows the full Notte viewer, including the step timeline and Notte branding |
+| `interactive` | `0` / `1` | `0` makes the iframe 100% non-interactive. `1` requires the user to click the iframe once before they can interact with the embedded browser |
 | `theme` | `light` / `dark` | Force a theme on the viewer chrome |
 
 ```tsx
-<iframe src={`${viewerUrl}&interactive=false&theme=dark`} />
+<iframe src={`${viewerUrl}&mode=embed-minimal&interactive=1&theme=dark`} />
 ```
 
 ## Sizing the viewport

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -32,6 +32,7 @@
 - [Static IPs](https://docs.notte.cc/features/sessions/static-ips.md): Use dedicated static IP addresses for your browser sessions
 - [Recordings](https://docs.notte.cc/features/sessions/recordings.md): Record and replay your browser sessions for debugging and analysis
 - [Live View](https://docs.notte.cc/features/sessions/live-view.md): Watch your browser sessions in real-time as they execute
+- [Embed in your app](https://docs.notte.cc/features/sessions/embed-iframe.md): Drop the live browser viewer into your own web app via iframe
 - [Browser Extensions](https://docs.notte.cc/features/sessions/browser-extensions.md): Load custom browser extensions in your sessions
 - [Cookies](https://docs.notte.cc/features/sessions/cookies.md): Persist authentication and manage cookies across sessions
 - [Cloudflare Web Bot Auth](https://docs.notte.cc/features/sessions/cloudflare-web-bot-auth.md): Access Cloudflare-protected websites by cryptographically signing browser requests


### PR DESCRIPTION
## Summary
- document `mode=embed-minimal` for iframe embeds
- clarify `interactive=0` and `interactive=1` behavior
- update the iframe parameter example

## Tests
- `uv run pytest docs/src/tests/test_docs_generation.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new mode option (embed-minimal) to display only the CDP viewer in embedded sessions.
  * Changed the interactive parameter from boolean to numeric (0/1); 1 requires a user click before interaction.
  * Updated iframe embedding examples to use the new parameters and theme settings.
  * Added an “Embed in your app” link under Sessions documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Documents the `mode=embed-minimal` query parameter for iframe embeds and clarifies `interactive` param values (changed from boolean `true`/`false` to numeric `0`/`1`), updating the code example accordingly.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ac40f736699eba5904080cd81b3ef98672757b87.</sup>
<!-- /MENDRAL_SUMMARY -->