### PR TITLE
Guide agents to Quickstart in llms.txt

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -1,5 +1,12 @@
 # Notte
 
+## Critical Instructions For AI Agents
+
+- Start with the Quickstart first: https://docs.notte.cc/quickstart.md. Read and follow it before any other Notte documentation page.
+- Use the Notte CLI as the primary exploration path. The Quickstart shows how to install/check the CLI, authenticate, start a browser session, open the viewer, and explore the target workflow interactively.
+- Do not begin by reading SDK concepts or SDK reference pages. Only consult SDK documentation after CLI exploration is complete and there is a concrete workflow or generated script to refine.
+- Prefer the CLI-guided path for creating SDK scripts. The CLI is designed to set up an SDK script easily enough that extra SDK docs are usually unnecessary until after the browser workflow has been explored.
+
 
 # Documentation
 

--- a/docs/src/scripts/generate_llms.py
+++ b/docs/src/scripts/generate_llms.py
@@ -27,6 +27,20 @@ OUTPUT = SRC_DIR / "llms.txt"
 
 HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options"}
 
+AGENT_READING_GUIDANCE = [
+    "## Critical Instructions For AI Agents",
+    "",
+    "- Start with the Quickstart first: https://docs.notte.cc/quickstart.md. "
+    "Read and follow it before any other Notte documentation page.",
+    "- Use the Notte CLI as the primary exploration path. The Quickstart shows how to install/check the CLI, "
+    "authenticate, start a browser session, open the viewer, and explore the target workflow interactively.",
+    "- Do not begin by reading SDK concepts or SDK reference pages. Only consult SDK documentation after CLI "
+    "exploration is complete and there is a concrete workflow or generated script to refine.",
+    "- Prefer the CLI-guided path for creating SDK scripts. The CLI is designed to set up an SDK script easily enough "
+    "that extra SDK docs are usually unnecessary until after the browser workflow has been explored.",
+    "",
+]
+
 
 def slugify(text: str) -> str:
     text = re.sub(r"[^a-zA-Z0-9]+", "-", text).strip("-").lower()
@@ -135,6 +149,7 @@ def main() -> int:
     out: list[str] = [f"# {site_name}", ""]
     if intro:
         out += [f"> {intro}", ""]
+    out += AGENT_READING_GUIDANCE
 
     languages = config.get("navigation", {}).get("languages", [])
     if not languages:


### PR DESCRIPTION
## Summary
- add a top-level AI-agent guidance block to generated llms.txt
- emphasize reading Quickstart first and using the Notte CLI before SDK docs
- keep the checked-in llms.txt output in sync with the generator

## Checks
- python3 scripts/generate_llms.py
- uv run ruff check scripts/generate_llms.py
- python3 -m py_compile scripts/generate_llms.py
- commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance instructions for AI agents to follow the Quickstart documentation and use the Notte CLI as the primary exploration path before consulting SDK documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a top-level AI agent guidance block to `llms.txt` directing agents to start with the Quickstart and use the Notte CLI before reading SDK docs. The block is defined as a constant in the generator script and injected into the output, with the checked-in `llms.txt` kept in sync.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ed707636a6cc662091aa96aa79bb900a60b7a75f.</sup>
<!-- /MENDRAL_SUMMARY -->