### PR TITLE
test: bound test_signup_email_extraction with thread-method timeout

### DIFF
--- a/tests/browser/test_tools.py
+++ b/tests/browser/test_tools.py
@@ -52,6 +52,7 @@ def test_tool_execution_in_session(persona: NottePersona, action: EmailReadActio
         assert len(out.data.structured.get().emails) > 0
 
 
+@pytest.mark.timeout(120, method="thread")
 @pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_signup_email_extraction(persona: NottePersona):
     with notte.Session(headless=True) as session:


### PR DESCRIPTION
## Problem

`tests/browser/test_tools.py::test_signup_email_extraction` is a live end-to-end test against `console.notte.cc`, marked `@pytest.mark.flaky(reruns=3, reruns_delay=5)`. The repo-wide `timeout = 300` in `pyproject.toml` uses the default `signal` method, which relies on `SIGALRM` and does not preempt subprocess waits or blocking C-extension I/O.

Observed: pytest reaches this test, the test fails once, `pytest-rerunfailures` triggers `RERUN`, the rerun hangs indefinitely. Runner cancels the whole `pytest cicd` job after ~11 minutes of silence.

Reproduces on recent main pushes (commits `eddc2c0c`, `fafa8db`) and on every feature branch that runs `pytest cicd`. Affects PR #758 today.

## Fix

Add `@pytest.mark.timeout(120, method="thread")` above the existing flaky marker. The thread-method watchdog uses `_thread.interrupt_main()` which can preempt blocking operations where `signal` cannot. 120 s is generous against a happy-path run of 60-90 s; worst case the test fails fast and the rest of the suite proceeds.

## Test plan

- [ ] Push and observe the next `pytest cicd` run on this branch completes without job-level cancellation
- [ ] If the timeout fires cleanly (test fails rather than hangs), follow up separately to either tune the value or move the live `console.notte.cc` tests to a dedicated job

## Out-of-scope follow-ups worth considering

- Reduce `reruns=3` to `reruns=1` so worst-case stack is `1 * 120s` instead of `3 * 120s`
- Move live `console.notte.cc` tests behind a `slow` or `live` marker and exclude from the default `tests` matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added execution time limits to improve test reliability and prevent hanging tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `@pytest.mark.timeout(120, method="thread")` to `test_signup_email_extraction` to prevent indefinite hangs when pytest-rerunfailures triggers reruns on a blocked test. The thread-method watchdog uses `_thread.interrupt_main()` which can preempt blocking I/O where the default `signal`/`SIGALRM` method cannot.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 14a2338bca46f839f121577e0dad994fb8bfbe18.</sup>
<!-- /MENDRAL_SUMMARY -->