### PR TITLE
Handle boolean additionalProperties in response formats

### DIFF
--- a/packages/notte-core/src/notte_core/utils/pydantic_schema.py
+++ b/packages/notte-core/src/notte_core/utils/pydantic_schema.py
@@ -1,7 +1,7 @@
 # Code taken from:
 import datetime as dt
 from enum import StrEnum
-from typing import Any, ClassVar, Literal, Optional, Union  # type: ignore[attr-defined]
+from typing import Any, ClassVar, Literal, Optional, Union, cast  # type: ignore[attr-defined]
 
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_serializer, field_validator, model_validator
 from typing_extensions import override
@@ -102,7 +102,11 @@ def create_model_from_schema(schema: dict[str, Any]) -> type[BaseModel]:
             else:
                 # Handle generic objects with additionalProperties
                 additional_props = field_schema.get("additionalProperties")
-                value_type = resolve_field_type(additional_props) if additional_props else Any
+                value_type = (
+                    resolve_field_type(cast(dict[str, Any], additional_props))
+                    if isinstance(additional_props, dict)
+                    else Any
+                )
                 return dict[str, value_type]
 
         return field_type  # type: ignore[return-value]

--- a/tests/utils/test_pydantic_utils.py
+++ b/tests/utils/test_pydantic_utils.py
@@ -120,3 +120,29 @@ def test_json_response_format_conversion(json_response_format: dict[str, Any]):
     Format = convert_response_format_to_pydantic_model(json_response_format)
     assert Format is not None
     assert Format.model_json_schema() == json_response_format
+
+
+def test_response_format_with_open_ended_dict_values():
+    class OpenEndedDictResponse(BaseModel):
+        visible_filter_counts: dict[str, Any] | None = None
+
+    schema = OpenEndedDictResponse.model_json_schema()
+    Format = convert_response_format_to_pydantic_model(schema)
+
+    assert Format is not None
+    instance = Format.model_validate(
+        {
+            "visible_filter_counts": {
+                "batch": 2024,
+                "location": {"san_francisco": 12},
+                "labels": ["B2B", "AI"],
+            }
+        }
+    )
+    assert instance.model_dump() == {
+        "visible_filter_counts": {
+            "batch": 2024,
+            "location": {"san_francisco": 12},
+            "labels": ["B2B", "AI"],
+        }
+    }


### PR DESCRIPTION
## Summary
- Treat boolean JSON Schema additionalProperties values as open-ended dict values in response format conversion
- Add regression coverage for Pydantic schemas generated from dict[str, Any]

## Testing
- uv run pytest tests/utils/test_pydantic_utils.py
- uv run ruff check packages/notte-core/src/notte_core/utils/pydantic_schema.py tests/utils/test_pydantic_utils.py
- uv run basedpyright packages/notte-core/src/notte_core/utils/pydantic_schema.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the handling of dictionary properties in response schema conversion to support flexible value types, improving robustness when processing open-ended dictionary fields.

* **Tests**
  * Added test coverage for validating conversion of dictionary fields from JSON schemas into Pydantic models with mixed value types and round-trip serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a crash when JSON Schema `additionalProperties` is a boolean (e.g., `true` or `false`) instead of a dict, by treating non-dict values as open-ended `dict[str, Any]`. Adds a regression test covering `dict[str, Any] | None` Pydantic fields.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e535f977b2c80ae2b57c2af21770d3b7bb0776d8.</sup>
<!-- /MENDRAL_SUMMARY -->