### PR TITLE
Add templates link to docs getting started

### DIFF
--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -30,6 +30,7 @@
                 "pages": [
                   "index",
                   "quickstart",
+                  "templates",
                   "concepts"
                 ]
               },

--- a/docs/src/index.mdx
+++ b/docs/src/index.mdx
@@ -5,9 +5,13 @@ mode: "wide"
 
 Notte is the unified platform for AI agents and automation scripts that need to use the browser. Build, debug, and deploy production workflows with cloud browsers, web agents, scraping, serverless functions, credentials, and identities in one place.
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Quickstart" icon="square-arrow-up-right" href="/quickstart">
     Continue to the full quickstart for Agents, Scraping, and additional examples.
+  </Card>
+
+  <Card title="Templates" icon="copy" href="https://www.notte.cc/templates">
+    Start from ready-made browser automation templates for common workflows.
   </Card>
 
   <Card title="SDK Reference" icon="book" href="/sdk-reference/manual/index">

--- a/docs/src/templates.mdx
+++ b/docs/src/templates.mdx
@@ -1,0 +1,4 @@
+---
+title: Templates
+url: "https://www.notte.cc/templates"
+---


### PR DESCRIPTION
## Summary
- Add a Templates card to the docs introduction page
- Add Templates to the Getting Started sidebar as an external link

## Checks
- jq empty docs/src/docs.json
- git diff --check
- pre-commit docs checks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Templates page to the documentation
  * Reorganized the homepage introduction section layout to feature the new Templates section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a Templates card to the docs introduction page and a Templates entry in the Getting Started sidebar, both linking to the external notte.cc/templates page.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b861b777955ef72583a685cab6d508013d5f57de.</sup>
<!-- /MENDRAL_SUMMARY -->