### PR TITLE
fix(docs): banner text color in light mode

### DIFF
--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -58,8 +58,7 @@ html:not(.dark) #banner {
   color: rgb(20, 83, 45) !important;
 }
 
-html:not(.dark) #banner p,
-html:not(.dark) #banner span {
+html:not(.dark) #banner *:not(a):not(code) {
   color: rgb(20, 83, 45) !important;
 }
 


### PR DESCRIPTION
## Summary
- The Mintlify docs `banner` text stayed white in light mode because the existing override only targeted `#banner p` and `#banner span`, missing other wrapper elements Mintlify uses for the banner's markdown content.
- Replace those two selectors with `#banner *:not(a):not(code)` so every nested text element inherits the dark-green light-mode color while links and inline code keep their dedicated styles.

## Test plan
- [ ] `make docs-dev` and confirm banner text is readable in light mode
- [ ] Toggle to dark mode and confirm banner text remains the existing light-green color
- [ ] Confirm banner link + inline code colors are unchanged in both themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated banner text color styling in light theme to apply more consistently across all text elements, excluding links and code blocks, for a unified visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes banner text color in light mode by replacing narrow element selectors (`p`, `span`) with a wildcard selector that excludes links and inline code, ensuring all nested text elements inherit the dark-green color.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6f2a4b3ad63454c713048632853aefd9f952939a.</sup>
<!-- /MENDRAL_SUMMARY -->