### PR TITLE
Fix agent action and log stream timeouts

### DIFF
--- a/packages/notte-browser/src/notte_browser/controller.py
+++ b/packages/notte-browser/src/notte_browser/controller.py
@@ -222,11 +222,26 @@ class BrowserController:
             # Interaction actions
             case ClickAction():
                 is_disabled = await locator.evaluate(
-                    """(el) =>
-                        el.disabled === true ||
-                        el.inert === true ||
-                        el.getAttribute('disabled') !== null ||
-                        el.getAttribute('aria-disabled') === 'true'
+                    """(el) => {
+                        const isDisabled = (node) =>
+                            node.disabled === true ||
+                            node.inert === true ||
+                            node.getAttribute('disabled') !== null ||
+                            node.getAttribute('aria-disabled') === 'true';
+                        let node = el;
+                        while (node !== null) {
+                            if (isDisabled(node)) {
+                                return true;
+                            }
+                            if (node.assignedSlot) {
+                                node = node.assignedSlot;
+                                continue;
+                            }
+                            const root = node.getRootNode && node.getRootNode();
+                            node = root instanceof ShadowRoot ? root.host : node.parentElement;
+                        }
+                        return false;
+                    }
                     """,
                     timeout=action_timeout,
                 )

--- a/packages/notte-browser/src/notte_browser/controller.py
+++ b/packages/notte-browser/src/notte_browser/controller.py
@@ -221,6 +221,17 @@ class BrowserController:
         match action:
             # Interaction actions
             case ClickAction():
+                is_disabled = await locator.evaluate(
+                    """(el) =>
+                        el.disabled === true ||
+                        el.inert === true ||
+                        el.getAttribute('disabled') !== null ||
+                        el.getAttribute('aria-disabled') === 'true'
+                    """,
+                    timeout=action_timeout,
+                )
+                if is_disabled:
+                    raise ActionExecutionError(action.id, window.page.url, reason="Element is disabled")
                 try:
                     await locator.click(timeout=action_timeout)
                 except PlaywrightTimeoutError as e:

--- a/packages/notte-browser/src/notte_browser/dom/buildDomNode.js
+++ b/packages/notte-browser/src/notte_browser/dom/buildDomNode.js
@@ -490,6 +490,38 @@
 		return cursorStates.isInteractive || cursorStates.isHoverInteractive;
 	}
 
+	const NON_INTERACTIVE_CURSORS = new Set(['not-allowed', 'no-drop', 'wait', 'progress', 'initial', 'inherit']);
+
+	function getDisabledReason(element, style) {
+		if (style?.cursor && NON_INTERACTIVE_CURSORS.has(style.cursor)) {
+			return 'DISABLED_CURSOR';
+		}
+		if (
+			element.hasAttribute('disabled') ||
+			element.getAttribute('disabled') === 'true' ||
+			element.getAttribute('disabled') === '' ||
+			element.getAttribute('aria-disabled') === 'true'
+		) {
+			return 'DISABLED_ATTRIBUTE';
+		}
+		if (element.disabled) {
+			return 'DISABLED_PROPERTY';
+		}
+		if (
+			element.hasAttribute('readonly') ||
+			element.getAttribute('readonly') === 'true' ||
+			element.getAttribute('readonly') === '' ||
+			element.getAttribute('aria-readonly') === 'true' ||
+			element.readOnly
+		) {
+			return 'DISABLED_READONLY';
+		}
+		if (element.inert || element.hasAttribute('inert') || element.getAttribute('aria-inert') === 'true') {
+			return 'DISABLED_INERT';
+		}
+		return null;
+	}
+
 
 	/**
 	 * Checks if an element is interactive (general interactivity detection).
@@ -509,6 +541,11 @@
 		// Cache the tagName and style lookups
 		const tagName = element.tagName.toLowerCase();
 		const style = getCachedComputedStyle(element);
+
+		const disabledReason = getDisabledReason(element, style);
+		if (disabledReason !== null) {
+			return disabledReason;
+		}
 
 		// Check if element has pointer cursor using the dedicated function
 		let isInteractiveCursor = isPointerElementWithHover(element);
@@ -939,6 +976,10 @@
 	 */
 	function isElementDistinctInteraction(element) {
 		if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+			return false;
+		}
+
+		if (getDisabledReason(element, getCachedComputedStyle(element)) !== null) {
 			return false;
 		}
 

--- a/packages/notte-browser/src/notte_browser/dom/buildDomNode.js
+++ b/packages/notte-browser/src/notte_browser/dom/buildDomNode.js
@@ -490,7 +490,7 @@
 		return cursorStates.isInteractive || cursorStates.isHoverInteractive;
 	}
 
-	const NON_INTERACTIVE_CURSORS = new Set(['not-allowed', 'no-drop', 'wait', 'progress', 'initial', 'inherit']);
+	const NON_INTERACTIVE_CURSORS = new Set(['not-allowed', 'no-drop', 'wait', 'progress']);
 
 	function getDisabledReason(element, style) {
 		if (style?.cursor && NON_INTERACTIVE_CURSORS.has(style.cursor)) {
@@ -506,15 +506,6 @@
 		}
 		if (element.disabled) {
 			return 'DISABLED_PROPERTY';
-		}
-		if (
-			element.hasAttribute('readonly') ||
-			element.getAttribute('readonly') === 'true' ||
-			element.getAttribute('readonly') === '' ||
-			element.getAttribute('aria-readonly') === 'true' ||
-			element.readOnly
-		) {
-			return 'DISABLED_READONLY';
 		}
 		if (element.inert || element.hasAttribute('inert') || element.getAttribute('aria-inert') === 'true') {
 			return 'DISABLED_INERT';
@@ -560,9 +551,7 @@
 			'not-allowed', // Action not allowed
 			'no-drop',     // Drop not allowed
 			'wait',        // Processing
-			'progress',    // In progress
-			'initial',     // Initial value
-			'inherit'      // Inherited value
+			'progress'     // In progress
 			//? Let's just include all potentially clickable elements that are not specifically blocked
 			// 'none',        // No cursor
 			// 'default',     // Default cursor
@@ -589,7 +578,7 @@
 		const explicitDisableTags = new Set([
 			'disabled',           // Standard disabled attribute
 			// 'aria-disabled',      // ARIA disabled state
-			'readonly',          // Read-only state
+			// 'readonly',          // Read-only state
 			// 'aria-readonly',     // ARIA read-only state
 			// 'aria-hidden',       // Hidden from accessibility
 			// 'hidden',            // Hidden attribute
@@ -618,11 +607,6 @@
 			// Check for disabled property on form elements
 			if (element.disabled) {
 				return 'DISABLED_PROPERTY';
-			}
-
-			// Check for readonly property on form elements
-			if (element.readOnly) {
-				return 'DISABLED_READONLY';
 			}
 
 			// Check for inert property

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -780,7 +780,13 @@ class NotteSession(AsyncResource, SyncResource):
                             raise NoToolProvidedError(resolved_action)
                     case _:
                         resolved_action = await self._action_with_vault(resolved_action)
-                        success = await self.controller.execute(self.window, resolved_action, self._snapshot)
+                        if isinstance(resolved_action, InteractionAction):
+                            success = await asyncio.wait_for(
+                                self.controller.execute(self.window, resolved_action, self._snapshot),
+                                timeout=resolved_action.timeout / 1000.0,
+                            )
+                        else:
+                            success = await self.controller.execute(self.window, resolved_action, self._snapshot)
 
             except (NoSnapshotObservedError, NoStorageObjectProvidedError, NoToolProvidedError) as e:
                 # this should be handled by the caller
@@ -792,6 +798,14 @@ class NotteSession(AsyncResource, SyncResource):
             except RateLimitError as e:
                 success = False
                 message = "Rate limit reached. Waiting before retry."
+                exception = e
+            except asyncio.TimeoutError as e:
+                success = False
+                message = (
+                    f"Action timed out after {resolved_action.timeout}ms"
+                    if isinstance(resolved_action, InteractionAction)
+                    else "Action timed out."
+                )
                 exception = e
             except NotteBaseError as e:
                 # When raise_on_failure is True, we use the dev message to give more details to the user
@@ -843,7 +857,10 @@ class NotteSession(AsyncResource, SyncResource):
 
         # add screenshot to trajectory (after the execution)
         if self._window is not None:
-            _ = await self.ascreenshot()
+            try:
+                _ = await self.ascreenshot()
+            except Exception as e:
+                logger.warning(f"Failed to capture post-action screenshot: {e}")
 
         _raise_on_failure = raise_on_failure if raise_on_failure is not None else self.default_raise_on_failure
         if _raise_on_failure and exception is not None:

--- a/packages/notte-core/src/notte_core/actions/actions.py
+++ b/packages/notte-core/src/notte_core/actions/actions.py
@@ -987,7 +987,7 @@ class InteractionAction(BaseAction, metaclass=ABCMeta):
     press_enter: bool | None = Field(default=None)
     text_label: str | None = Field(default=None)
     param: ActionParameter | None = Field(default=None, exclude=True)
-    timeout: int = Field(default=config.timeout_action_ms, description="Action timeout in milliseconds")
+    timeout: int = Field(default=config.timeout_action_ms, gt=0, description="Action timeout in milliseconds")
 
     INTERACTION_ACTION_REGISTRY: ClassVar[dict[str, typeAlias["InteractionAction"]]] = {}
 

--- a/packages/notte-core/src/notte_core/common/config.py
+++ b/packages/notte-core/src/notte_core/common/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Literal, Required, Self, Unpack
 
 import toml
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, Field, computed_field
 from typing_extensions import TypedDict, override
 
 from notte_core import LoggingSetup
@@ -435,8 +435,8 @@ class NotteConfig(TomlConfig):
     # [agent]
     max_steps: int
     use_vision: bool
-    agent_logs_inactivity_timeout_seconds: float
-    agent_status_poll_timeout_seconds: float
+    agent_logs_inactivity_timeout_seconds: float = Field(gt=0)
+    agent_status_poll_timeout_seconds: float = Field(gt=0)
 
     # [dom_parsing]
     highlight_elements: bool

--- a/packages/notte-core/src/notte_core/common/config.py
+++ b/packages/notte-core/src/notte_core/common/config.py
@@ -329,6 +329,8 @@ class NotteConfigDict(TypedDict, total=False):
     # [agent]
     max_steps: int
     use_vision: bool
+    agent_logs_inactivity_timeout_seconds: float | None
+    agent_status_poll_timeout_seconds: float
 
     # [dom_parsing]
     highlight_elements: bool
@@ -433,6 +435,8 @@ class NotteConfig(TomlConfig):
     # [agent]
     max_steps: int
     use_vision: bool
+    agent_logs_inactivity_timeout_seconds: float | None
+    agent_status_poll_timeout_seconds: float
 
     # [dom_parsing]
     highlight_elements: bool

--- a/packages/notte-core/src/notte_core/common/config.py
+++ b/packages/notte-core/src/notte_core/common/config.py
@@ -329,7 +329,7 @@ class NotteConfigDict(TypedDict, total=False):
     # [agent]
     max_steps: int
     use_vision: bool
-    agent_logs_inactivity_timeout_seconds: float | None
+    agent_logs_inactivity_timeout_seconds: float
     agent_status_poll_timeout_seconds: float
 
     # [dom_parsing]
@@ -435,7 +435,7 @@ class NotteConfig(TomlConfig):
     # [agent]
     max_steps: int
     use_vision: bool
-    agent_logs_inactivity_timeout_seconds: float | None
+    agent_logs_inactivity_timeout_seconds: float
     agent_status_poll_timeout_seconds: float
 
     # [dom_parsing]

--- a/packages/notte-core/src/notte_core/config.toml
+++ b/packages/notte-core/src/notte_core/config.toml
@@ -9,6 +9,8 @@ use_vision = true
 highlight_elements = true
 # max_history_tokens = 32000
 max_steps = 20
+agent_logs_inactivity_timeout_seconds = 300.0
+agent_status_poll_timeout_seconds = 300.0
 
 # [error]
 max_error_length = 500

--- a/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Unpack, overload
 # import websockets
 from halo import Halo  # pyright: ignore[reportMissingTypeStubs]
 from notte_core.agent_types import AgentCompletion
+from notte_core.common.config import config
 from notte_core.common.logging import logger
 from notte_core.common.notifier import BaseNotifier
 from notte_core.common.telemetry import track_usage
@@ -50,7 +51,10 @@ if RUNNING_IN_PYODIDE:
     from pyodide.ffi import (  # pyright: ignore[reportMissingImports]
         create_proxy,  # pyright: ignore[reportUnknownVariableType]
     )
+
+    ConnectionClosedOK = ConnectionError
 else:
+    from websockets.exceptions import ConnectionClosedOK
     from websockets.sync import client as sync_client
 
 
@@ -333,7 +337,12 @@ class AgentsClient(BaseClient):
                 logger.error(f"Error parsing agent logs for message: {message}: {e}")
             return (None, False)
 
-    def watch_logs(self, agent_id: str, session_id: str, log: bool = True) -> AgentStatusResponse | None:
+    def watch_logs(
+        self,
+        agent_id: str,
+        session_id: str,
+        log: bool = True,
+    ) -> AgentStatusResponse | None:
         """
         Watch the logs of the specified agent.
         """
@@ -358,7 +367,16 @@ class AgentsClient(BaseClient):
                 close_timeout=5,
                 max_size=5 * (2**20),  # 5MB max size
             ) as websocket:
-                for message in websocket:
+                while True:
+                    try:
+                        message = websocket.recv(timeout=config.agent_logs_inactivity_timeout_seconds)
+                    except TimeoutError:
+                        warning_message = (
+                            f"[Agent] {agent_id} websocket had no log events for "
+                            f"{config.agent_logs_inactivity_timeout_seconds}s. Falling back to status polling."
+                        )
+                        logger.warning(warning_message)
+                        return None
                     if not isinstance(message, str):
                         logger.warning(f"Expected str message, got {type(message).__name__}. Skipping.")
                         continue
@@ -369,6 +387,8 @@ class AgentsClient(BaseClient):
                         if isinstance(response, AgentStatusResponse):
                             return response
                         return None
+        except ConnectionClosedOK:
+            return None
         except ConnectionError as e:
             logger.error(f"Connection error: {agent_id} {e}")
             return None
@@ -376,9 +396,12 @@ class AgentsClient(BaseClient):
             logger.error(f"Unexpected websocket processing error: {agent_id} {e} {traceback.format_exc()}")
             raise
 
-        return None
-
-    def watch_logs_and_wait(self, agent_id: str, session_id: str, log: bool = True) -> AgentStatusResponse:
+    def watch_logs_and_wait(
+        self,
+        agent_id: str,
+        session_id: str,
+        log: bool = True,
+    ) -> AgentStatusResponse:
         """
         Execute a task with the agent and wait for completion.
 
@@ -397,20 +420,24 @@ class AgentsClient(BaseClient):
             )
 
         try:
-            response = self.watch_logs(agent_id=agent_id, session_id=session_id, log=log)
+            response = self.watch_logs(
+                agent_id=agent_id,
+                session_id=session_id,
+                log=log,
+            )
             if response is not None:
                 return response
             # If we didn't get a response, poll status until agent is closed
             logger.warning(f"[Agent] {agent_id} did not return status response. Polling status until closed.")
-            max_wait_secs = 300
-            waited = 0
-            while waited < max_wait_secs:
+            deadline = time.monotonic() + config.agent_status_poll_timeout_seconds
+            while time.monotonic() < deadline:
                 status = self.status(agent_id=agent_id)
                 if status.status == AgentStatus.closed:
                     return status
                 time.sleep(1)
-                waited += 1
-            raise TimeoutError(f"Agent {agent_id} did not reach a terminal state within {max_wait_secs}s")
+            raise TimeoutError(
+                f"Agent {agent_id} did not reach a terminal state within {config.agent_status_poll_timeout_seconds}s"
+            )
 
         except KeyboardInterrupt:
             status = self.status(agent_id=agent_id)
@@ -418,7 +445,12 @@ class AgentsClient(BaseClient):
                 _ = self.stop(agent_id=agent_id, session_id=session_id)
             raise
 
-    async def async_watch_logs(self, agent_id: str, session_id: str, log: bool = True) -> AgentStatusResponse | None:
+    async def async_watch_logs(
+        self,
+        agent_id: str,
+        session_id: str,
+        log: bool = True,
+    ) -> AgentStatusResponse | None:
         """
         Watch the logs of the specified agent asynchronously.
 
@@ -501,7 +533,17 @@ class AgentsClient(BaseClient):
                 await asyncio.sleep(0.1)
                 connect_waited += 0.1
             while True:
-                message = await message_queue.get()
+                try:
+                    message = await asyncio.wait_for(
+                        message_queue.get(), timeout=config.agent_logs_inactivity_timeout_seconds
+                    )
+                except TimeoutError:
+                    warning_message = (
+                        f"[Agent] {agent_id} websocket had no log events for "
+                        f"{config.agent_logs_inactivity_timeout_seconds}s. Falling back to status polling."
+                    )
+                    logger.warning(warning_message)
+                    return None
                 if message is None:
                     break
 
@@ -523,7 +565,12 @@ class AgentsClient(BaseClient):
 
         return None
 
-    async def async_watch_logs_and_wait(self, agent_id: str, session_id: str, log: bool = True) -> AgentStatusResponse:
+    async def async_watch_logs_and_wait(
+        self,
+        agent_id: str,
+        session_id: str,
+        log: bool = True,
+    ) -> AgentStatusResponse:
         """
         Execute a task with the agent and wait for completion asynchronously.
 
@@ -544,20 +591,24 @@ class AgentsClient(BaseClient):
             )
 
         try:
-            response = await self.async_watch_logs(agent_id=agent_id, session_id=session_id, log=log)
+            response = await self.async_watch_logs(
+                agent_id=agent_id,
+                session_id=session_id,
+                log=log,
+            )
             if response is not None:
                 return response
             # If we didn't get a response, poll status until agent is closed
             logger.warning(f"[Agent] {agent_id} did not return status response. Polling status until closed.")
-            max_wait_secs = 300
-            waited = 0
-            while waited < max_wait_secs:
+            deadline = time.monotonic() + config.agent_status_poll_timeout_seconds
+            while time.monotonic() < deadline:
                 status = self.status(agent_id=agent_id)
                 if status.status == AgentStatus.closed:
                     return status
                 await asyncio.sleep(1)
-                waited += 1
-            raise TimeoutError(f"Agent {agent_id} did not reach a terminal state within {max_wait_secs}s")
+            raise TimeoutError(
+                f"Agent {agent_id} did not reach a terminal state within {config.agent_status_poll_timeout_seconds}s"
+            )
 
         except asyncio.CancelledError:
             # Best-effort cleanup: don't let HTTP failures mask the CancelledError

--- a/tests/config/test_default_config.py
+++ b/tests/config/test_default_config.py
@@ -11,6 +11,8 @@ def test_default_config():
     assert config.raise_condition == "retry"
     assert config.max_error_length == 500
     assert config.max_consecutive_failures == 3
+    assert config.agent_logs_inactivity_timeout_seconds == 300.0
+    assert config.agent_status_poll_timeout_seconds == 300.0
     assert config.timeout_goto_ms == 10000
     assert config.timeout_default_ms == 8000
     assert config.timeout_action_ms == 5000

--- a/tests/config/test_default_config.py
+++ b/tests/config/test_default_config.py
@@ -1,4 +1,6 @@
-from notte_core.common.config import config
+import pytest
+from notte_core.common.config import NotteConfig, config
+from pydantic import ValidationError
 
 
 def test_default_config():
@@ -24,3 +26,15 @@ def test_default_config():
 
 def test_default_is_headless():
     assert config.headless, "headless should be true by default for tests"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("agent_logs_inactivity_timeout_seconds", 0.0),
+        ("agent_status_poll_timeout_seconds", -1.0),
+    ],
+)
+def test_agent_timeout_config_values_must_be_positive(field: str, value: float):
+    with pytest.raises(ValidationError, match=field):
+        _ = NotteConfig.from_toml(**{field: value})

--- a/tests/pipe/action/test_listing.py
+++ b/tests/pipe/action/test_listing.py
@@ -197,4 +197,4 @@ async def test_groundtruth_interactions():
         action_ids = [action.id for action in actions]
         # TODO: since new dom changes, the list had to be updated (to be revisited later)
         # assert action_ids == ["L1", "F1", "I1", "B1", "L2", "B2", "F2", "L3", "F3", "L4", "L5"]
-        assert action_ids == ["L1", "I1", "B1", "L2", "B2", "L3", "L4", "L5"]
+        assert action_ids == ["L1", "I1", "L2", "B1", "L3", "L4", "L5"]

--- a/tests/sdk/test_agent_log_timeouts.py
+++ b/tests/sdk/test_agent_log_timeouts.py
@@ -1,0 +1,80 @@
+import datetime as dt
+from types import SimpleNamespace
+
+import notte_sdk.endpoints.agents as agents_module
+from notte_sdk.endpoints.agents import AgentsClient
+from notte_sdk.types import AgentStatus, AgentStatusResponse
+
+
+class _TimeoutWebsocket:
+    def __init__(self) -> None:
+        self.recv_timeout: float | None = None
+
+    def __enter__(self) -> "_TimeoutWebsocket":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def recv(self, timeout: float | None = None) -> str:
+        self.recv_timeout = timeout
+        raise TimeoutError
+
+
+def _agents_client() -> AgentsClient:
+    client = object.__new__(AgentsClient)
+    client.token = "token"
+    client.request_path = lambda _endpoint: (  # type: ignore[method-assign]
+        "https://api.notte.cc/agents/{agent_id}/debug/logs?token={token}&session_id={session_id}"
+    )
+    return client
+
+
+def _closed_agent_status(agent_id: str, session_id: str) -> AgentStatusResponse:
+    return AgentStatusResponse(
+        agent_id=agent_id,
+        session_id=session_id,
+        created_at=dt.datetime.now(dt.UTC),
+        status=AgentStatus.closed,
+        task="task",
+        success=False,
+    )
+
+
+def test_watch_logs_returns_on_websocket_inactivity(monkeypatch) -> None:
+    websocket = _TimeoutWebsocket()
+    monkeypatch.setattr("notte_sdk.endpoints.agents.sync_client.connect", lambda **_kwargs: websocket)
+    monkeypatch.setattr(
+        agents_module,
+        "config",
+        SimpleNamespace(agent_logs_inactivity_timeout_seconds=12.5),
+    )
+
+    response = _agents_client().watch_logs(
+        agent_id="agent-id",
+        session_id="session-id",
+        log=False,
+    )
+
+    assert response is None
+    assert websocket.recv_timeout == 12.5
+
+
+def test_watch_logs_and_wait_polls_status_after_websocket_inactivity(monkeypatch) -> None:
+    client = _agents_client()
+    monkeypatch.setattr(client, "watch_logs", lambda **_kwargs: None)
+    monkeypatch.setattr(client, "status", lambda agent_id: _closed_agent_status(agent_id, "session-id"))
+    monkeypatch.setattr(
+        agents_module,
+        "config",
+        SimpleNamespace(agent_status_poll_timeout_seconds=1.0),
+    )
+
+    response = client.watch_logs_and_wait(
+        agent_id="agent-id",
+        session_id="session-id",
+        log=False,
+    )
+
+    assert response.status == AgentStatus.closed
+    assert response.agent_id == "agent-id"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import notte_core
 import pytest
 from notte_browser.captcha import CaptchaHandler
@@ -16,6 +18,7 @@ from notte_core.actions.actions import ScrapeAction
 from notte_core.browser.snapshot import BrowserSnapshot
 from notte_core.errors.actions import InvalidActionError
 from notte_llm.service import LLMService
+from pydantic import ValidationError
 
 from tests.mock.mock_browser import MockBrowserDriver
 from tests.mock.mock_service import MockLLMService
@@ -280,3 +283,42 @@ async def test_execute_with_custom_timeout() -> None:
         # Execute with custom timeout (10 seconds)
         result = await session.aexecute(type="click", id="B1", timeout=10000, raise_on_failure=False)
         assert result is not None
+
+
+def test_interaction_action_rejects_non_positive_timeout() -> None:
+    with pytest.raises(ValidationError):
+        _ = ClickAction(id="B1", timeout=0)
+
+
+@pytest.mark.asyncio
+async def test_click_disabled_ancestor_returns_failed_result() -> None:
+    async with NotteSession(headless=True) as session:
+        await session.window.page.set_content("""
+            <main inert>
+                <button id="target">Apply</button>
+            </main>
+        """)
+
+        result = await session.aexecute(type="click", selector="#target", raise_on_failure=False)
+
+        assert result.success is False
+        assert result.message is not None
+        assert "Element is disabled" in result.message
+
+
+@pytest.mark.asyncio
+async def test_interaction_execution_timeout_returns_failed_result() -> None:
+    async def slow_execute(*_args, **_kwargs) -> bool:
+        await asyncio.sleep(0.05)
+        return True
+
+    async with NotteSession(headless=True) as session:
+        session.controller.execute = slow_execute  # pyright: ignore[reportAttributeAccessIssue, reportMethodAssign]
+
+        result = await session.aexecute(
+            ClickAction(selector="#target", timeout=1),
+            raise_on_failure=False,
+        )
+
+        assert result.success is False
+        assert result.message == "Action timed out after 1ms"


### PR DESCRIPTION
## Summary
- bound interaction action execution with the action timeout and return a failed execution result on timeout
- fail disabled element clicks before Playwright enters retry loops
- filter disabled custom interactive elements out of DOM action discovery
- add SDK websocket inactivity timeouts with bounded status polling fallback

## Tests
- `PYTHONPATH=/home/lboesinger/github/work/notte/packages/notte-browser/src:/home/lboesinger/github/work/notte/packages/notte-core/src:/home/lboesinger/github/work/notte/packages/notte-llm/src:/home/lboesinger/github/work/notte/packages/notte-sdk/src /home/lboesinger/github/work/monorepo/apps/back/notte-api/.venv/bin/python -m pytest tests/sdk/test_agent_log_timeouts.py tests/test_session.py::test_execute_with_custom_timeout -q`
- pre-commit hooks run during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-action interaction timeouts enforced (must be positive) and improved fallback polling behavior
  * New configurable agent timeouts for log inactivity and status polling (defaults added)

* **Bug Fixes**
  * Clicks on disabled/inert or otherwise non-interactive controls are blocked and reported
  * Post-action screenshot failures are now non-fatal warnings

* **Tests**
  * Added tests for agent log inactivity/timeouts, status-poll fallback, and interaction timeout/disabled behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes action and log stream timeouts: bounds `InteractionAction` execution with `asyncio.wait_for`, short-circuits disabled element clicks before Playwright's retry loop via JS ancestor traversal (including shadow DOM), filters disabled elements from DOM action discovery with a new `getDisabledReason` helper, and adds configurable WebSocket inactivity timeouts with a status-polling fallback. Makes post-action screenshots non-fatal and validates that timeout config values are positive.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 82dc739291e8edb6345bf822bda7ca6da2ad4ae6.</sup>
<!-- /MENDRAL_SUMMARY -->