### PR TITLE
Fix headless aspect ratio viewport handling

### DIFF
--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -79,6 +79,12 @@ class BrowserWindowOptions(BaseModel):
             raise ValueError("Both viewport_width and viewport_height must be set together or both must be None")
 
         if self.headless and self.viewport_width is None and self.viewport_height is None:
+            if self.cdp_url is not None:
+                logger.info(
+                    "🪟 Headless CDP session detected. Leaving viewport unset so the remote browser geometry is preserved."
+                )
+                return
+
             if self.aspect_ratio is not None:
                 self.viewport_width, self.viewport_height = self._fit_aspect_ratio_in_default_viewport(
                     self.aspect_ratio

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -26,6 +26,7 @@ from notte_core.utils.url import is_valid_url
 from notte_sdk.types import (
     DEFAULT_HEADLESS_VIEWPORT_HEIGHT,
     DEFAULT_HEADLESS_VIEWPORT_WIDTH,
+    AspectRatio,
     Cookie,
     SessionStartRequest,
 )
@@ -55,6 +56,7 @@ class BrowserWindowOptions(BaseModel):
     proxy: PlaywrightProxySettings | None
     viewport_width: int | None
     viewport_height: int | None
+    aspect_ratio: AspectRatio | None = None
     browser_type: BrowserType
     chrome_args: list[str] | None
     web_security: bool
@@ -77,6 +79,17 @@ class BrowserWindowOptions(BaseModel):
             raise ValueError("Both viewport_width and viewport_height must be set together or both must be None")
 
         if self.headless and self.viewport_width is None and self.viewport_height is None:
+            if self.aspect_ratio is not None:
+                self.viewport_width, self.viewport_height = self._fit_aspect_ratio_in_default_viewport(
+                    self.aspect_ratio
+                )
+                message = (
+                    f"🪟 Headless mode detected. Setting viewport to {self.viewport_width}x{self.viewport_height} "
+                    + f"to respect aspect_ratio={self.aspect_ratio}."
+                )
+                logger.info(message)
+                return
+
             width_variation = random.randint(-50, 50)
             height_variation = random.randint(-50, 50)
             logger.warning(
@@ -84,6 +97,17 @@ class BrowserWindowOptions(BaseModel):
             )
             self.viewport_width = DEFAULT_HEADLESS_VIEWPORT_WIDTH + width_variation
             self.viewport_height = DEFAULT_HEADLESS_VIEWPORT_HEIGHT + height_variation
+
+    @staticmethod
+    def _fit_aspect_ratio_in_default_viewport(aspect_ratio: AspectRatio) -> tuple[int, int]:
+        width_ratio, height_ratio = (int(part) for part in aspect_ratio.split(":"))
+
+        width = DEFAULT_HEADLESS_VIEWPORT_WIDTH
+        height = round(width * height_ratio / width_ratio)
+        if height > DEFAULT_HEADLESS_VIEWPORT_HEIGHT:
+            height = DEFAULT_HEADLESS_VIEWPORT_HEIGHT
+            width = round(height * width_ratio / height_ratio)
+        return width, height
 
     def get_chrome_args(self) -> list[str]:
         chrome_args = self.chrome_args or []
@@ -139,6 +163,7 @@ class BrowserWindowOptions(BaseModel):
             chrome_args=request.chrome_args,
             viewport_height=request.viewport_height,
             viewport_width=request.viewport_width,
+            aspect_ratio=request.aspect_ratio,
             cdp_url=request.cdp_url,
             web_security=config.web_security,
             debug_port=config.debug_port,

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -107,13 +107,7 @@ class BrowserWindowOptions(BaseModel):
     @staticmethod
     def _fit_aspect_ratio_in_default_viewport(aspect_ratio: AspectRatio) -> tuple[int, int]:
         width_ratio, height_ratio = (int(part) for part in aspect_ratio.split(":"))
-
-        width = DEFAULT_HEADLESS_VIEWPORT_WIDTH
-        height = round(width * height_ratio / width_ratio)
-        if height > DEFAULT_HEADLESS_VIEWPORT_HEIGHT:
-            height = DEFAULT_HEADLESS_VIEWPORT_HEIGHT
-            width = round(height * width_ratio / height_ratio)
-        return width, height
+        return DEFAULT_HEADLESS_VIEWPORT_WIDTH, round(DEFAULT_HEADLESS_VIEWPORT_WIDTH * height_ratio / width_ratio)
 
     def get_chrome_args(self) -> list[str]:
         chrome_args = self.chrome_args or []

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -835,6 +835,8 @@ class SessionStartRequest(SdkRequest):
             return data
         if data.get("viewport_width") is not None or data.get("viewport_height") is not None:
             raise ValueError("aspect_ratio cannot be set together with viewport_width or viewport_height")
+        data["viewport_width"] = None
+        data["viewport_height"] = None
         allowed = get_args(AspectRatio)
         if aspect not in allowed:
             raise ValueError(f"Unsupported aspect_ratio {aspect!r}; expected one of {list(allowed)}")

--- a/tests/browser/test_window_options.py
+++ b/tests/browser/test_window_options.py
@@ -1,0 +1,41 @@
+import pytest
+from notte_browser.window import BrowserWindowOptions
+from notte_sdk.types import (
+    DEFAULT_HEADLESS_VIEWPORT_HEIGHT,
+    DEFAULT_HEADLESS_VIEWPORT_WIDTH,
+    SessionStartRequest,
+)
+from pydantic import ValidationError
+
+
+def test_headless_window_options_preserve_16_9_aspect_ratio() -> None:
+    request = SessionStartRequest(headless=True, aspect_ratio="16:9")
+
+    options = BrowserWindowOptions.from_request(request)
+
+    assert options.viewport_width == DEFAULT_HEADLESS_VIEWPORT_WIDTH
+    assert options.viewport_height == 720
+
+
+def test_headless_window_options_preserve_5_4_aspect_ratio() -> None:
+    request = SessionStartRequest(headless=True, aspect_ratio="5:4")
+
+    options = BrowserWindowOptions.from_request(request)
+
+    assert options.viewport_width == DEFAULT_HEADLESS_VIEWPORT_WIDTH
+    assert options.viewport_height == 1024
+    assert options.viewport_height <= DEFAULT_HEADLESS_VIEWPORT_HEIGHT
+
+
+def test_explicit_viewport_takes_precedence_over_aspect_ratio_defaulting() -> None:
+    options = BrowserWindowOptions.from_request(
+        SessionStartRequest(headless=True, viewport_width=1000, viewport_height=500)
+    )
+
+    assert options.viewport_width == 1000
+    assert options.viewport_height == 500
+
+
+def test_aspect_ratio_rejects_explicit_viewport() -> None:
+    with pytest.raises(ValidationError, match="aspect_ratio cannot be set together with viewport_width"):
+        SessionStartRequest(headless=True, aspect_ratio="16:9", viewport_width=1000, viewport_height=500)

--- a/tests/browser/test_window_options.py
+++ b/tests/browser/test_window_options.py
@@ -39,3 +39,24 @@ def test_explicit_viewport_takes_precedence_over_aspect_ratio_defaulting() -> No
 def test_aspect_ratio_rejects_explicit_viewport() -> None:
     with pytest.raises(ValidationError, match="aspect_ratio cannot be set together with viewport_width"):
         SessionStartRequest(headless=True, aspect_ratio="16:9", viewport_width=1000, viewport_height=500)
+
+
+def test_headless_cdp_window_options_do_not_synthesize_viewport() -> None:
+    options = BrowserWindowOptions(
+        headless=True,
+        solve_captchas=False,
+        user_agent=None,
+        proxy=None,
+        viewport_width=None,
+        viewport_height=None,
+        aspect_ratio="16:9",
+        browser_type="chromium",
+        chrome_args=None,
+        web_security=False,
+        cdp_url="ws://127.0.0.1:9222/devtools/browser/test",
+        debug_port=None,
+        custom_devtools_frontend=None,
+    )
+
+    assert options.viewport_width is None
+    assert options.viewport_height is None

--- a/tests/integration/test_window_options.py
+++ b/tests/integration/test_window_options.py
@@ -1,0 +1,10 @@
+import pytest
+from notte_browser.session import NotteSession
+
+
+@pytest.mark.asyncio
+async def test_headless_aspect_ratio_sets_browser_viewport() -> None:
+    async with NotteSession(headless=True, aspect_ratio="16:9") as session:
+        viewport = await session.window.page.evaluate("[window.innerWidth, window.innerHeight]")
+
+    assert viewport == [1280, 720]


### PR DESCRIPTION
## Summary
- preserve `aspect_ratio` through `BrowserWindowOptions` so local headless sessions can derive an aspect-matching viewport instead of falling back to the default headless size
- clear implicit SDK viewport defaults when `aspect_ratio` is provided, while still rejecting explicit viewport dimensions combined with `aspect_ratio`
- avoid synthesizing viewport dimensions for headless CDP sessions so remote browser geometry/fingerprint state is preserved

## Why
Remote browser-pod sessions already apply coherent screen/avail/window geometry in the browser service before the worker connects over CDP. Synthesizing a viewport in the worker causes Playwright/CDP viewport emulation to collapse `screen.*` to the viewport size, creating inconsistent fingerprint geometry.

## Tests
- `uv run pytest tests/browser/test_window_options.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added aspect-ratio support for headless browser windows, calculating viewport height from a default headless width (e.g., 16:9, 5:4).
  * When a remote/CDP endpoint is used in headless mode, the viewport is left unset.

* **Bug Fixes**
  * Explicit viewport values continue to override aspect-ratio defaults.
  * Validation now ensures aspect-ratio presets are applied exclusively (clears explicit viewport fields).

* **Tests**
  * Added unit and integration tests covering aspect-ratio behavior and precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `aspect_ratio` support to `BrowserWindowOptions` so headless sessions derive viewport dimensions from an aspect ratio string instead of falling back to the randomised default. CDP sessions short-circuit before viewport synthesis to preserve remote browser geometry. The SDK validator is updated to clear implicit viewport defaults when `aspect_ratio` is provided, and new unit + integration tests cover both paths.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit dca59bcd3417d6887de560494c398b5e90570a62.</sup>
<!-- /MENDRAL_SUMMARY -->