### PR TITLE
fix(telemetry): filter sensitive kwargs in error path of track_usage decorator

### DIFF
--- a/packages/notte-core/src/notte_core/common/telemetry.py
+++ b/packages/notte-core/src/notte_core/common/telemetry.py
@@ -243,7 +243,9 @@ def track_usage(method_name: str) -> Callable[[F], F]:
                 capture_event(event_name, properties={"input": {"args": args, "kwargs": filtered_kwargs}})
                 return result
             except Exception as e:
-                capture_event(event_name, properties={"input": {"args": args, "kwargs": filtered_kwargs}, "error": str(e)})
+                capture_event(
+                    event_name, properties={"input": {"args": args, "kwargs": filtered_kwargs}, "error": str(e)}
+                )
                 raise e
 
         return wrapper  # type: ignore

--- a/packages/notte-core/src/notte_core/common/telemetry.py
+++ b/packages/notte-core/src/notte_core/common/telemetry.py
@@ -237,13 +237,13 @@ def track_usage(method_name: str) -> Callable[[F], F]:
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             event_name = method_name
+            filtered_kwargs = {k: v for k, v in kwargs.items() if k not in exclude_kwargs}
             try:
                 result = func(*args, **kwargs)
-                filtered_kwargs = {k: v for k, v in kwargs.items() if k not in exclude_kwargs}
                 capture_event(event_name, properties={"input": {"args": args, "kwargs": filtered_kwargs}})
                 return result
             except Exception as e:
-                capture_event(event_name, properties={"input": {"args": args, "kwargs": kwargs}, "error": str(e)})
+                capture_event(event_name, properties={"input": {"args": args, "kwargs": filtered_kwargs}, "error": str(e)})
                 raise e
 
         return wrapper  # type: ignore


### PR DESCRIPTION
## Vulnerability: Sensitive credentials leaked to external telemetry on errors (CWE-200)

**Affected file:** `packages/notte-core/src/notte_core/common/telemetry.py`
**Affected function:** `track_usage` decorator (line ~237)
**Severity:** High — credentials sent to third-party services

### Summary

The `track_usage` decorator filters sensitive kwargs (`password`, `email`, `username`, `mfa_secret`) before sending telemetry events on the success path, but the error/exception path bypasses this filtering entirely. When a decorated function raises an exception, the raw unfiltered `kwargs` dict — including plaintext passwords and secrets — is sent to external telemetry services (PostHog, Scarf).

This directly affects the vault credential endpoints in `packages/notte-sdk/src/notte_sdk/endpoints/vaults.py`, where functions like `add_or_update_credentials` accept sensitive fields (`password`, `email`, `username`, `mfa_secret`) as kwargs and are decorated with `@track_usage`.

### Data flow

1. User calls `vault_client.add_or_update_credentials(vault_id, password="s3cret", email="user@example.com")`
2. `track_usage` decorator wraps the call
3. If the underlying API call raises (network error, auth failure, server error, etc.), the `except` block fires
4. **Before this fix:** `capture_event()` is called with raw `kwargs` containing `password` and `email`
5. `capture_event()` forwards to PostHog and Scarf — external third-party services
6. Plaintext credentials are now stored in third-party telemetry backends

### PoC

```python
from notte_core.common.telemetry import track_usage

@track_usage("test.leak")
def demo_leak(vault_id: str, password: str = "", email: str = ""):
    raise ConnectionError("simulated API failure")

# On the unfixed code, this sends password="s3cret" and email="me@example.com"
# to PostHog/Scarf telemetry endpoints
try:
    demo_leak("vault-123", password="s3cret", email="me@example.com")
except ConnectionError:
    pass
```

To confirm leakage, you can temporarily patch `capture_event` to print its properties argument — you'll see the raw password in the error-path payload but not in the success-path payload.

### Fix

The fix hoists the `filtered_kwargs` computation above the `try` block so both the success and error paths use the same filtered dict. This is a 2-line change: move the filtering line up by 1 line, and replace `kwargs` with `filtered_kwargs` in the `except` block.

Before:
```python
try:
    result = func(*args, **kwargs)
    filtered_kwargs = {k: v for k, v in kwargs.items() if k not in exclude_kwargs}
    capture_event(event_name, properties={"input": {"args": args, "kwargs": filtered_kwargs}})
    return result
except Exception as e:
    capture_event(event_name, properties={"input": {"args": args, "kwargs": kwargs}, "error": str(e)})
    raise e
```

After:
```python
filtered_kwargs = {k: v for k, v in kwargs.items() if k not in exclude_kwargs}
try:
    result = func(*args, **kwargs)
    capture_event(event_name, properties={"input": {"args": args, "kwargs": filtered_kwargs}})
    return result
except Exception as e:
    capture_event(event_name, properties={"input": {"args": args, "kwargs": filtered_kwargs}, "error": str(e)})
    raise e
```

### Testing

- Verified the decorator still correctly filters `password`, `email`, `username`, and `mfa_secret` on the success path
- Verified the error path now uses `filtered_kwargs` instead of raw `kwargs`
- Confirmed that the `exclude_kwargs` set matches the sensitive fields used by vault credential endpoints

### Adversarial review

Before submitting, we considered whether this exposure is mitigated by other controls. It is not — telemetry is enabled by default (`NOTTE_DISABLE_TELEMETRY` must be explicitly set), the `capture_event` function sends data to external PostHog and Scarf endpoints over HTTPS, and there is no secondary filtering or redaction layer between the decorator and the HTTP calls. Any exception in a vault credential operation (network timeout, 401, server 500) triggers the leak. The filtering logic already existed for the success path, confirming the project's intent to exclude these fields from telemetry — the error path was simply missed.

---



<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a security bug in the `track_usage` decorator where sensitive kwargs (`password`, `email`, `username`, `mfa_secret`) were correctly filtered on the success path but sent raw to external telemetry (PostHog, Scarf) on the exception path. The fix hoists `filtered_kwargs` computation above the `try` block so both paths use the same filtered dict. The second commit applies `ruff format` to address the previous review comment.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 88d97323905682dc2237a052b7938c968ea60b1d.</sup>
<!-- /MENDRAL_SUMMARY -->