### PR TITLE
docs: update schedules console link

### DIFF
--- a/docs/src/features/functions/schedules.mdx
+++ b/docs/src/features/functions/schedules.mdx
@@ -33,7 +33,7 @@ Schedules are configured in the [Notte Console](https://console.notte.cc) and ru
 
 ### Via Console
 
-1. Go to [console.notte.cc/workflows](https://console.notte.cc/workflows)
+1. Go to [console.notte.cc/functions](https://console.notte.cc/functions)
 2. Select your Function
 3. Click "Schedule"
 4. Enter cron expression


### PR DESCRIPTION
## Summary
- replace the obsolete console `/workflows` link in Function Schedules with `/functions`

## Notes
- This was a hand-written MDX link in `docs/src/features/functions/schedules.mdx`, not generated output.
- Other `workflows` hits are docs pages or prose references, not console `/workflows` links.

## Tests
- `uv run pytest docs/src/tests/test_docs_generation.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated function scheduling instructions to direct users to the correct interface for managing schedules in the console.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates a single documentation link in `schedules.mdx`, changing the Notte Console URL from `/workflows` to `/functions` to reflect the current console path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 5bf91d685a6a7807048ee0876ddccd02a6706633.</sup>
<!-- /MENDRAL_SUMMARY -->