### PR TITLE
Use functions endpoint for function cURL generation

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -113,7 +113,7 @@ class WorkflowsClient(BaseClient):
         """
         super().__init__(
             root_client=root_client,
-            base_endpoint_path="workflows",
+            base_endpoint_path="functions",
             server_url=server_url,
             api_key=api_key,
             verbose=verbose,

--- a/tests/sdk/test_function_endpoint_paths.py
+++ b/tests/sdk/test_function_endpoint_paths.py
@@ -1,0 +1,16 @@
+from notte_sdk import NotteClient
+
+
+def test_functions_get_curl_uses_functions_endpoint() -> None:
+    client = NotteClient(api_key="test-api-key", server_url="https://api.notte.cc")
+
+    curl = client.functions.get_curl(function_id="function-123", query="hello")
+
+    assert "https://api.notte.cc/functions/function-123/runs/start" in curl
+    assert "/workflows/" not in curl
+
+
+def test_functions_remains_workflows_alias() -> None:
+    client = NotteClient(api_key="test-api-key", server_url="https://api.notte.cc")
+
+    assert client.functions is client.workflows


### PR DESCRIPTION
## Summary
- route the SDK workflow/function client through the `/functions` API path
- add regression coverage for `client.functions.get_curl()` using `/functions/.../runs/start`
- keep `client.functions` as the existing `client.workflows` alias

## Tests
- `uv run pytest tests/sdk/test_function_endpoint_paths.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Routing for workflow-related operations now targets the /functions/ endpoint path instead of /workflows/, ensuring requests hit the correct API route.

* **Tests**
  * Added unit tests to validate the updated endpoint usage and to confirm the workflows alias continues to work for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Routes the SDK workflow/function client through the `/functions` API path by changing `base_endpoint_path` from `"workflows"` to `"functions"`, adds regression tests verifying the new URL and the `client.workflows` alias, and keeps backward compatibility.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a7083c7071b780c26e41c4a90a5ef41b881f9c65.</sup>
<!-- /MENDRAL_SUMMARY -->