### PR TITLE
Refresh snapshot before vault credential replacement

### DIFF
--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -528,6 +528,8 @@ class NotteSession(AsyncResource, SyncResource):
         if self.vault is None or not isinstance(action, _SUPPORTED) or not self.vault.contains_credentials(action):
             return action
 
+        if self._window is not None:
+            self.snapshot = await self.window.snapshot()
         snapshot = self.snapshot
         try:
             if isinstance(action, FormFillAction):

--- a/tests/integration/sdk/test_vault.py
+++ b/tests/integration/sdk/test_vault.py
@@ -1,10 +1,13 @@
 import os
+from pathlib import Path
 from unittest import TestCase
 
 import pytest
 from dotenv import load_dotenv
 from notte_agent.falco.agent import FalcoAgent
 from notte_core.actions import FillAction, FormFillAction, WaitAction
+from notte_core.credentials import PASSWORD as PASSWORD_PLACEHOLDER
+from notte_core.credentials import USERNAME as USERNAME_PLACEHOLDER
 from notte_core.credentials.base import BaseVault, CredentialField, EmailField, PasswordField
 from notte_core.credentials.types import ValueWithPlaceholder, get_str_value
 from notte_core.errors.actions import NoCredentialsFoundError
@@ -12,6 +15,19 @@ from notte_sdk import NotteClient
 from notte_sdk.errors import NotteAPIError
 
 import notte
+
+
+async def load_github_signin_fixture(session: notte.Session) -> None:
+    html = Path("tests/data/github_signin.html").read_text()
+
+    async def fulfill_github_login(route):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+        await route.fulfill(status=200, content_type="text/html", body=html)
+
+    await session.window.page.route("https://github.com/login", fulfill_github_login)
+    _ = await session.window.page.goto(url="https://github.com/login")
+    res = await session.aexecute(WaitAction(time_ms=100))
+    assert res.success
+    _ = await session.aobserve()
 
 
 def test_vault_in_local_agent():
@@ -215,6 +231,50 @@ def test_invalid_credentials_in_local_agent():
 # ============================================
 
 
+def test_session_form_fill_with_vault_without_observe_uses_live_url():
+    """Test form_fill credential replacement snapshots the live page before vault lookup."""
+    _ = load_dotenv()
+    client = NotteClient(api_key=os.getenv("NOTTE_API_KEY"))
+    base_url = "https://apartment-board-demo-nine.vercel.app"
+    login_url = f"{base_url}/auth/signin"
+    username = "alder"
+    password = "rentals123"  # pragma: allowlist secret
+
+    with client.Vault() as vault:
+        _ = vault.add_credentials(url=base_url, username=username, password=password)
+
+        with notte.Session(vault=vault, headless=True, idle_timeout_minutes=3, max_duration_minutes=15) as session:
+            goto_result = session.execute(type="goto", url=login_url)
+            assert goto_result.success
+
+            fill_result = session.execute(
+                type="form_fill",
+                value={"username": USERNAME_PLACEHOLDER, "password": PASSWORD_PLACEHOLDER},
+            )
+            assert fill_result.success
+            assert session.snapshot.metadata.url == login_url
+
+            values_result = session.execute(
+                type="evaluate_js",
+                code="""(() => {
+                    const usernameInput = document.querySelector(
+                        'input#username, input[name="username"], input[autocomplete="username"], input[type="text"]'
+                    );
+                    const passwordInput = document.querySelector(
+                        'input#password, input[type="password"], input[autocomplete="current-password"]'
+                    );
+                    return {
+                        username: usernameInput?.value,
+                        password: passwordInput?.value,
+                    };
+                })()""",
+            )
+            assert values_result.success
+            assert values_result.data is not None
+            assert f'"username": "{username}"' in values_result.data.markdown
+            assert f'"password": "{password}"' in values_result.data.markdown
+
+
 @pytest.mark.asyncio
 async def test_session_set_vault_enables_credential_replacement():
     """Test that session.set_vault() enables credential replacement via _action_with_vault."""
@@ -230,12 +290,8 @@ async def test_session_set_vault_enables_credential_replacement():
         # Set vault on session directly (not via agent)
         session.set_vault(vault)
 
-        # Load a page and set up snapshot
-        file_path = "tests/data/github_signin.html"
-        _ = await session.window.page.goto(url=f"file://{os.path.abspath(file_path)}")
-        _ = await session.aexecute(WaitAction(time_ms=100))
-        _ = await session.aobserve()
-        session.snapshot.metadata.url = URL
+        # Load the fixture through a real URL so refreshed snapshots keep matching vault credentials.
+        await load_github_signin_fixture(session)
 
         # Test _action_with_vault replaces credentials
         action = FormFillAction(
@@ -264,11 +320,7 @@ async def test_session_vault_in_constructor():
 
         # Pass vault directly to session constructor
         with notte.Session(vault=vault) as session:
-            file_path = "tests/data/github_signin.html"
-            _ = await session.window.page.goto(url=f"file://{os.path.abspath(file_path)}")
-            _ = await session.aexecute(WaitAction(time_ms=100))
-            _ = await session.aobserve()
-            session.snapshot.metadata.url = URL
+            await load_github_signin_fixture(session)
 
             action = FormFillAction(value={"email": EmailField.placeholder_value})
             replaced = await session._action_with_vault(action)
@@ -288,11 +340,7 @@ async def test_session_fill_action_with_vault():
     with client.Vault() as vault, notte.Session(vault=vault) as session:
         _ = vault.add_credentials(url=URL, email=EMAIL, password="pw")
 
-        file_path = "tests/data/github_signin.html"
-        _ = await session.window.page.goto(url=f"file://{os.path.abspath(file_path)}")
-        _ = await session.aexecute(WaitAction(time_ms=100))
-        _ = await session.aobserve()
-        session.snapshot.metadata.url = URL
+        await load_github_signin_fixture(session)
 
         fill_action = FillAction(id="I1", value=EmailField.placeholder_value)
         replaced = await session._action_with_vault(fill_action)

--- a/tests/integration/sdk/test_vault.py
+++ b/tests/integration/sdk/test_vault.py
@@ -238,7 +238,7 @@ def test_session_form_fill_with_vault_without_observe_uses_live_url():
     base_url = "https://apartment-board-demo-nine.vercel.app"
     login_url = f"{base_url}/auth/signin"
     username = "alder"
-    password = "rentals123"  # pragma: allowlist secret
+    password = "test-password"  # noqa: S105  # pragma: allowlist secret
 
     with client.Vault() as vault:
         _ = vault.add_credentials(url=base_url, username=username, password=password)

--- a/tests/integration/sdk/test_vault.py
+++ b/tests/integration/sdk/test_vault.py
@@ -18,7 +18,8 @@ import notte
 
 
 async def load_github_signin_fixture(session: notte.Session) -> None:
-    html = Path("tests/data/github_signin.html").read_text()
+    fixture_path = Path(__file__).resolve().parents[2] / "data" / "github_signin.html"
+    html = fixture_path.read_text(encoding="utf-8")
 
     async def fulfill_github_login(route):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
         await route.fulfill(status=200, content_type="text/html", body=html)
@@ -231,7 +232,8 @@ def test_invalid_credentials_in_local_agent():
 # ============================================
 
 
-def test_session_form_fill_with_vault_without_observe_uses_live_url():
+@pytest.mark.asyncio
+async def test_session_form_fill_with_vault_without_observe_uses_live_url():
     """Test form_fill credential replacement snapshots the live page before vault lookup."""
     _ = load_dotenv()
     client = NotteClient(api_key=os.getenv("NOTTE_API_KEY"))
@@ -244,17 +246,34 @@ def test_session_form_fill_with_vault_without_observe_uses_live_url():
         _ = vault.add_credentials(url=base_url, username=username, password=password)
 
         with notte.Session(vault=vault, headless=True, idle_timeout_minutes=3, max_duration_minutes=15) as session:
-            goto_result = session.execute(type="goto", url=login_url)
+
+            async def fulfill_login(route):  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]
+                await route.fulfill(
+                    status=200,
+                    content_type="text/html",
+                    body="""
+                        <form>
+                            <label for="username">Username</label>
+                            <input id="username" autocomplete="username" type="text" />
+                            <label for="password">Password</label>
+                            <input id="password" autocomplete="current-password" type="password" />
+                        </form>
+                    """,
+                )
+
+            await session.window.page.route(login_url, fulfill_login)
+
+            goto_result = await session.aexecute(type="goto", url=login_url)
             assert goto_result.success
 
-            fill_result = session.execute(
+            fill_result = await session.aexecute(
                 type="form_fill",
                 value={"username": USERNAME_PLACEHOLDER, "password": PASSWORD_PLACEHOLDER},
             )
             assert fill_result.success
             assert session.snapshot.metadata.url == login_url
 
-            values_result = session.execute(
+            values_result = await session.aexecute(
                 type="evaluate_js",
                 code="""(() => {
                     const usernameInput = document.querySelector(

--- a/tests/test_session_vault_helpers.py
+++ b/tests/test_session_vault_helpers.py
@@ -2,11 +2,19 @@ import asyncio
 
 from notte_browser.session import NotteSession
 from notte_core.actions import FormFillAction
-from notte_core.credentials import EMAIL, PASSWORD
+from notte_core.credentials import EMAIL, PASSWORD, USERNAME
 from notte_core.credentials.types import ValueWithPlaceholder
 
 from tests.mock.mock_vault import MockVault
 from tests.mock.snapshot_factory import make_snapshot
+
+
+class FakeWindow:
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+    async def snapshot(self):
+        return make_snapshot(self.url)
 
 
 def test_session_vault_replaces_form_fill_placeholders() -> None:
@@ -22,6 +30,38 @@ def test_session_vault_replaces_form_fill_placeholders() -> None:
     assert str(updated.value["email"]) == EMAIL
     assert isinstance(updated.value["current_password"], ValueWithPlaceholder)
     assert updated.value["current_password"].get_secret_value() == "s3cr3t"
+
+
+def test_session_vault_refreshes_snapshot_from_window() -> None:
+    vault = MockVault({"https://example.com": {"username": "fresh-user"}})
+    session = NotteSession(vault=vault)
+    session._window = FakeWindow("https://example.com")  # pyright: ignore[reportAttributeAccessIssue]
+
+    action = FormFillAction(value={"username": USERNAME})
+    updated = asyncio.run(session._action_with_vault(action))
+
+    assert session.snapshot.metadata.url == "https://example.com"
+    assert isinstance(updated.value["username"], ValueWithPlaceholder)
+    assert updated.value["username"].get_secret_value() == "fresh-user"
+
+
+def test_session_vault_uses_fresh_snapshot_instead_of_stale_snapshot() -> None:
+    vault = MockVault(
+        {
+            "https://old.example.com": {"username": "stale-user"},
+            "https://example.com": {"username": "fresh-user"},
+        }
+    )
+    session = NotteSession(vault=vault)
+    session.snapshot = make_snapshot("https://old.example.com")
+    session._window = FakeWindow("https://example.com")  # pyright: ignore[reportAttributeAccessIssue]
+
+    action = FormFillAction(value={"username": USERNAME})
+    updated = asyncio.run(session._action_with_vault(action))
+
+    assert session.snapshot.metadata.url == "https://example.com"
+    assert isinstance(updated.value["username"], ValueWithPlaceholder)
+    assert updated.value["username"].get_secret_value() == "fresh-user"
 
 
 def test_session_set_vault_enables_credential_replacement() -> None:


### PR DESCRIPTION
## Summary
- refresh the session snapshot from the live browser window before vault credential replacement
- keep existing helper behavior for tests without a live window
- add regression coverage for missing and stale snapshots during vault replacement

## Tests
- uv run pytest tests/test_session_persona_helpers.py tests/test_session_vault_helpers.py
- uv run ruff check packages/notte-browser/src/notte_browser/session.py tests/test_session_vault_helpers.py
- uv run ruff format --check packages/notte-browser/src/notte_browser/session.py tests/test_session_vault_helpers.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credential vault replacement now refreshes the browser snapshot from the live window when available, ensuring replacements use the most up-to-date page state.

* **Tests**
  * Added unit and integration tests validating snapshot-refresh behavior and that credential replacement uses fresh/live snapshot metadata.
  * Added a test helper to simulate loading a live sign-in page for integration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refreshes the session snapshot from the live browser window inside `_action_with_vault` before performing vault credential lookup, so the vault always operates on the current page URL rather than a potentially stale cached snapshot. Adds unit tests for the refresh and stale-snapshot regression paths, and updates three integration tests to use Playwright route interception instead of the `file://`+URL-override hack.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d6b5cc07ab8cc9cc741c5702712b312b6f428a58.</sup>
<!-- /MENDRAL_SUMMARY -->