### PR TITLE
Fix prefixed selector action lookup

### DIFF
--- a/packages/notte-browser/src/notte_browser/dom/locate.py
+++ b/packages/notte-browser/src/notte_browser/dom/locate.py
@@ -41,14 +41,18 @@ async def locate_element(page: Page, selectors: NodeSelectors) -> Locator:
         except PlaywrightTimeoutError as e:
             raise InvalidLocatorRuntimeError("Element is not visible", selector=selectors.playwright_selector) from e
 
-    for selector in selectors.selectors():
+    candidate_selectors = selectors.selectors()
+    if len(candidate_selectors) == 0:
+        raise InvalidLocatorRuntimeError("No valid selector available", selector="")
+
+    for selector in candidate_selectors:
         locator = frame.locator(selector)
         count = await locator.count()
         if count > 1:
             logger.debug(f"Found {count} elements for '{selector}'. Check out the dom tree for more details.")
         elif count == 1:
             return locator
-    raise InvalidLocatorRuntimeError("count=0 for selector", selector=selectors.selectors()[0])
+    raise InvalidLocatorRuntimeError("count=0 for selector", selector=candidate_selectors[0])
 
 
 def selectors_through_shadow_dom(node: DomNode) -> NodeSelectors:

--- a/packages/notte-browser/src/notte_browser/dom/locate.py
+++ b/packages/notte-browser/src/notte_browser/dom/locate.py
@@ -25,13 +25,13 @@ async def locale_element_in_iframes(page: Page, selectors: NodeSelectors) -> Fra
 async def locate_element(page: Page, selectors: NodeSelectors) -> Locator:
     frame: Page | FrameLocator = page
 
-    if selectors.playwright_selector is not None:
+    if selectors.playwright_selector:
         return page.locator(selectors.playwright_selector)
 
     if selectors.in_iframe:
         frame = await locale_element_in_iframes(page, selectors)
     # regular case, locate element + scroll into view if needed
-    if selectors.playwright_selector is not None:
+    if selectors.playwright_selector:
         # for playwright we wait for the element to be visible
         locator = frame.locator(selectors.playwright_selector)
         if selectors.playwright_selector in DEFAULT_RAW_FILE_SELECTORS:

--- a/packages/notte-core/src/notte_core/browser/dom_tree.py
+++ b/packages/notte-core/src/notte_core/browser/dom_tree.py
@@ -77,9 +77,9 @@ class NodeSelectors(BaseModel):
         xpath_selector = ""
         playwright_selector: str | None = None
         if unique_selector.startswith("xpath="):
-            xpath_selector = unique_selector.replace("xpath=", "")
+            xpath_selector = unique_selector.removeprefix("xpath=")
         elif unique_selector.startswith("css="):
-            css_selector = unique_selector.replace("css=", "")
+            css_selector = unique_selector.removeprefix("css=")
         elif unique_selector.startswith("internal:"):
             playwright_selector = unique_selector
         elif unique_selector.startswith("~"):

--- a/packages/notte-core/src/notte_core/browser/dom_tree.py
+++ b/packages/notte-core/src/notte_core/browser/dom_tree.py
@@ -73,25 +73,25 @@ class NodeSelectors(BaseModel):
 
     @staticmethod
     def from_unique_selector(unique_selector: str) -> "NodeSelectors":
-        keys = dict(
-            css_selector="",
-            xpath_selector="",
-            playwright_selector="",
-        )
+        css_selector = ""
+        xpath_selector = ""
+        playwright_selector: str | None = None
         if unique_selector.startswith("xpath="):
-            keys["xpath_selector"] = unique_selector.replace("xpath=", "")
+            xpath_selector = unique_selector.replace("xpath=", "")
         elif unique_selector.startswith("css="):
-            keys["css_selector"] = unique_selector.replace("css=", "")
+            css_selector = unique_selector.replace("css=", "")
         elif unique_selector.startswith("internal:"):
-            keys["playwright_selector"] = unique_selector
+            playwright_selector = unique_selector
         elif unique_selector.startswith("~"):
             text = unique_selector.replace("~", "").strip()
-            keys["playwright_selector"] = f'internal:text="{text}"'
+            playwright_selector = f'internal:text="{text}"'
         else:
-            keys["playwright_selector"] = unique_selector
+            playwright_selector = unique_selector
 
         return NodeSelectors(
-            **keys,
+            css_selector=css_selector,
+            xpath_selector=xpath_selector,
+            playwright_selector=playwright_selector,
             notte_selector="",
             in_iframe=False,
             in_shadow_root=False,

--- a/tests/browser/test_node_type.py
+++ b/tests/browser/test_node_type.py
@@ -177,6 +177,16 @@ def test_html_selector():
     assert selector.xpath_selector == "//form/button[@name='Submit']"
 
 
+def test_from_unique_selector_strips_only_prefix():
+    css_selector = NodeSelectors.from_unique_selector('css=a[href*="css=foo"]')
+    xpath_selector = NodeSelectors.from_unique_selector('xpath=//a[contains(text(), "xpath=foo")]')
+
+    assert css_selector.css_selector == 'a[href*="css=foo"]'
+    assert css_selector.playwright_selector is None
+    assert xpath_selector.xpath_selector == '//a[contains(text(), "xpath=foo")]'
+    assert xpath_selector.playwright_selector is None
+
+
 def test_node_attributes():
     pre_attrs = DomAttributes.safe_init(
         modal=True,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -308,6 +308,30 @@ async def test_click_disabled_ancestor_returns_failed_result() -> None:
         assert "Element is disabled" in result.message
 
 
+@pytest.mark.parametrize("selector", ['xpath=//button[@id="target"]', "css=#target"])
+@pytest.mark.asyncio
+async def test_click_accepts_prefixed_selector(selector: str) -> None:
+    async with NotteSession(headless=True) as session:
+        await session.window.page.set_content("""
+            <button id="target">Apply</button>
+        """)
+        await session.window.page.evaluate("""
+            window.clicked = false;
+            document.querySelector("#target").addEventListener("click", () => {
+                window.clicked = true;
+            });
+        """)
+
+        result = await session.aexecute(
+            type="click",
+            selector=selector,
+            raise_on_failure=False,
+        )
+
+        assert result.success is True
+        assert await session.window.page.evaluate("window.clicked") is True
+
+
 @pytest.mark.asyncio
 async def test_interaction_execution_timeout_returns_failed_result() -> None:
     async def slow_execute(*_args, **_kwargs) -> bool:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -333,6 +333,20 @@ async def test_click_accepts_prefixed_selector(selector: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_click_empty_selector_returns_failed_result() -> None:
+    async with NotteSession(headless=True) as session:
+        result = await session.aexecute(
+            type="click",
+            selector="",
+            raise_on_failure=False,
+        )
+
+        assert result.success is False
+        assert result.message is not None
+        assert "No valid selector available" in result.message
+
+
+@pytest.mark.asyncio
 async def test_interaction_execution_timeout_returns_failed_result() -> None:
     async def slow_execute(*_args, **_kwargs) -> bool:
         await asyncio.sleep(0.05)


### PR DESCRIPTION
## Summary
- normalize prefixed CSS/XPath selectors without an empty Playwright selector
- skip empty Playwright selector values during action lookup
- add regression coverage for css= and xpath= click selectors

## Tests
- uv run pytest tests/test_session.py -k 'prefixed_selector or disabled_ancestor or timeout'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed selector handling so empty or prefixed selector variants no longer misroute; selector type parsing now preserves intended distinctions and yields consistent resolution and errors when no match is found.

* **Tests**
  * Added tests to verify click actions accept prefixed selectors (xpath=..., css=...) and selector parsing preserves prefixes while setting selector fields correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes `from_unique_selector` to set `playwright_selector=None` (instead of `""`) for `css=` and `xpath=` prefixed inputs, which previously caused `locate_element` to invoke `page.locator("")` and misroute the lookup. Pairs with truthiness guards in `locate_element` and an early-exit when no candidate selectors are available.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7132880907c0df3c4bd10291b423c9c63ff9da57.</sup>
<!-- /MENDRAL_SUMMARY -->