### PR TITLE
docs: note 100MB file upload limit

### DIFF
--- a/docs/src/concepts/file-storage.mdx
+++ b/docs/src/concepts/file-storage.mdx
@@ -53,6 +53,11 @@ Upload files from your local machine to make them available in sessions:
 
 <UploadingFiles />
 
+<Note>
+  Each uploaded file must be under **100 MB**. For larger files, contact the
+  team at [support@notte.cc](mailto:support@notte.cc).
+</Note>
+
 ## Downloading Files
 
 Download files that agents retrieved from websites:


### PR DESCRIPTION
## What

Adds a `<Note>` to the File Storage docs page stating that each uploaded file must be under **100 MB**, with a pointer to support@notte.cc for larger files.

## Why

The upload size limit was not documented anywhere in the docs. A user hit a `max retries` error uploading a ~500MB mp4 via the Python SDK and had no way to know the cap existed. Verified the limit by probing the upload endpoint: files up to 99 MB succeed, 100 MB+ are rejected.

## Notes

Factual limit only, no infra detail. The SDK reference `upload()` page is auto-generated from docstrings, so it is not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated file storage documentation to clarify the 100 MB upload file size limit and provide guidance for users needing to upload larger files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `<Note>` component to the file-storage docs page documenting the 100 MB per-file upload limit and directing users with larger files to support.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 955dc30dda67df9801df6c326bc89efe64f667a3.</sup>
<!-- /MENDRAL_SUMMARY -->