### PR TITLE
Redesign quickstart callout and fix banner light mode

### DIFF
--- a/docs/src/quickstart.mdx
+++ b/docs/src/quickstart.mdx
@@ -9,18 +9,21 @@ import SetApiKey from '/snippets/quickstart/set_api_key.mdx';
 
 <Visibility for="humans">
 
-## Fast setup
-
-The goal is to produce a reliable Python SDK automation script. The recommended path is to use the Notte skill and CLI as the authoring tool first: inspect the live site, validate actions and selectors in a real browser session, then export workflow code with `notte sessions workflow-code`. That generated script is the SDK automation you run, customize, or deploy.
+Build reliable Python SDK automation scripts by authoring in a real browser first. Use the Notte skill and CLI to inspect live sites, validate actions and selectors, then export working code with `notte sessions workflow-code` — ready to run, customize, or deploy.
 
 <div className="notte-fast-setup">
-  <div className="notte-fast-setup__body">
-    <p>
+  <div className="notte-fast-setup__header">
+    <p className="notte-fast-setup__title">Launch your AI coding agent</p>
+    <p className="notte-fast-setup__desc">
       Copy this into your AI coding agent (Codex, Claude Code, Cursor, etc.). It installs the Notte skill, checks the CLI, authenticates your account, opens a live browser session, and points the agent toward generating SDK workflow code instead of hand-writing fragile browser automation.
     </p>
-    <button
-      type="button"
-      className="notte-fast-setup__button"
+  </div>
+
+  <div className="notte-fast-setup__divider" />
+
+  <button
+    type="button"
+    className="notte-fast-setup__button"
       onClick={(event) => {
         const button = event.currentTarget;
         const label = button.querySelector(".notte-fast-setup__button-label");
@@ -794,9 +797,45 @@ The goal is to produce a reliable Python SDK automation script. The recommended 
         }, 1600);
       }}
     >
-      <span className="notte-fast-setup__button-icon" aria-hidden="true" />
-      <span className="notte-fast-setup__button-label" aria-live="polite">Copy setup prompt</span>
+      <span className="notte-fast-setup__button-icon-wrap" aria-hidden="true">
+        <Icon icon="copy" size={18} color="#00c85a" />
+      </span>
+      <span className="notte-fast-setup__button-text">
+        <span className="notte-fast-setup__button-label" aria-live="polite">Copy setup prompt</span>
+        <span className="notte-fast-setup__button-subtitle">Click to copy to your clipboard</span>
+      </span>
+      <Icon icon="chevron-right" size={16} className="notte-fast-setup__button-arrow" />
     </button>
+
+  <div className="notte-fast-setup__features">
+    <div className="notte-fast-setup__feature">
+      <Icon icon="download" size={28} color="#00c85a" />
+      <div>
+        <span className="notte-fast-setup__feature-title">Installs</span>
+        <span className="notte-fast-setup__feature-sub">Notte skill</span>
+      </div>
+    </div>
+    <div className="notte-fast-setup__feature">
+      <Icon icon="terminal" size={28} color="#00c85a" />
+      <div>
+        <span className="notte-fast-setup__feature-title">Checks</span>
+        <span className="notte-fast-setup__feature-sub">the CLI</span>
+      </div>
+    </div>
+    <div className="notte-fast-setup__feature">
+      <Icon icon="user" size={28} color="#00c85a" />
+      <div>
+        <span className="notte-fast-setup__feature-title">Authenticates</span>
+        <span className="notte-fast-setup__feature-sub">your account</span>
+      </div>
+    </div>
+    <div className="notte-fast-setup__feature">
+      <Icon icon="tv" size={28} color="#00c85a" />
+      <div>
+        <span className="notte-fast-setup__feature-title">Opens</span>
+        <span className="notte-fast-setup__feature-sub">live session</span>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -58,6 +58,11 @@ html:not(.dark) #banner {
   color: rgb(20, 83, 45) !important;
 }
 
+html:not(.dark) #banner p,
+html:not(.dark) #banner span {
+  color: rgb(20, 83, 45) !important;
+}
+
 html:not(.dark) #banner code {
   background: rgb(220, 252, 231) !important;
   color: rgb(20, 83, 45) !important;
@@ -70,129 +75,216 @@ html:not(.dark) #banner a {
 
 .notte-fast-setup {
   margin: 1rem 0 0.75rem;
-  padding: clamp(1.25rem, 3.2vw, 2.4rem);
-  border: 1px solid rgba(0, 230, 115, 0.22);
-  border-radius: 0.75rem;
-  background: rgba(0, 184, 92, 0.09);
+  padding: clamp(1.5rem, 3.2vw, 2.5rem);
+  border: 1px solid rgba(0, 230, 115, 0.18);
+  border-radius: 0.875rem;
+  background: transparent;
 }
 
-.notte-fast-setup__body {
+.notte-fast-setup__header {
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 0.4rem;
 }
 
-.notte-fast-setup__body p {
-  margin: 0;
-  max-width: 68rem;
-  color: rgb(188, 201, 194);
-  font-size: 1rem;
-  line-height: 1.65;
+.notte-fast-setup__title {
+  margin: 0 !important;
+  font-size: 1.35rem !important;
+  font-weight: 700 !important;
+  line-height: 1.3 !important;
+  color: var(--tw-prose-headings, inherit) !important;
+}
+
+.notte-fast-setup__desc {
+  margin: 0.4rem 0 0 !important;
+  max-width: 60rem;
+  color: rgb(170, 185, 178);
+  font-size: 0.95rem !important;
+  line-height: 1.6 !important;
+}
+
+.notte-fast-setup__divider {
+  height: 1px;
+  margin: 1.5rem 0;
+  background: rgba(0, 230, 115, 0.12);
 }
 
 .notte-fast-setup__button {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.875rem;
+  gap: 1rem;
   width: 100%;
-  min-height: clamp(3.4rem, 4.8vw, 4.4rem);
-  border: 1px solid rgba(0, 230, 115, 0.46);
-  border-radius: 0.25rem;
-  background: rgb(0, 230, 115);
-  color: rgb(2, 20, 11);
+  padding: 0.875rem 1.25rem;
+  border: 1px solid rgba(0, 230, 115, 0.22);
+  border-radius: 0.75rem;
+  background: rgba(0, 184, 92, 0.05);
   font: inherit;
-  font-size: clamp(1rem, 1.2vw, 1.15rem);
-  font-weight: 750;
   cursor: pointer;
-  box-shadow: 0 0 0 0 rgba(0, 230, 115, 0);
   transition:
     background-color 160ms ease,
     border-color 160ms ease,
-    box-shadow 160ms ease,
-    transform 120ms ease;
+    box-shadow 160ms ease;
 }
 
 .notte-fast-setup__button:hover {
-  background: rgb(89, 255, 171);
-  border-color: rgba(161, 255, 205, 0.9);
-  transform: translateY(-1px);
+  background: rgba(0, 184, 92, 0.1);
+  border-color: rgba(0, 230, 115, 0.35);
+  box-shadow: 0 2px 12px rgba(0, 184, 92, 0.1);
 }
 
 .notte-fast-setup__button:active {
-  transform: translateY(0) scale(0.985);
-  box-shadow: 0 0 0 0.35rem rgba(0, 230, 115, 0.13);
+  background: rgba(0, 184, 92, 0.14);
 }
 
 .notte-fast-setup__button.is-copied {
   animation: notte-copy-confirm 260ms ease-out;
-  background: rgb(89, 255, 171);
-  border-color: rgba(161, 255, 205, 0.9);
+  border-color: rgba(0, 230, 115, 0.4);
 }
 
 .notte-fast-setup__button:focus-visible {
-  outline: 3px solid rgba(161, 255, 205, 0.62);
-  outline-offset: 4px;
+  outline: 2px solid rgba(0, 190, 95, 0.5);
+  outline-offset: 2px;
 }
 
-.notte-fast-setup__button-icon {
-  position: relative;
-  width: 1.15em;
-  height: 1.15em;
-  flex: 0 0 auto;
+.notte-fast-setup__button-icon-wrap {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  background: rgba(0, 184, 92, 0.1);
 }
 
-.notte-fast-setup__button-icon::before,
-.notte-fast-setup__button-icon::after {
-  position: absolute;
-  width: 0.62em;
-  height: 0.72em;
-  border: 0.13em solid currentcolor;
-  border-radius: 0.16em;
-  content: "";
+.notte-fast-setup__button-text {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  flex: 1;
+  gap: 0.125rem;
 }
 
-.notte-fast-setup__button-icon::before {
-  top: 0.32em;
-  left: 0.08em;
-  opacity: 0.62;
+.notte-fast-setup__button-label {
+  color: rgb(0, 230, 115);
+  font-weight: 600;
+  font-size: 0.95rem;
 }
 
-.notte-fast-setup__button-icon::after {
-  top: 0.08em;
-  left: 0.36em;
-  background: transparent;
+.notte-fast-setup__button-subtitle {
+  color: rgb(140, 155, 148);
+  font-size: 0.82rem;
+}
+
+.notte-fast-setup__button-arrow {
+  flex-shrink: 0;
+  opacity: 0.6;
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.notte-fast-setup__button:hover .notte-fast-setup__button-arrow {
+  opacity: 1;
+  transform: translateX(2px);
+}
+
+.notte-fast-setup__features {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: 1.5rem;
+}
+
+.notte-fast-setup__feature {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.25rem 0.75rem;
+  border-right: 1px solid rgba(0, 230, 115, 0.1);
+}
+
+.notte-fast-setup__feature > svg {
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.notte-fast-setup__feature:last-child {
+  border-right: none;
+}
+
+.notte-fast-setup__feature-title {
+  display: block;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.notte-fast-setup__feature-sub {
+  display: block;
+  color: rgb(140, 155, 148);
+  font-size: 0.78rem;
 }
 
 html:not(.dark) .notte-fast-setup {
-  border-color: rgba(4, 119, 59, 0.18);
-  background: rgb(237, 252, 243);
+  border-color: rgba(0, 140, 70, 0.15);
+  background: transparent;
 }
 
-html:not(.dark) .notte-fast-setup__body p {
-  color: rgb(74, 85, 79);
+html:not(.dark) .notte-fast-setup__desc {
+  color: rgb(80, 95, 88);
+}
+
+html:not(.dark) .notte-fast-setup__divider {
+  background: rgba(0, 140, 70, 0.1);
+}
+
+html:not(.dark) .notte-fast-setup__button {
+  border-color: rgba(0, 140, 70, 0.15);
+  background: rgba(0, 160, 80, 0.04);
+}
+
+html:not(.dark) .notte-fast-setup__button:hover {
+  background: rgba(0, 160, 80, 0.08);
+  border-color: rgba(0, 140, 70, 0.25);
+  box-shadow: 0 2px 12px rgba(0, 140, 70, 0.06);
+}
+
+html:not(.dark) .notte-fast-setup__button-icon-wrap {
+  background: rgba(0, 160, 80, 0.08);
+}
+
+html:not(.dark) .notte-fast-setup__button-label {
+  color: rgb(0, 140, 70);
+}
+
+html:not(.dark) .notte-fast-setup__button-subtitle {
+  color: rgb(100, 115, 108);
+}
+
+html:not(.dark) .notte-fast-setup__feature {
+  border-color: rgba(0, 140, 70, 0.1);
+}
+
+html:not(.dark) .notte-fast-setup__feature-sub {
+  color: rgb(100, 115, 108);
 }
 
 @media (max-width: 720px) {
   .notte-fast-setup {
-    padding: 1.5rem;
+    padding: 1.25rem;
   }
 
-  .notte-fast-setup__body {
-    gap: 1.25rem;
+  .notte-fast-setup__features {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+  }
+
+  .notte-fast-setup__feature {
+    border-right: none;
+    padding: 0;
   }
 }
 
 @keyframes notte-copy-confirm {
-  0% {
-    transform: scale(0.985);
-  }
-
-  65% {
-    transform: scale(1.012);
-  }
-
-  100% {
-    transform: scale(1);
-  }
+  0% { transform: scale(0.985); }
+  65% { transform: scale(1.008); }
+  100% { transform: scale(1); }
 }


### PR DESCRIPTION
## Summary
- Fix banner text being invisible in light mode by explicitly targeting `<p>` and `<span>` children inside `#banner`
- Redesign the quickstart setup prompt callout: structured header with title, card-style copy button with icon/subtitle/chevron, and a 4-column feature chip row (Installs, Checks, Authenticates, Opens)
- Add proper dark/light mode styling for all new elements and mobile responsiveness (2-column feature grid on small screens)
- Trim intro copy to be more concise and use active voice

## Test plan
- [ ] Verify banner text is readable in both light and dark mode
- [ ] Verify the callout renders correctly in dark mode
- [ ] Verify the callout renders correctly in light mode
- [ ] Click "Copy setup prompt" and confirm clipboard copy still works
- [ ] Check mobile viewport — feature chips should collapse to 2 columns
- [ ] Verify "Copied" feedback text appears after clicking the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote and restructured the Fast setup guide into a header-driven layout with clearer title, description, divider and four labeled setup steps (Installs, Checks, Authenticates, Opens)
  * Updated clipboard/button copy text layout to show icon, label and subtitle

* **Style**
  * Redesigned the setup section visuals: full-width button layout, feature grid, light-mode banner text color and mobile/layout adjustments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Redesigns the quickstart setup callout with a structured header, card-style copy button with icon/subtitle/chevron, and a 4-column feature chip row. Also fixes banner text being invisible in light mode by explicitly targeting `p` and `span` children of `#banner`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6a261e823c8ecc4eae8c59f59c155c2a6c9e9e7a.</sup>
<!-- /MENDRAL_SUMMARY -->