### PR TITLE
docs: add OpenClaw integration guide

### DIFF
--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -149,6 +149,7 @@
                   "integrations/massive",
                   "integrations/openai-cua",
                   "integrations/stagehand",
+                  "integrations/openclaw",
                   "features/sessions/cloudflare-web-bot-auth"
                 ]
               }

--- a/docs/src/integrations/openclaw.mdx
+++ b/docs/src/integrations/openclaw.mdx
@@ -1,0 +1,66 @@
+---
+title: OpenClaw
+description: 'Use Notte cloud browsers with OpenClaw'
+---
+import AgentMdNotice from '/partials/agent-md-notice.mdx';
+
+<AgentMdNotice />
+
+[OpenClaw](https://openclaw.ai) is an open-source personal AI assistant you run on your own devices. Its browser tool can drive any Chrome DevTools Protocol (CDP) endpoint — by pointing it at a Notte session URL, every browser task OpenClaw runs executes on a Notte cloud browser with built-in stealth, residential proxies, and anti-detection.
+
+## Prerequisites
+
+- A Notte API key ([get one here](https://console.notte.cc))
+- OpenClaw installed ([installation guide](https://docs.openclaw.ai))
+
+## Connect OpenClaw to a Notte browser
+
+OpenClaw's browser tool supports remote CDP **profiles**. Add a `notte` profile to `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "browser": {
+    "enabled": true,
+    "defaultProfile": "notte",
+    "remoteCdpTimeoutMs": 3000,
+    "remoteCdpHandshakeTimeoutMs": 5000,
+    "profiles": {
+      "notte": {
+        "cdpUrl": "wss://us-prod.notte.cc/sessions/connect?token=<NOTTE_API_KEY>",
+        "color": "#7C3AED"
+      }
+    }
+  }
+}
+```
+
+Replace `<NOTTE_API_KEY>` with your key from the [Notte console](https://console.notte.cc). That's it — OpenClaw now runs its browser tool on a Notte cloud browser.
+
+<Note>
+  The `wss://us-prod.notte.cc/sessions/connect` endpoint creates a fresh browser session when OpenClaw connects and tears it down when the connection closes — there is no manual session lifecycle to manage.
+</Note>
+
+## Run a browser task
+
+Start the profile and drive it from the OpenClaw CLI:
+
+```bash
+# Start the Notte-backed browser profile
+openclaw browser --browser-profile notte start
+
+# Open a page
+openclaw browser --browser-profile notte open https://example.com
+
+# Capture a screenshot
+openclaw browser --browser-profile notte screenshot
+```
+
+Once the profile is running, OpenClaw's agent uses it automatically for any task that needs a browser — every page load, click, and screenshot executes on the Notte cloud browser.
+
+## Benefits of using Notte with OpenClaw
+
+* **No local browser management**: run OpenClaw's browser tool without installing or maintaining Chrome locally
+* **Stealth & anti-detection**: built-in fingerprint hardening and CAPTCHA solving
+* **Residential proxies**: route traffic through residential IPs across regions
+* **Live session view**: watch any running session from the [Notte console](https://console.notte.cc)
+* **Scalability**: each connection gets its own isolated cloud browser, so multiple OpenClaw instances run in parallel without contention


### PR DESCRIPTION
## Summary

Adds `integrations/openclaw.mdx` — a guide for pointing [OpenClaw](https://openclaw.ai)'s browser tool at a Notte cloud browser via the `/sessions/connect` CDP endpoint. Registers the page in the Integrations nav, right after Stagehand.

## What changed

- **New:** `docs/src/integrations/openclaw.mdx` — intro, prerequisites, the `~/.openclaw/openclaw.json` config block, the `openclaw browser` CLI commands, and a benefits section. Modeled on the existing `stagehand.mdx` (external automation tool → Notte cloud browser).
- **Modified:** `docs/src/docs.json` — one nav entry (`integrations/openclaw`).

## Verification

Verified end-to-end against `wss://us-prod.notte.cc/sessions/connect`:

- `openclaw browser --browser-profile notte open https://example.com` → returns a real tab id
- `openclaw browser --browser-profile notte screenshot` → captures the rendered page
- Playwright `connectOverCDP` + `newCDPSession` round-trip also confirmed (~1.8s end-to-end)

## Notes

- Standalone page — does not depend on the parallel upstream OpenClaw docs PR ([openclaw/openclaw#81506](https://github.com/openclaw/openclaw/pull/81506)).
- Mintlify preview deploy on this PR will render the new page for a final visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenClaw integration documentation covering setup, configuration of cloud browser profiles, CLI commands for running browser tasks, and benefits including automatic browser management, anti-detection capabilities, residential proxies, live session monitoring, and cloud-based scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new `integrations/openclaw.mdx` doc page explaining how to point OpenClaw's CDP browser tool at a Notte cloud session via `wss://us-prod.notte.cc/sessions/connect`, and registers it in the nav.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9e03c23cdbd01f1b1d01b9a2c136d66a9dbbc0e3.</sup>
<!-- /MENDRAL_SUMMARY -->