### PR TITLE
Raise max_duration_minutes cap to 24h in SessionStartRequest

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -753,7 +753,7 @@ class SessionStartRequest(SdkRequest):
         Field(
             description="Maximum session lifetime in minutes (absolute maximum, not affected by activity).",
             gt=0,
-            le=DEFAULT_SESSION_MAX_DURATION_IN_MINUTES,
+            le=24 * 60,
         ),
     ] = DEFAULT_SESSION_MAX_DURATION_IN_MINUTES
 

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -431,19 +431,21 @@ def test_timeout_minutes_backward_compatibility() -> None:
 
 
 def test_max_duration_validation() -> None:
-    """Test max_duration_minutes validation (must be <= 60)."""
+    """Test max_duration_minutes validation (must be <= 24 * 60)."""
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError) as exc_info:
-        test_max_duration = DEFAULT_SESSION_MAX_DURATION_IN_MINUTES + 1
-        _ = SessionStartRequest(max_duration_minutes=test_max_duration)
+        _ = SessionStartRequest(max_duration_minutes=24 * 60 + 1)
 
     # Check that the error is about the max_duration_minutes field
     assert "max_duration_minutes" in str(exc_info.value)
 
-    # Should work with valid value
+    # Should work with values up to the 24h ceiling; per-tier enforcement
+    # happens server-side, the SDK only guards the absolute upper bound.
     request = SessionStartRequest(max_duration_minutes=DEFAULT_SESSION_MAX_DURATION_IN_MINUTES)
     assert request.max_duration_minutes == DEFAULT_SESSION_MAX_DURATION_IN_MINUTES
+    request = SessionStartRequest(max_duration_minutes=24 * 60)
+    assert request.max_duration_minutes == 24 * 60
 
 
 def test_idle_timeout_validation() -> None:


### PR DESCRIPTION
## Summary
- SDK previously capped `max_duration_minutes` at `DEFAULT_SESSION_MAX_DURATION_IN_MINUTES` (15, the free-tier default), which incorrectly blocked higher-tier users from requesting longer sessions even though the API accepts values up to 24h.
- Match the API's `ApiSessionStartRequest` upper bound (`le=24 * 60`) on `SessionStartRequest.max_duration_minutes`. The default value is unchanged (still 15); per-tier enforcement remains on the server side via `auth.check_session_duration_limit_exceeded`.
- Updated `test_max_duration_validation` to assert the new `24 * 60` ceiling and that valid sub-ceiling values pass.

## Test plan
- [x] `uv run pytest tests/sdk/test_client.py::test_max_duration_validation tests/sdk/test_client.py::test_new_timeout_parameters_with_defaults tests/sdk/test_client.py::test_new_timeout_parameters_explicit tests/sdk/test_client.py::test_idle_timeout_validation` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session duration validation now enforces a strict maximum of 24 hours per session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Raises the `max_duration_minutes` upper bound in `SessionStartRequest` from `DEFAULT_SESSION_MAX_DURATION_IN_MINUTES` (15) to `24 * 60` (1440), matching the API's `ApiSessionStartRequest` constraint. The default value is unchanged; per-tier enforcement stays server-side. Test updated to assert the new ceiling.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 2ca84af6fc0167272e81f406a46e4e957932298b.</sup>
<!-- /MENDRAL_SUMMARY -->