### PR TITLE
Bump default action timeout

### DIFF
--- a/docs/src/sdk-reference/misc/checkaction.mdx
+++ b/docs/src/sdk-reference/misc/checkaction.mdx
@@ -40,7 +40,7 @@ session.execute(type="check", id="newsletter-checkbox", value=False)
 <ParamField path="param" type="UnionType[ActionParameter, None]" default="name=&#x27;value&#x27; type=&#x27;bool&#x27; default=None values=[]">
 </ParamField>
 
-<ParamField path="timeout" type="int" default="5000">
+<ParamField path="timeout" type="int" default="15000">
   Action timeout in milliseconds
 </ParamField>
 

--- a/docs/src/sdk-reference/misc/clickaction.mdx
+++ b/docs/src/sdk-reference/misc/clickaction.mdx
@@ -37,7 +37,7 @@ session.execute(type="click", id="submit-button")
 <ParamField path="param" type="UnionType[ActionParameter, None]">
 </ParamField>
 
-<ParamField path="timeout" type="int" default="5000">
+<ParamField path="timeout" type="int" default="15000">
   Action timeout in milliseconds
 </ParamField>
 

--- a/docs/src/sdk-reference/misc/downloadfileaction.mdx
+++ b/docs/src/sdk-reference/misc/downloadfileaction.mdx
@@ -42,7 +42,7 @@ session.execute(type="download_file", id="html")
 <ParamField path="param" type="UnionType[ActionParameter, None]">
 </ParamField>
 
-<ParamField path="timeout" type="int" default="5000">
+<ParamField path="timeout" type="int" default="15000">
   Action timeout in milliseconds
 </ParamField>
 

--- a/docs/src/sdk-reference/misc/fallbackfillaction.mdx
+++ b/docs/src/sdk-reference/misc/fallbackfillaction.mdx
@@ -36,7 +36,7 @@ session.execute(type="fallback_fill", id="difficult-input", value="fallback text
 <ParamField path="param" type="UnionType[ActionParameter, None]" default="name=&#x27;value&#x27; type=&#x27;str&#x27; default=None values=[]">
 </ParamField>
 
-<ParamField path="timeout" type="int" default="5000">
+<ParamField path="timeout" type="int" default="15000">
   Action timeout in milliseconds
 </ParamField>
 

--- a/docs/src/sdk-reference/misc/fillaction.mdx
+++ b/docs/src/sdk-reference/misc/fillaction.mdx
@@ -38,7 +38,7 @@ session.execute(type="fill", id="name-input", value="John Doe", clear_before_fil
 <ParamField path="param" type="UnionType[ActionParameter, None]" default="name=&#x27;value&#x27; type=&#x27;str&#x27; default=None values=[]">
 </ParamField>
 
-<ParamField path="timeout" type="int" default="5000">
+<ParamField path="timeout" type="int" default="15000">
   Action timeout in milliseconds
 </ParamField>
 

--- a/docs/src/sdk-reference/misc/multifactorfillaction.mdx
+++ b/docs/src/sdk-reference/misc/multifactorfillaction.mdx
@@ -36,7 +36,7 @@ session.execute(type="multi_factor_fill", id="otp-input", value="123456")
 <ParamField path="param" type="UnionType[ActionParameter, None]" default="name=&#x27;value&#x27; type=&#x27;str&#x27; default=None values=[]">
 </ParamField>
 
-<ParamField path="timeout" type="int" default="5000">
+<ParamField path="timeout" type="int" default="15000">
   Action timeout in milliseconds
 </ParamField>
 

--- a/docs/src/sdk-reference/misc/selectdropdownoptionaction.mdx
+++ b/docs/src/sdk-reference/misc/selectdropdownoptionaction.mdx
@@ -40,7 +40,7 @@ session.execute(type="select_dropdown_option", id="size-select", value="Large")
 <ParamField path="param" type="UnionType[ActionParameter, None]" default="name=&#x27;value&#x27; type=&#x27;str&#x27; default=None values=[]">
 </ParamField>
 
-<ParamField path="timeout" type="int" default="5000">
+<ParamField path="timeout" type="int" default="15000">
   Action timeout in milliseconds
 </ParamField>
 

--- a/docs/src/sdk-reference/misc/uploadfileaction.mdx
+++ b/docs/src/sdk-reference/misc/uploadfileaction.mdx
@@ -40,7 +40,7 @@ session.execute(type="upload_file", id="image-upload", file_path="./image.jpg")
 <ParamField path="param" type="UnionType[ActionParameter, None]" default="name=&#x27;file_path&#x27; type=&#x27;str&#x27; default=None values=[]">
 </ParamField>
 
-<ParamField path="timeout" type="int" default="5000">
+<ParamField path="timeout" type="int" default="15000">
   Action timeout in milliseconds
 </ParamField>
 

--- a/packages/notte-core/src/notte_core/config.toml
+++ b/packages/notte-core/src/notte_core/config.toml
@@ -66,7 +66,7 @@ enable_pointer_elements = true
 # [playwright wait/timeout]
 timeout_goto_ms        = 10000
 timeout_default_ms     =  8000
-timeout_action_ms      =  5000
+timeout_action_ms      = 15000
 timeout_evaluate_js_ms = 45000
 wait_retry_snapshot_ms =  1000
 wait_short_ms          =   500

--- a/tests/config/test_default_config.py
+++ b/tests/config/test_default_config.py
@@ -17,7 +17,7 @@ def test_default_config():
     assert config.agent_status_poll_timeout_seconds == 300.0
     assert config.timeout_goto_ms == 10000
     assert config.timeout_default_ms == 8000
-    assert config.timeout_action_ms == 5000
+    assert config.timeout_action_ms == 15000
     assert config.wait_retry_snapshot_ms == 1000
     assert config.wait_short_ms == 500
     assert config.empty_page_max_retry == 5

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -266,11 +266,11 @@ async def test_execute_with_default_timeout() -> None:
     async with NotteSession(headless=True) as session:
         _ = await session.aexecute(type="goto", url="https://www.google.com")
         _ = await session.aobserve(perception_type="fast")
-        # Execute with default timeout (should use config.timeout_action_ms = 5000ms)
+        # Execute with default timeout (should use config.timeout_action_ms = 15000ms)
         # Try to click on first button (may fail if not found, but timeout param should work)
         result = await session.aexecute(type="click", id="B1", raise_on_failure=False)
         assert result is not None
-        assert config.timeout_action_ms == 5000  # Verify default
+        assert config.timeout_action_ms == 15000  # Verify default
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Increase the default interaction action timeout from 5s to 15s
- Update generated SDK reference defaults for interaction actions

## Verification
- `uv run python -c "from notte_core.common.config import config; from notte_core.actions import ClickAction; print(config.timeout_action_ms); print(ClickAction(id='x').timeout)"`
- pre-commit hooks run by `git commit` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation & Configuration**
  * Action timeout defaults increased from 5000 ms to 15000 ms across all relevant actions; SDK reference docs and core configuration updated to reflect the new defaults.

* **Tests**
  * Test expectations updated to assert the new default timeout of 15000 ms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Increases the default action timeout from 5s to 15s in `config.toml`, updates all 8 SDK reference doc pages, and fixes the two test assertions that were previously flagged.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 18dfaf992adad6d03a97d6e59b6e8ade04607fcd.</sup>
<!-- /MENDRAL_SUMMARY -->