### PR TITLE
feat(browser): add configurable timeout for EvaluateJsAction

### DIFF
--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -744,7 +744,13 @@ class NotteSession(AsyncResource, SyncResource):
                             evaluate_kwargs: dict[str, bool] = {}
                             if config.browser_backend == BrowserBackend.PATCHRIGHT:
                                 evaluate_kwargs["isolated_context"] = False
-                            result = await self.window.page.evaluate(js_code, **evaluate_kwargs)
+                            result = await asyncio.wait_for(
+                                self.window.page.evaluate(js_code, **evaluate_kwargs),
+                                timeout=config.timeout_evaluate_js_ms / 1000.0,
+                            )
+                        except asyncio.TimeoutError:
+                            success = False
+                            message = f"JavaScript evaluation timed out after {config.timeout_evaluate_js_ms}ms"
                         except PlaywrightError as js_err:
                             success = False
                             message = f"JavaScript evaluation failed: {js_err}"

--- a/packages/notte-core/src/notte_core/common/config.py
+++ b/packages/notte-core/src/notte_core/common/config.py
@@ -340,6 +340,7 @@ class NotteConfigDict(TypedDict, total=False):
     timeout_goto_ms: int
     timeout_default_ms: int
     timeout_action_ms: int
+    timeout_evaluate_js_ms: int
     wait_retry_snapshot_ms: int
     wait_short_ms: int
     empty_page_max_retry: int
@@ -443,6 +444,7 @@ class NotteConfig(TomlConfig):
     timeout_goto_ms: int
     timeout_default_ms: int
     timeout_action_ms: int
+    timeout_evaluate_js_ms: int
     wait_retry_snapshot_ms: int
     wait_short_ms: int
     empty_page_max_retry: int

--- a/packages/notte-core/src/notte_core/config.toml
+++ b/packages/notte-core/src/notte_core/config.toml
@@ -65,6 +65,7 @@ enable_pointer_elements = true
 timeout_goto_ms        = 10000
 timeout_default_ms     =  8000
 timeout_action_ms      =  5000
+timeout_evaluate_js_ms = 45000
 wait_retry_snapshot_ms =  1000
 wait_short_ms          =   500
 empty_page_max_retry   = 5


### PR DESCRIPTION
## Summary
- Adds a 45s (default) timeout on `page.evaluate` in `EvaluateJsAction` using `asyncio.wait_for`
- New config field `timeout_evaluate_js_ms` in the standard config system (TOML / `NotteConfig`)
- Returns a clear error message on timeout instead of hanging indefinitely

## Test plan
- [ ] Run an `EvaluateJsAction` with JS that completes quickly — should work as before
- [ ] Run an `EvaluateJsAction` with JS like `new Promise(() => {})` — should timeout after 45s with a clear message
- [ ] Override `timeout_evaluate_js_ms` in a custom config TOML — verify the override is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a configurable `timeout_evaluate_js_ms` (default 45 000 ms) to `EvaluateJsAction`, wrapping `page.evaluate` in `asyncio.wait_for` and returning a clear failure message on timeout. The field is wired through `config.toml`, `NotteConfigDict`, and `Config`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 46550be33094410ef30c0bb6b7670eef33c2fc18.</sup>
<!-- /MENDRAL_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JavaScript evaluation now enforces a configurable timeout (default: 45s).

* **Bug Fixes**
  * JS evaluation timeouts produce clearer failure messages.
  * Backend-specific execution behavior adjusted to improve JS evaluation reliability.

* **Tests / Chores**
  * Test config switched to isolate-based timeout handling.
  * Flaky-test retry logic added to test harness to run isolated retries with delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->