### PR TITLE
Remove resolution failure screenshot upload

### DIFF
--- a/tests/integration/test_resolution.py
+++ b/tests/integration/test_resolution.py
@@ -1,6 +1,3 @@
-import io
-
-import aiohttp
 import pytest
 from loguru import logger
 from notte_browser.resolution import NodeResolutionPipe
@@ -35,20 +32,6 @@ def urls() -> list[str]:
     ]
 
 
-async def upload_screenshot_to_0x0(screenshot_bytes: bytes) -> str:
-    # Save screenshot to bytes
-    bytes_io = io.BytesIO(screenshot_bytes)
-    _ = bytes_io.seek(0)
-
-    # Upload to 0x0.st
-    async with aiohttp.ClientSession() as session:
-        async with session.post(
-            "https://0x0.st", data={"file": bytes_io.read()}, headers={"User-Agent": "screenshot-debugger/1.0"}
-        ) as response:
-            screenshot_url = await response.text()
-            return screenshot_url.strip()
-
-
 @pytest.mark.flaky(reruns=2, reruns_delay=5)
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -61,7 +44,7 @@ async def test_action_node_resolution_pipe(url: str) -> None:
     total_count = 0
     async with NotteSession(headless=True, viewport_width=1280, viewport_height=1080) as page:
         _ = await page.aexecute(type="goto", value=url)
-        obs = await page.aobserve(perception_type="fast")
+        _ = await page.aobserve(perception_type="fast")
 
         for node in page.snapshot.interaction_nodes():
             total_count += 1
@@ -77,8 +60,7 @@ async def test_action_node_resolution_pipe(url: str) -> None:
                 errors.append(f"Error for node {node.id}: {e}")
 
     if total_count <= 0:
-        screenshot_url = await upload_screenshot_to_0x0(obs.screenshot.bytes())
-        assert total_count > 0, f"No nodes found. Screenshot: {screenshot_url}"
+        assert total_count > 0, "No nodes found."
 
     error_text = "\n".join(errors)
     assert len(error_text) == 0, f"Percentage of errors: {len(errors) / total_count * 100:.2f}%\n Errors:\n{error_text}"


### PR DESCRIPTION
## Summary
- remove the 0x0.st screenshot upload helper from the resolution integration test
- keep the no-node assertion local instead of depending on an external upload service

## Testing
- python -m py_compile tests/integration/test_resolution.py
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified test flow by removing indirect failure reporting and asserting positive result counts; observation handling streamlined.

* **Chores**
  * Removed unused dependencies and an obsolete screenshot-upload helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the `upload_screenshot_to_0x0` debug helper from the resolution integration test, replacing external screenshot uploads to `0x0.st` on failure with a plain assertion message. Also drops the now-unused `aiohttp` and `io` imports.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8feb56d742c31cdcbca990afe503d08255a90435.</sup>
<!-- /MENDRAL_SUMMARY -->