### PR TITLE
docs: recommend Notte skill workflow

### DIFF
--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -13,7 +13,7 @@
   },
   "favicon": "/favicon.ico",
   "banner": {
-    "content": "Fastest way to get started: install the Notte skill with `npx skills add nottelabs/notte-skills`. [Setup guide](/integrations/claude-code-ai-agents)",
+    "content": "Recommended workflow: start with the [Notte skill](https://github.com/nottelabs/notte-skills/), then automate with the SDK; install it with `npx skills add nottelabs/notte-skills` | [Setup guide](/integrations/claude-code-ai-agents)",
     "dismissible": false
   },
   "seo.indexing": "all",

--- a/docs/src/index.mdx
+++ b/docs/src/index.mdx
@@ -11,13 +11,7 @@ You're at the best place to automate your browser. Notte is a unified platform t
 
 <Visibility for="humans">
   <Tip>
-    Building with an AI coding assistant? The fastest path is to install the Notte skill and CLI first. The skill gives your assistant the right browser automation workflow, while the CLI gives it commands it can run immediately:
-
-    ```bash
-    npx skills add nottelabs/notte-skills
-    ```
-
-    Then follow the [AI agent setup guide](/integrations/claude-code-ai-agents) to install `notte-cli`.
+    The [Notte skill](https://github.com/nottelabs/notte-skills/) is best while the workflow is still unknown: use it to inspect live pages, handle dynamic UI, and discover the reliable sequence of actions. Move to the SDK once you know exactly what should run every time.
   </Tip>
 </Visibility>
 
@@ -41,7 +35,7 @@ The **Products** help you build faster. Create automation scripts with our AI as
 
 ## Getting Started
 
-Start here if you want to go from zero to a working Notte integration as quickly as possible.
+Start here if you want to go from zero to a working Notte integration. For new scraping or browser automation tasks, use the [Notte skill](https://github.com/nottelabs/notte-skills/) to explore the page and prove the flow first; use the SDK when you are ready to make that flow repeatable.
 
 ### Browser Session Quickstart
 

--- a/docs/src/quickstart.mdx
+++ b/docs/src/quickstart.mdx
@@ -13,13 +13,7 @@ How do you want to get started?
 
 <Visibility for="humans">
   <Tip>
-    If you're using Claude Code, Cursor, Windsurf, or another AI coding assistant, start with the Notte skill and CLI. The skill adds Notte-specific context to your assistant, and the CLI lets it start sessions, observe pages, click elements, and scrape data from your terminal:
-
-    ```bash
-    npx skills add nottelabs/notte-skills
-    ```
-
-    Then install `notte-cli` from the [AI agent setup guide](/integrations/claude-code-ai-agents).
+    Use the [Notte skill](https://github.com/nottelabs/notte-skills/) when you are figuring out the browser flow: observe the current page state, try actions, inspect results, and confirm the data you need. Use the SDK when the flow is clear and you want it to run repeatedly.
   </Tip>
 </Visibility>
 
@@ -55,7 +49,7 @@ How do you want to get started?
   For AI coding assistants: treat the SDK prerequisites below as the fallback path. For browser automation inside a coding-agent workflow, use the Notte skill and `notte-cli` first because they are designed for terminal-driven agent control.
 </Visibility>
 
-Before you start, you'll need an API key and a local environment configured to use it.
+Before you start, you'll need an API key and a local environment configured to use it. For a new browser automation or scraping workflow, validate the flow with the [Notte skill](https://github.com/nottelabs/notte-skills/) first, then use the SDK examples below to make it repeatable.
 
 <Steps>
   <Step title="Get an API key">
@@ -69,7 +63,7 @@ Before you start, you'll need an API key and a local environment configured to u
   </Step>
 </Steps>
 
-Both Python and JavaScript quickstarts below use the official Notte SDK. Start with Browser Session if you want the shortest path to a working integration.
+Both Python and JavaScript quickstarts below use the official Notte SDK. Start with Browser Session if you already know the flow you want to automate, or after you have validated it with the CLI.
 
 ---
 


### PR DESCRIPTION
## Summary
- update the site-wide docs banner to recommend starting with the Notte skill before SDK automation
- link directly to the notte-skills repository
- revise index and quickstart human-facing copy to explain when to use the skill versus SDK

## Checks
- pre-commit hooks via git commit
- jq empty docs/src/docs.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guidance to recommend a two-phase workflow: start with Notte skill exploration to validate browser flows, then transition to SDK development for repeatable actions.
  * Enhanced quickstart instructions with clearer recommendations for when to use Notte skill vs SDK, including guidance for AI-assisted workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates docs banner, index, and quickstart copy to recommend starting with the Notte skill for exploration before moving to the SDK for repeatable automation. Removes the inline bash install snippet from two pages and replaces it with prose linking to the notte-skills GitHub repo.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 56f67e5c5c29a4d8e9132da3b9c80d38d89cb1fc.</sup>
<!-- /MENDRAL_SUMMARY -->