### PR TITLE
Preserve selectors for MFA vault fills

### DIFF
--- a/packages/notte-core/src/notte_core/credentials/base.py
+++ b/packages/notte-core/src/notte_core/credentials/base.py
@@ -690,7 +690,15 @@ class BaseVault(ABC):
 
                     # replace fill action if mfa but agent chose the wrong action
                     if cred_class is MFAField and isinstance(action, FillAction):
-                        action = MultiFactorFillAction(id=action.id, value=action.value)
+                        action = MultiFactorFillAction(
+                            id=action.id,
+                            selector=action.selector,
+                            value=action.value,
+                            clear_before_fill=action.clear_before_fill,
+                            press_enter=action.press_enter,
+                            text_label=action.text_label,
+                            timeout=action.timeout,
+                        )
                 else:
                     logger.trace(f"Could not validate element with attrs {attrs} for {cred_key}")
             else:

--- a/tests/test_session_vault_helpers.py
+++ b/tests/test_session_vault_helpers.py
@@ -1,8 +1,8 @@
 import asyncio
 
 from notte_browser.session import NotteSession
-from notte_core.actions import FormFillAction
-from notte_core.credentials import EMAIL, PASSWORD, USERNAME
+from notte_core.actions import FillAction, FormFillAction, MultiFactorFillAction
+from notte_core.credentials import EMAIL, MFA, PASSWORD, USERNAME
 from notte_core.credentials.types import ValueWithPlaceholder
 
 from tests.mock.mock_vault import MockVault
@@ -15,6 +15,11 @@ class FakeWindow:
 
     async def snapshot(self):
         return make_snapshot(self.url)
+
+
+class NoopLocateSession(NotteSession):
+    async def locate(self, action):
+        return None
 
 
 def test_session_vault_replaces_form_fill_placeholders() -> None:
@@ -112,3 +117,21 @@ def test_session_vault_action_without_placeholders_passes_through() -> None:
     result = asyncio.run(session._action_with_vault(action))
     # Should pass through unchanged since no placeholders
     assert result is action
+
+
+def test_session_vault_preserves_selector_when_fill_mfa_becomes_multi_factor_fill() -> None:
+    mfa_secret = "AAAAAAAAAAAA"  # pragma: allowlist secret
+    vault = MockVault({"https://example.com": {"email": "test@test.com", "password": "pw", "mfa_secret": mfa_secret}})
+    session = NoopLocateSession(vault=vault)
+    session.snapshot = make_snapshot("https://example.com")
+
+    action = FillAction(selector='internal:role=textbox[name="Enter code"i]', value=MFA)
+    updated = asyncio.run(session._action_with_vault(action))
+
+    assert isinstance(updated, MultiFactorFillAction)
+    assert updated.id == ""
+    assert updated.selector is not None
+    assert updated.selector.playwright_selector == 'internal:role=textbox[name="Enter code"i]'
+    assert isinstance(updated.value, ValueWithPlaceholder)
+    assert len(updated.value.get_secret_value()) == 6
+    assert updated.value.get_secret_value().isdigit()


### PR DESCRIPTION
## Summary
- Preserve selector-based targeting when vault replacement converts fill actions with MFA placeholders into multi_factor_fill actions
- Add regression coverage for selector-only MFA fill actions

## Test
- uv run pytest tests/test_session_vault_helpers.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential handling for MFA fields to properly preserve all action parameters (selector, text, timeout, and behavioral settings) when converting fill actions, previously these details were discarded.

* **Tests**
  * Added test coverage to verify MFA credential transformations retain proper selector information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a field-loss bug when converting a `FillAction` to `MultiFactorFillAction` during vault credential replacement. Previously, only `id` and `value` were copied — `selector`, `clear_before_fill`, `press_enter`, `text_label`, and `timeout` were silently dropped. The fix copies all fields and adds a regression test using a `NoopLocateSession` to verify selector preservation end-to-end.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f809eb1131f40ac37506a037dc522985fd1c8a8b.</sup>
<!-- /MENDRAL_SUMMARY -->