### PR TITLE
Close local function runs on failure

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -165,6 +165,7 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 - [Massive](https://docs.notte.cc/integrations/massive.md): Use Massive residential proxies with Notte sessions
 - [OpenAI CUA](https://docs.notte.cc/integrations/openai-cua.md): Integrate OpenAI CUA with Notte Browser Sessions
 - [Stagehand](https://docs.notte.cc/integrations/stagehand.md): Use Notte cloud browsers with Stagehand browser automation
+- [OpenClaw](https://docs.notte.cc/integrations/openclaw.md): Use Notte cloud browsers with OpenClaw
 - [Cloudflare Web Bot Auth](https://docs.notte.cc/features/sessions/cloudflare-web-bot-auth.md): Access Cloudflare-protected websites by cryptographically signing browser requests
 
 
@@ -237,6 +238,13 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 ## Search
 
 - [POST Search Web](https://docs.notte.cc/api-reference/search/search-web.md)
+
+## Secrets
+
+- [DELETE Delete Secret](https://docs.notte.cc/api-reference/secrets/delete-secret.md)
+- [GET Get Secret](https://docs.notte.cc/api-reference/secrets/get-secret.md)
+- [GET List Secrets](https://docs.notte.cc/api-reference/secrets/list-secrets.md)
+- [POST Store Secret](https://docs.notte.cc/api-reference/secrets/store-secret.md)
 
 ## Sessions
 

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -835,7 +835,7 @@ class RemoteWorkflow:
             except Exception as e:
                 logger.error(f"[Function] {self.function_id} run failed with error: {traceback.format_exc()}")
                 result = str(e)
-                status = "failed"
+                status = "closed"
                 exception = e
             # update the run with the result
             self._session_id = log_capture.session_id

--- a/tests/integration/sdk/test_workflow_runs.py
+++ b/tests/integration/sdk/test_workflow_runs.py
@@ -330,14 +330,14 @@ class TestRemoteFunctionRuns:
         workflows_client.update_run.assert_called_once()
         assert workflows_client.update_run.call_args.kwargs["status"] == "closed"
 
-    @patch("notte_core.ast.SecureScriptRunner")
-    @patch("notte_sdk.utils.LogCapture")
+    @patch("notte_sdk.endpoints.workflows.SecureScriptRunner")
+    @patch("notte_sdk.endpoints.workflows.LogCapture")
     def test_remote_workflow_run_local(
         self, mock_log_capture, mock_script_runner, test_remote_workflow: RemoteWorkflow
     ):
         """Test running a RemoteWorkflow locally."""
         # Mock log capture
-        mock_log_instance = mock_log_capture.return_value.__enter__.return_value
+        mock_log_instance = mock_log_capture.return_value
         mock_log_instance.session_id = "test-session-id"
         mock_log_instance.get_logs.return_value = ["Log 1", "Log 2"]
 
@@ -346,7 +346,10 @@ class TestRemoteFunctionRuns:
         mock_runner_instance.run_script.return_value = {"test_var": "local_test", "result": "local_execution_result"}
 
         # Mock the download method to return script content with run function
-        with patch.object(test_remote_workflow, "download") as mock_download:
+        with (
+            patch.object(test_remote_workflow, "download") as mock_download,
+            patch.object(test_remote_workflow.client, "update_run") as mock_update_run,
+        ):
             mock_download.return_value = """import notte
 
 def run(test_var: str = "default"):
@@ -354,7 +357,7 @@ def run(test_var: str = "default"):
         return {"test_var": test_var, "result": "local_execution_result"}"""
 
             # Run locally
-            result = test_remote_workflow.run(local=True, test_var="local_test")
+            result = test_remote_workflow.run(local=True, function_run_id="test-run-id", test_var="local_test")
 
             assert result is not None
             assert isinstance(result, FunctionRunResponse)
@@ -362,8 +365,10 @@ def run(test_var: str = "default"):
             # Verify download was called
             mock_download.assert_called_once_with(workflow_path=None, version=None)
 
-            # The actual script execution happens, so just verify we got a response
-            # No need to verify mock calls since the real execution takes place
+            mock_runner_instance.run_script.assert_called_once()
+            mock_update_run.assert_called_once()
+            assert mock_update_run.call_args.kwargs["run_id"] == "test-run-id"
+            assert mock_update_run.call_args.kwargs["status"] == "closed"
 
     @patch("requests.post")
     def test_remote_workflow_run_cloud(self, mock_post, test_remote_workflow: RemoteWorkflow):

--- a/tests/integration/sdk/test_workflow_runs.py
+++ b/tests/integration/sdk/test_workflow_runs.py
@@ -2,7 +2,7 @@ import json
 import os
 import tempfile
 from collections.abc import Generator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from dotenv import load_dotenv
@@ -272,7 +272,7 @@ class TestFunctionRunExecution:
         assert response.function_run_id == create_response.function_run_id
         assert response.session_id is not None
         assert response.result is not None
-        assert response.status in ["closed", "active", "failed"]
+        assert response.status == "closed"
 
         # Verify both requests were made correctly
         assert mock_post.call_count == 2
@@ -304,6 +304,31 @@ class TestFunctionRunExecution:
 
 class TestRemoteFunctionRuns:
     """Test cases for RemoteWorkflow run functionality."""
+
+    @patch("notte_sdk.endpoints.workflows.SecureScriptRunner")
+    @patch("notte_sdk.endpoints.workflows.LogCapture")
+    def test_remote_workflow_run_local_failure_closes_run(self, mock_log_capture, mock_script_runner):
+        """Test local function failures close the run instead of marking it failed."""
+        workflows_client = MagicMock()
+        workflows_client.get.return_value.function_id = "test-function-id"
+        root_client = MagicMock()
+        root_client.workflows = workflows_client
+
+        workflow = RemoteWorkflow(workflow_id="test-function-id", _client=root_client)
+        log_capture = mock_log_capture.return_value
+        log_capture.__enter__.return_value = log_capture
+        log_capture.session_id = "test-session-id"
+        log_capture.get_logs.return_value = ["Log 1"]
+
+        mock_script_runner.return_value.run_script.side_effect = RuntimeError("boom")
+
+        with patch.object(workflow, "download", return_value="def run():\n    raise RuntimeError('boom')"):
+            result = workflow.run(local=True, function_run_id="test-run-id", raise_on_failure=False)
+
+        assert result.status == "closed"
+        assert result.result == "boom"
+        workflows_client.update_run.assert_called_once()
+        assert workflows_client.update_run.call_args.kwargs["status"] == "closed"
 
     @patch("notte_core.ast.SecureScriptRunner")
     @patch("notte_sdk.utils.LogCapture")


### PR DESCRIPTION
## Summary
- mark local function-run failures as `closed` instead of `failed`
- add a regression test covering the `raise_on_failure=False` local runner path used by the Lambda
- tighten the mocked cloud-run status expectation to `closed`

## Tests
- `uv run pytest tests/integration/sdk/test_workflow_runs.py::TestRemoteFunctionRuns::test_remote_workflow_run_local_failure_closes_run`
- `python -m py_compile tests/integration/sdk/test_workflow_runs.py packages/notte-sdk/src/notte_sdk/endpoints/workflows.py`
- pre-commit hooks passed; `docs-sdk-generate` was skipped during commit because it regenerated unrelated docs output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow runs that fail during local execution now report a "closed" status to the backend instead of "failed".

* **Tests**
  * Added integration tests verifying local execution failures mark runs as "closed" and surface error details.

* **Documentation**
  * Added an "OpenClaw" integration link and a new "Secrets" subsection with operations for storing, listing, retrieving, and deleting secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Changes the status of local function-run failures from `"failed"` to `"closed"`, aligning the local execution path with the cloud runner's status contract. Adds a regression test for the `raise_on_failure=False` path and fixes mock patching paths in the existing `test_remote_workflow_run_local` test.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 36e4cb2fe86a4cd078d5881d9045aa35ef468c8e.</sup>
<!-- /MENDRAL_SUMMARY -->