### PR TITLE
Relax core function validator requirements

### DIFF
--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -42,9 +42,6 @@ class NotteModule(Protocol):
 class ScriptValidator(RestrictingNodeTransformer):
     """Validates that the AST only contains allowed operations"""
 
-    # Notte-specific operations that must be present in valid scripts
-    NOTTE_OPERATIONS: ClassVar[set[str]] = {"notte.Session", "client.Session", "cli.Session", "c.Session", "n.Session"}
-
     # Safe modules that can be imported in user scripts
     # These modules are considered safe because they don't provide:
     # - File system access (os, pathlib, shutil)
@@ -205,6 +202,12 @@ class ScriptValidator(RestrictingNodeTransformer):
         if node.module is None:
             raise SyntaxError("Relative imports are not allowed")
 
+        if node.module == "__future__":
+            imported_names = {alias.name for alias in node.names}
+            if imported_names == {"annotations"}:
+                return super().visit_ImportFrom(node)
+            raise SyntaxError("Only 'from __future__ import annotations' is allowed")
+
         ScriptValidator.check_valid_import(node.module, import_type="import from")
         return super().visit_ImportFrom(node)
 
@@ -302,18 +305,6 @@ class ScriptValidator(RestrictingNodeTransformer):
 
     @staticmethod
     def parse_script(code_string: str, restricted: bool = True) -> ParsedScriptInfo:
-        found_notte_operations: set[str] = set()
-
-        class StatefulScriptValidator(ScriptValidator):
-            @override
-            def visit_Call(self, node: ast.Call) -> ast.AST:
-                """Override to add custom call restrictions"""
-                call_name = self._get_call_name(node)
-                # Track notte operations
-                if call_name and call_name in self.NOTTE_OPERATIONS:
-                    found_notte_operations.add(call_name)
-                return super().visit_Call(node)
-
         # 1. Parse the AST first to check for run function
         tree = ast.parse(code_string)
 
@@ -331,14 +322,8 @@ class ScriptValidator(RestrictingNodeTransformer):
 
         # 4. Compile with RestrictedPython validation (strict mode only)
         code: types.CodeType = compile_restricted(  # pyright: ignore [reportUnknownVariableType]
-            code_string, filename="<user_script.py>", mode="exec", policy=StatefulScriptValidator
+            code_string, filename="<user_script.py>", mode="exec", policy=ScriptValidator
         )
-
-        # 5. Validate that at least one notte operation is present (strict mode only)
-        if restricted and not found_notte_operations:
-            raise ValueError(
-                f"Python script must contain at least one notte operation ({ScriptValidator.NOTTE_OPERATIONS})"
-            )
 
         return ParsedScriptInfo(code=code, variables=run_parameters)  # pyright: ignore [reportUnknownArgumentType]
 

--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -178,6 +178,12 @@ class ScriptValidator(RestrictingNodeTransformer):
             raise SyntaxError(f"Access to private attribute forbidden: '{node.attr}'")
         return super().visit_Attribute(node)
 
+    @override
+    def check_name(self, node: ast.AST, name: str | None, allow_magic_methods: bool = False) -> None:
+        if name == "__name__" and isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            return
+        return super().check_name(node, name, allow_magic_methods)  # pyright: ignore[reportUnknownMemberType]
+
     @staticmethod
     def check_valid_import(name: str, import_type: Literal["import", "import from"] = "import") -> None:
         # Allow exact matches and explicitly whitelisted submodules

--- a/tests/scripts/test_validator.py
+++ b/tests/scripts/test_validator.py
@@ -547,6 +547,34 @@ def run():
         _ = validator.parse_script(script)
 
 
+def test_main_guard_name_allowed():
+    """Test that scripts can include a standard Python main guard."""
+    script = """
+def run() -> str:
+    return "ok"
+
+if __name__ == "__main__":
+    print(run())
+"""
+    validator = ScriptValidator()
+    info = validator.parse_script(script)
+
+    assert info.variables == []
+
+
+def test_assigning_dunder_name_forbidden():
+    """Test that the main guard exception does not allow rebinding dunder names."""
+    script = """
+def run() -> str:
+    return "ok"
+
+__name__ = "__main__"
+"""
+    validator = ScriptValidator()
+    with pytest.raises(SyntaxError, match='"__name__" is an invalid variable name'):
+        _ = validator.parse_script(script)
+
+
 def test_syntax_error():
     """Test that syntax errors are caught"""
     script = """

--- a/tests/scripts/test_validator.py
+++ b/tests/scripts/test_validator.py
@@ -504,18 +504,46 @@ def test_comments_only_script_forbidden():
         _ = validator.parse_script(script)
 
 
-def test_only_non_notte_operations_forbidden():
-    """Test that scripts with only non-notte operations are forbidden"""
+def test_only_non_notte_operations_allowed():
+    """Test that scripts without notte session operations are allowed."""
     script = """
-def run():
+def run() -> int:
     x = 1
     y = 2
-    result = x + y
-    logger.info("Hello world")
+    return x + y
 
 """
     validator = ScriptValidator()
-    with pytest.raises(ValueError, match="Python script must contain at least one notte operation"):
+    info = validator.parse_script(script)
+
+    assert info.variables == []
+
+
+def test_future_annotations_import_allowed():
+    """Test that scripts can use postponed annotation evaluation."""
+    script = """
+from __future__ import annotations
+
+def run(url: str) -> dict[str, str]:
+    return {"url": url}
+"""
+    validator = ScriptValidator()
+    info = validator.parse_script(script)
+
+    assert [param.name for param in info.variables] == ["url"]
+    assert info.variables[0].type == "str"
+
+
+def test_other_future_imports_forbidden():
+    """Test that only future annotations are allowed."""
+    script = """
+from __future__ import generator_stop
+
+def run():
+    return None
+"""
+    validator = ScriptValidator()
+    with pytest.raises(SyntaxError, match="Only 'from __future__ import annotations' is allowed"):
         _ = validator.parse_script(script)
 
 


### PR DESCRIPTION
## Summary
- align notte-core function script validation with the API validator relaxation
- allow only `from __future__ import annotations` as a future import
- remove the requirement for restricted scripts to call a Notte session operation
- update validator tests for the relaxed behavior

## Tests
- `uv run ruff check packages/notte-core/src/notte_core/ast.py tests/scripts/test_validator.py`
- `uv run pytest tests/scripts/test_validator.py`
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scripts are no longer required to contain specific operations—basic computations alone are now supported
  * Support for Python's `__future__ annotations` feature is now enabled
  * Standard Python script guards (e.g., `if __name__ == "__main__":`) are now accepted
  * Improved validation logic for name handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the requirement for scripts to call a Notte session operation, eliminates the `StatefulScriptValidator` subclass, and adds two targeted relaxations: `__name__` reads are now allowed (enabling `if __name__ == "__main__"` guards), and `from __future__ import annotations` is permitted as the sole `__future__` import.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit bd7897415bf588f6c4e241d5207087042631148d.</sup>
<!-- /MENDRAL_SUMMARY -->