### PR TITLE
temporary change: allow schema timeout = 0

### DIFF
--- a/packages/notte-core/src/notte_core/actions/actions.py
+++ b/packages/notte-core/src/notte_core/actions/actions.py
@@ -987,7 +987,7 @@ class InteractionAction(BaseAction, metaclass=ABCMeta):
     press_enter: bool | None = Field(default=None)
     text_label: str | None = Field(default=None)
     param: ActionParameter | None = Field(default=None, exclude=True)
-    timeout: int = Field(default=config.timeout_action_ms, gt=0, description="Action timeout in milliseconds")
+    timeout: int = Field(default=config.timeout_action_ms, ge=0, description="Action timeout in milliseconds")
 
     INTERACTION_ACTION_REGISTRY: ClassVar[dict[str, typeAlias["InteractionAction"]]] = {}
 

--- a/packages/notte-core/src/notte_core/actions/actions.py
+++ b/packages/notte-core/src/notte_core/actions/actions.py
@@ -998,6 +998,14 @@ class InteractionAction(BaseAction, metaclass=ABCMeta):
             return value[:-3]
         return value
 
+    @field_validator("timeout")
+    @classmethod
+    def use_default_timeout_when_zero(cls, value: int) -> int:
+        # Playwright treats timeout=0 as infinite; keep LLM-provided zero bounded.
+        if value == 0:
+            return config.timeout_action_ms
+        return value
+
     @model_validator(mode="before")
     @classmethod
     def validate_id_and_selector(cls, data: Any) -> Any:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -284,6 +284,14 @@ async def test_execute_with_custom_timeout() -> None:
         assert result is not None
 
 
+def test_interaction_action_zero_timeout_uses_default_config_timeout() -> None:
+    from notte_core.common.config import config
+
+    action = ClickAction(id="B1", timeout=0)
+
+    assert action.timeout == config.timeout_action_ms
+
+
 @pytest.mark.asyncio
 async def test_click_disabled_ancestor_returns_failed_result() -> None:
     async with NotteSession(headless=True) as session:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -18,7 +18,6 @@ from notte_core.actions.actions import ScrapeAction
 from notte_core.browser.snapshot import BrowserSnapshot
 from notte_core.errors.actions import InvalidActionError
 from notte_llm.service import LLMService
-from pydantic import ValidationError
 
 from tests.mock.mock_browser import MockBrowserDriver
 from tests.mock.mock_service import MockLLMService
@@ -283,11 +282,6 @@ async def test_execute_with_custom_timeout() -> None:
         # Execute with custom timeout (10 seconds)
         result = await session.aexecute(type="click", id="B1", timeout=10000, raise_on_failure=False)
         assert result is not None
-
-
-def test_interaction_action_rejects_non_positive_timeout() -> None:
-    with pytest.raises(ValidationError):
-        _ = ClickAction(id="B1", timeout=0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interaction timeouts now accept 0 as a valid value; providing 0 will use the configured default timeout instead of being rejected.

* **Tests**
  * Updated tests to verify that a zero timeout is accepted and mapped to the configured default (removed the previous rejection test).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Changes `InteractionAction.timeout` field constraint from `gt=0` to `ge=0` and adds a `field_validator` that converts `timeout=0` to the configured default (`config.timeout_action_ms`), preventing Playwright's infinite-wait semantic from leaking in. The corresponding test is updated to assert the zero-to-default remapping.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f311a5291c135da7c559f7d4eed4451397d4fc35.</sup>
<!-- /MENDRAL_SUMMARY -->