### PR TITLE
docs: add Fireworks AI integration page

### DIFF
--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -149,6 +149,7 @@
                   "integrations/steel",
                   "integrations/massive",
                   "integrations/openai-cua",
+                  "integrations/fireworks",
                   "integrations/stagehand",
                   "integrations/openclaw",
                   "features/sessions/cloudflare-web-bot-auth"

--- a/docs/src/integrations/fireworks.mdx
+++ b/docs/src/integrations/fireworks.mdx
@@ -10,7 +10,7 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 Notte agents can drive the browser using any model served by [Fireworks AI](https://fireworks.ai), including Kimi K2.5, GLM-5, and MiniMax M2.5. Notte connects to Fireworks through LiteLLM, so the integration is a single `reasoning_model` string change with no separate provider plumbing.
 
-A recent joint benchmark, [Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agents-fail-on-execution), ran 720 browser-agent tasks across four LLMs. The three Fireworks-served models held an [Agent Execution Tax](https://notte.cc/blog/agent-execution-tax) of 0 to 1.6%, with consistent tail latency across three distinct MoE architectures.
+A recent joint benchmark, [Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax), ran 720 browser-agent tasks across four LLMs. The three Fireworks-served models held an [Agent Execution Tax](https://notte.cc/blog/agent-execution-tax) of 0 to 1.6%, with consistent tail latency across three distinct MoE architectures.
 
 ## Requirements
 
@@ -56,8 +56,8 @@ The following models were validated in the joint benchmark (180 runs each, 60 We
 | Model | Notes |
 |---|---|
 | Kimi K2.5 | 0% Agent Execution Tax across 852 calls; lowest token cost per task. Model ID: `fireworks_ai/accounts/fireworks/models/kimi-k2p5` |
-| GLM-5 | 0.6% Agent Execution Tax; strong on long-form sites (ArXiv, BBC, Wolfram Alpha). |
-| MiniMax M2.5 | 1.6% Agent Execution Tax; highest text-only task success rate in the benchmark. |
+| GLM-5 | 0.6% Agent Execution Tax; strong on long-form sites (ArXiv, BBC, Wolfram Alpha). Model ID: `fireworks_ai/accounts/fireworks/models/glm-5` |
+| MiniMax M2.5 | 1.6% Agent Execution Tax; highest text-only task success rate in the benchmark. Model ID: `fireworks_ai/accounts/fireworks/models/minimax-m2p5` |
 
 Any Fireworks-served model that supports JSON-mode structured output will work with Notte. For canonical model IDs, see the [Fireworks model catalogue](https://fireworks.ai/models).
 
@@ -72,11 +72,11 @@ uv run pytest packages/notte-eval/src/notte_eval/webvoyager/test_run.py \
   --n_runs 3 --use_vision false --headless true --max_steps 20 -v
 ```
 
-Full configuration, methodology, and per-model numbers are in the [joint benchmark report](https://fireworks.ai/blog/agents-fail-on-execution).
+Full configuration, methodology, and per-model numbers are in the [joint benchmark report](https://fireworks.ai/blog/agent-execution-tax).
 
 ## Resources
 
-* [Joint benchmark: Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agents-fail-on-execution)
+* [Joint benchmark: Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax)
 * [Agent Execution Tax explainer](https://notte.cc/blog/agent-execution-tax)
 * [Fireworks AI](https://fireworks.ai) and the [Fireworks model catalogue](https://fireworks.ai/models)
 * [Notte on GitHub](https://github.com/nottelabs/notte)

--- a/docs/src/integrations/fireworks.mdx
+++ b/docs/src/integrations/fireworks.mdx
@@ -1,0 +1,82 @@
+---
+title: 'Fireworks AI'
+description: 'Run Notte browser agents on Fireworks-served open-weight models'
+---
+import AgentMdNotice from '/partials/agent-md-notice.mdx';
+
+<AgentMdNotice />
+
+## Overview
+
+Notte agents can drive the browser using any model served by [Fireworks AI](https://fireworks.ai), including Kimi K2.5, GLM-5, and MiniMax M2.5. Notte connects to Fireworks through LiteLLM, so the integration is a single `reasoning_model` string change with no separate provider plumbing.
+
+A recent joint benchmark, [Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agents-fail-on-execution), ran 720 browser-agent tasks across four LLMs. The three Fireworks-served models held an [Agent Execution Tax](https://notte.cc/blog/agent-execution-tax) of 0 to 1.6%, with consistent tail latency across three distinct MoE architectures.
+
+## Requirements
+
+* A Fireworks AI API key ([fireworks.ai](https://fireworks.ai))
+* A Notte API key ([console.notte.cc](https://console.notte.cc))
+* Python 3.11 or later
+
+## Setup
+
+<Steps>
+  <Step title="Install the Notte SDK">
+    ```bash
+    pip install --upgrade notte-sdk
+    ```
+  </Step>
+  <Step title="Configure your API keys as environment variables">
+    ```bash
+    export NOTTE_API_KEY="<your-notte-api-key>"
+    export FIREWORKS_API_KEY="<your-fireworks-api-key>"
+    ```
+  </Step>
+  <Step title="Run an agent against a Fireworks-served model">
+    ```python
+    from notte_sdk import NotteClient
+
+    notte = NotteClient()
+    with notte.Session() as session:
+        agent = notte.Agent(
+            session=session,
+            reasoning_model="fireworks_ai/accounts/fireworks/models/kimi-k2p5",
+        )
+        response = agent.run(
+            task="Go to news.ycombinator.com and return the top three stories."
+        )
+    ```
+  </Step>
+</Steps>
+
+## Validated Fireworks models
+
+The following models were validated in the joint benchmark (180 runs each, 60 WebVoyager tasks × 3 runs):
+
+| Model | Notes |
+|---|---|
+| Kimi K2.5 | 0% Agent Execution Tax across 852 calls; lowest token cost per task. Model ID: `fireworks_ai/accounts/fireworks/models/kimi-k2p5` |
+| GLM-5 | 0.6% Agent Execution Tax; strong on long-form sites (ArXiv, BBC, Wolfram Alpha). |
+| MiniMax M2.5 | 1.6% Agent Execution Tax; highest text-only task success rate in the benchmark. |
+
+Any Fireworks-served model that supports JSON-mode structured output will work with Notte. For canonical model IDs, see the [Fireworks model catalogue](https://fireworks.ai/models).
+
+## Reproducing the benchmark
+
+The benchmark is fully reproducible from the Notte repo:
+
+```bash
+uv run pytest packages/notte-eval/src/notte_eval/webvoyager/test_run.py \
+  --task_dir "webvoyager/webvoyager_simple.jsonl" \
+  --model "fireworks_ai/accounts/fireworks/models/kimi-k2p5" \
+  --n_runs 3 --use_vision false --headless true --max_steps 20 -v
+```
+
+Full configuration, methodology, and per-model numbers are in the [joint benchmark report](https://fireworks.ai/blog/agents-fail-on-execution).
+
+## Resources
+
+* [Joint benchmark: Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agents-fail-on-execution)
+* [Agent Execution Tax explainer](https://notte.cc/blog/agent-execution-tax)
+* [Fireworks AI](https://fireworks.ai) and the [Fireworks model catalogue](https://fireworks.ai/models)
+* [Notte on GitHub](https://github.com/nottelabs/notte)

--- a/docs/src/integrations/fireworks.mdx
+++ b/docs/src/integrations/fireworks.mdx
@@ -13,7 +13,6 @@ For numbers on how these models hold up across browser-agent workloads, see the 
 
 ## Prerequisites
 
-- A Notte API key ([get one here](https://console.notte.cc))
 - A Fireworks AI API key ([fireworks.ai](https://fireworks.ai))
 - Python 3.11 or later
 

--- a/docs/src/integrations/fireworks.mdx
+++ b/docs/src/integrations/fireworks.mdx
@@ -7,7 +7,7 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 <AgentMdNotice />
 
-[Fireworks AI](https://fireworks.ai) hosts open-weight LLMs including Kimi K2.5, GLM-5, and MiniMax M2.5. To run a Notte agent on any of them, pass the model string to `reasoning_model`. Notte talks to Fireworks through LiteLLM, so there's no extra provider setup.
+[Fireworks AI](https://fireworks.ai) hosts open-weight LLMs such as Kimi, GLM, and MiniMax. To run a Notte agent on any of them, pass the model string to `reasoning_model`. Notte talks to Fireworks through LiteLLM, so there's no extra provider setup.
 
 For numbers on how these models hold up across browser-agent workloads, see the joint benchmark, [Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax).
 
@@ -38,13 +38,13 @@ Pass the model string (formatted as `fireworks_ai/accounts/fireworks/models/<id>
 
 ## Supported models
 
-Any Fireworks model with JSON-mode structured output works with Notte. Three were covered in the joint benchmark with Fireworks:
+Any Fireworks model with JSON-mode structured output works with Notte. For example:
 
 - Kimi K2.5: `fireworks_ai/accounts/fireworks/models/kimi-k2p5`
-- GLM-5: `fireworks_ai/accounts/fireworks/models/glm-5`
-- MiniMax M2.5: `fireworks_ai/accounts/fireworks/models/minimax-m2p5`
+- GLM 5.2: `fireworks_ai/accounts/fireworks/models/glm-5p2`
+- MiniMax M3: `fireworks_ai/accounts/fireworks/models/minimax-m3`
 
-See the [Fireworks model catalogue](https://fireworks.ai/models) for everything else.
+Model availability on Fireworks changes over time — see the [Fireworks model catalogue](https://fireworks.ai/models) for the current list. For how Fireworks-served models perform on browser-agent workloads, see the [joint benchmark](https://fireworks.ai/blog/agent-execution-tax).
 
 ## Resources
 

--- a/docs/src/integrations/fireworks.mdx
+++ b/docs/src/integrations/fireworks.mdx
@@ -22,13 +22,12 @@ For numbers on how these models hold up across browser-agent workloads, see the 
 ### 1. Install the SDK
 
 ```bash
-pip install --upgrade notte-sdk
+pip install --upgrade notte
 ```
 
-### 2. Set your API keys
+### 2. Set your API key
 
 ```bash
-export NOTTE_API_KEY=<your-notte-api-key>
 export FIREWORKS_API_KEY=<your-fireworks-api-key>
 ```
 

--- a/docs/src/integrations/fireworks.mdx
+++ b/docs/src/integrations/fireworks.mdx
@@ -79,4 +79,5 @@ Full configuration, methodology, and per-model numbers are in the [joint benchma
 * [Joint benchmark: Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax)
 * [Agent Execution Tax explainer](https://notte.cc/blog/agent-execution-tax)
 * [Fireworks AI](https://fireworks.ai) and the [Fireworks model catalogue](https://fireworks.ai/models)
-* [Notte on GitHub](https://github.com/nottelabs/notte)
+* [Browser Arena](https://browserarena.ai): Notte's open benchmark of cloud browser providers
+* [Notte Console](https://console.notte.cc)

--- a/docs/src/integrations/fireworks.mdx
+++ b/docs/src/integrations/fireworks.mdx
@@ -7,9 +7,9 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 <AgentMdNotice />
 
-[Fireworks AI](https://fireworks.ai) serves open-weight LLMs (Kimi K2.5, GLM-5, MiniMax M2.5, and others) on production-grade inference infrastructure. By passing a Fireworks model string to a Notte agent, you can run browser automations on any Fireworks-hosted model without writing provider-specific code: Notte connects to Fireworks through LiteLLM, so the integration is a single `reasoning_model` string change.
+[Fireworks AI](https://fireworks.ai) hosts open-weight LLMs including Kimi K2.5, GLM-5, and MiniMax M2.5. To run a Notte agent on any of them, pass the model string to `reasoning_model`. Notte talks to Fireworks through LiteLLM, so there's no extra provider setup.
 
-For benchmark context on running browser agents across Fireworks-served models, see [Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax).
+For numbers on how these models hold up across browser-agent workloads, see the joint benchmark, [Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax).
 
 ## Prerequisites
 
@@ -19,38 +19,34 @@ For benchmark context on running browser agents across Fireworks-served models, 
 
 ## Setup
 
-### 1. Install the Notte SDK
+### 1. Install the SDK
 
 ```bash
 pip install --upgrade notte-sdk
 ```
 
-### 2. Configure your API keys
-
-Set the following environment variables:
+### 2. Set your API keys
 
 ```bash
 export NOTTE_API_KEY=<your-notte-api-key>
 export FIREWORKS_API_KEY=<your-fireworks-api-key>
 ```
 
-### 3. Run an agent against a Fireworks-served model
+### 3. Run an agent on a Fireworks model
 
-Pass a `reasoning_model` string in the `fireworks_ai/accounts/fireworks/models/<id>` shape:
+Pass the model string (formatted as `fireworks_ai/accounts/fireworks/models/<id>`) to `reasoning_model`:
 
 <FireworksBasic />
 
-That's it: the agent now drives the browser using Kimi K2.5 served by Fireworks.
-
 ## Supported models
 
-Any Fireworks-served model that supports JSON-mode structured output will work with Notte. The following were validated as part of the joint Notte × Fireworks benchmark:
+Any Fireworks model with JSON-mode structured output works with Notte. Three were covered in the joint benchmark with Fireworks:
 
 - Kimi K2.5: `fireworks_ai/accounts/fireworks/models/kimi-k2p5`
 - GLM-5: `fireworks_ai/accounts/fireworks/models/glm-5`
 - MiniMax M2.5: `fireworks_ai/accounts/fireworks/models/minimax-m2p5`
 
-See the [Fireworks model catalogue](https://fireworks.ai/models) for the full list.
+See the [Fireworks model catalogue](https://fireworks.ai/models) for everything else.
 
 ## Resources
 

--- a/docs/src/integrations/fireworks.mdx
+++ b/docs/src/integrations/fireworks.mdx
@@ -2,82 +2,60 @@
 title: 'Fireworks AI'
 description: 'Run Notte browser agents on Fireworks-served open-weight models'
 ---
+import FireworksBasic from '/snippets/integrations/fireworks_basic.mdx';
 import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 <AgentMdNotice />
 
-## Overview
+[Fireworks AI](https://fireworks.ai) serves open-weight LLMs (Kimi K2.5, GLM-5, MiniMax M2.5, and others) on production-grade inference infrastructure. By passing a Fireworks model string to a Notte agent, you can run browser automations on any Fireworks-hosted model without writing provider-specific code: Notte connects to Fireworks through LiteLLM, so the integration is a single `reasoning_model` string change.
 
-Notte agents can drive the browser using any model served by [Fireworks AI](https://fireworks.ai), including Kimi K2.5, GLM-5, and MiniMax M2.5. Notte connects to Fireworks through LiteLLM, so the integration is a single `reasoning_model` string change with no separate provider plumbing.
+For benchmark context on running browser agents across Fireworks-served models, see [Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax).
 
-A recent joint benchmark, [Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax), ran 720 browser-agent tasks across four LLMs. The three Fireworks-served models held an [Agent Execution Tax](https://notte.cc/blog/agent-execution-tax) of 0 to 1.6%, with consistent tail latency across three distinct MoE architectures.
+## Prerequisites
 
-## Requirements
-
-* A Fireworks AI API key ([fireworks.ai](https://fireworks.ai))
-* A Notte API key ([console.notte.cc](https://console.notte.cc))
-* Python 3.11 or later
+- A Notte API key ([get one here](https://console.notte.cc))
+- A Fireworks AI API key ([fireworks.ai](https://fireworks.ai))
+- Python 3.11 or later
 
 ## Setup
 
-<Steps>
-  <Step title="Install the Notte SDK">
-    ```bash
-    pip install --upgrade notte-sdk
-    ```
-  </Step>
-  <Step title="Configure your API keys as environment variables">
-    ```bash
-    export NOTTE_API_KEY="<your-notte-api-key>"
-    export FIREWORKS_API_KEY="<your-fireworks-api-key>"
-    ```
-  </Step>
-  <Step title="Run an agent against a Fireworks-served model">
-    ```python
-    from notte_sdk import NotteClient
-
-    notte = NotteClient()
-    with notte.Session() as session:
-        agent = notte.Agent(
-            session=session,
-            reasoning_model="fireworks_ai/accounts/fireworks/models/kimi-k2p5",
-        )
-        response = agent.run(
-            task="Go to news.ycombinator.com and return the top three stories."
-        )
-    ```
-  </Step>
-</Steps>
-
-## Validated Fireworks models
-
-The following models were validated in the joint benchmark (180 runs each, 60 WebVoyager tasks × 3 runs):
-
-| Model | Notes |
-|---|---|
-| Kimi K2.5 | 0% Agent Execution Tax across 852 calls; lowest token cost per task. Model ID: `fireworks_ai/accounts/fireworks/models/kimi-k2p5` |
-| GLM-5 | 0.6% Agent Execution Tax; strong on long-form sites (ArXiv, BBC, Wolfram Alpha). Model ID: `fireworks_ai/accounts/fireworks/models/glm-5` |
-| MiniMax M2.5 | 1.6% Agent Execution Tax; highest text-only task success rate in the benchmark. Model ID: `fireworks_ai/accounts/fireworks/models/minimax-m2p5` |
-
-Any Fireworks-served model that supports JSON-mode structured output will work with Notte. For canonical model IDs, see the [Fireworks model catalogue](https://fireworks.ai/models).
-
-## Reproducing the benchmark
-
-The benchmark is fully reproducible from the Notte repo:
+### 1. Install the Notte SDK
 
 ```bash
-uv run pytest packages/notte-eval/src/notte_eval/webvoyager/test_run.py \
-  --task_dir "webvoyager/webvoyager_simple.jsonl" \
-  --model "fireworks_ai/accounts/fireworks/models/kimi-k2p5" \
-  --n_runs 3 --use_vision false --headless true --max_steps 20 -v
+pip install --upgrade notte-sdk
 ```
 
-Full configuration, methodology, and per-model numbers are in the [joint benchmark report](https://fireworks.ai/blog/agent-execution-tax).
+### 2. Configure your API keys
+
+Set the following environment variables:
+
+```bash
+export NOTTE_API_KEY=<your-notte-api-key>
+export FIREWORKS_API_KEY=<your-fireworks-api-key>
+```
+
+### 3. Run an agent against a Fireworks-served model
+
+Pass a `reasoning_model` string in the `fireworks_ai/accounts/fireworks/models/<id>` shape:
+
+<FireworksBasic />
+
+That's it: the agent now drives the browser using Kimi K2.5 served by Fireworks.
+
+## Supported models
+
+Any Fireworks-served model that supports JSON-mode structured output will work with Notte. The following were validated as part of the joint Notte × Fireworks benchmark:
+
+- Kimi K2.5: `fireworks_ai/accounts/fireworks/models/kimi-k2p5`
+- GLM-5: `fireworks_ai/accounts/fireworks/models/glm-5`
+- MiniMax M2.5: `fireworks_ai/accounts/fireworks/models/minimax-m2p5`
+
+See the [Fireworks model catalogue](https://fireworks.ai/models) for the full list.
 
 ## Resources
 
-* [Joint benchmark: Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax)
-* [Agent Execution Tax explainer](https://notte.cc/blog/agent-execution-tax)
-* [Fireworks AI](https://fireworks.ai) and the [Fireworks model catalogue](https://fireworks.ai/models)
-* [Browser Arena](https://browserarena.ai): Notte's open benchmark of cloud browser providers
-* [Notte Console](https://console.notte.cc)
+- [Joint benchmark: Agents Don't Fail on Intelligence. They Fail on Execution](https://fireworks.ai/blog/agent-execution-tax)
+- [Agent Execution Tax explainer](https://notte.cc/blog/agent-execution-tax)
+- [Fireworks AI](https://fireworks.ai) and the [Fireworks model catalogue](https://fireworks.ai/models)
+- [Browser Arena](https://browserarena.ai): Notte's open benchmark of cloud browser providers
+- [Notte Console](https://console.notte.cc)

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -164,6 +164,7 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 - [Steel](https://docs.notte.cc/integrations/steel.md): Run Notte with Steel cloud browsers (CDP)
 - [Massive](https://docs.notte.cc/integrations/massive.md): Use Massive residential proxies with Notte sessions
 - [OpenAI CUA](https://docs.notte.cc/integrations/openai-cua.md): Integrate OpenAI CUA with Notte Browser Sessions
+- [Fireworks AI](https://docs.notte.cc/integrations/fireworks.md): Run Notte browser agents on Fireworks-served open-weight models
 - [Stagehand](https://docs.notte.cc/integrations/stagehand.md): Use Notte cloud browsers with Stagehand browser automation
 - [OpenClaw](https://docs.notte.cc/integrations/openclaw.md): Use Notte cloud browsers with OpenClaw
 - [Cloudflare Web Bot Auth](https://docs.notte.cc/features/sessions/cloudflare-web-bot-auth.md): Access Cloudflare-protected websites by cryptographically signing browser requests

--- a/docs/src/quickstart.mdx
+++ b/docs/src/quickstart.mdx
@@ -223,7 +223,7 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
           "",
           "**Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.",
           "",
-          "Session debugging and export:",
+          "Session debugging:",
           "",
           "```bash",
           "# Get network logs",
@@ -231,11 +231,49 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
           "",
           "# Get replay URL/data",
           "notte sessions replay",
+          "```",
           "",
+          "Session export:",
+          "",
+          "```bash",
           "# Export session steps as Python workflow code.",
           "# Use --session-id to export a specific session, including one that has been stopped.",
-          "notte sessions workflow-code",
           "notte sessions workflow-code --session-id <session-id>",
+          "",
+          "# example flow",
+          "notte sessions start",
+          "notte page goto news.ycombinator.com",
+          "notte page scrape --instructions \"Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments\" -o json",
+          "notte sessions workflow-code",
+          "",
+          "# returns",
+          "from __future__ import annotations",
+          "",
+          "from notte_sdk import NotteClient",
+          "from pydantic import BaseModel",
+          "",
+          "class Story(BaseModel):",
+          "    rank: int | None = None",
+          "    title: str | None = None",
+          "    url: str | None = None",
+          "    points: int | None = None",
+          "    author: str | None = None",
+          "    number_of_comments: int | None = None",
+          "",
+          "",
+          "class Model(BaseModel):",
+          "    stories: list[Story] | None = None",
+          "",
+          "client = NotteClient()",
+          "",
+          "def run() -> Model:",
+          "    with client.Session(use_file_storage=True) as session:",
+          "        _ = session.execute(type='goto', url='news.ycombinator.com')",
+          "",
+          "        # directly parses the output using response_format and returns the Model",
+          "        return session.scrape(instructions='Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments', only_main_content=False, only_images=False, scrape_links=True, scrape_images=False, response_format=Model)",
+          "",
+          "run()",
           "```",
           "",
           "Cookie management:",
@@ -1040,7 +1078,7 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
 
     **Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.
 
-    Session debugging and export:
+    Session debugging:
 
     ```bash
     # Get network logs
@@ -1048,11 +1086,49 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
 
     # Get replay URL/data
     notte sessions replay
+    ```
 
+    Session export:
+
+    ```bash
     # Export session steps as Python workflow code.
     # Use --session-id to export a specific session, including one that has been stopped.
-    notte sessions workflow-code
     notte sessions workflow-code --session-id <session-id>
+
+    # example flow
+    notte sessions start
+    notte page goto news.ycombinator.com
+    notte page scrape --instructions "Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments" -o json
+    notte sessions workflow-code
+
+    # returns
+    from __future__ import annotations
+
+    from notte_sdk import NotteClient
+    from pydantic import BaseModel
+
+    class Story(BaseModel):
+        rank: int | None = None
+        title: str | None = None
+        url: str | None = None
+        points: int | None = None
+        author: str | None = None
+        number_of_comments: int | None = None
+
+
+    class Model(BaseModel):
+        stories: list[Story] | None = None
+
+    client = NotteClient()
+
+    def run() -> Model:
+        with client.Session(use_file_storage=True) as session:
+            _ = session.execute(type='goto', url='news.ycombinator.com')
+
+            # directly parses the output using response_format and returns the Model
+            return session.scrape(instructions='Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments', only_main_content=False, only_images=False, scrape_links=True, scrape_images=False, response_format=Model)
+
+    run()
     ```
 
     Cookie management:
@@ -1838,7 +1914,7 @@ notte sessions list [--page N] [--page-size N] [--only-active]
 
 **Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.
 
-Session debugging and export:
+Session debugging:
 
 ```bash
 # Get network logs
@@ -1846,11 +1922,49 @@ notte sessions network
 
 # Get replay URL/data
 notte sessions replay
+```
 
+Session export:
+
+```bash
 # Export session steps as Python workflow code.
 # Use --session-id to export a specific session, including one that has been stopped.
-notte sessions workflow-code
 notte sessions workflow-code --session-id <session-id>
+
+# example flow
+notte sessions start
+notte page goto news.ycombinator.com
+notte page scrape --instructions "Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments" -o json
+notte sessions workflow-code
+
+# returns
+from __future__ import annotations
+
+from notte_sdk import NotteClient
+from pydantic import BaseModel
+
+class Story(BaseModel):
+    rank: int | None = None
+    title: str | None = None
+    url: str | None = None
+    points: int | None = None
+    author: str | None = None
+    number_of_comments: int | None = None
+
+
+class Model(BaseModel):
+    stories: list[Story] | None = None
+
+client = NotteClient()
+
+def run() -> Model:
+    with client.Session(use_file_storage=True) as session:
+        _ = session.execute(type='goto', url='news.ycombinator.com')
+
+        # directly parses the output using response_format and returns the Model
+        return session.scrape(instructions='Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments', only_main_content=False, only_images=False, scrape_links=True, scrape_images=False, response_format=Model)
+
+run()
 ```
 
 Cookie management:

--- a/docs/src/snippets/integrations/fireworks_basic.mdx
+++ b/docs/src/snippets/integrations/fireworks_basic.mdx
@@ -1,0 +1,17 @@
+{/* Auto-generated mdx file. Do not edit! */}
+{/* @sniptest testers/integrations/fireworks_basic.py */}
+
+```python fireworks_basic.py
+from notte_sdk import NotteClient
+
+client = NotteClient()
+
+with client.Session() as session:
+    agent = client.Agent(
+        session=session,
+        reasoning_model="fireworks_ai/accounts/fireworks/models/kimi-k2p5",
+    )
+    response = agent.run(
+        task="Go to news.ycombinator.com and return the top three stories."
+    )
+```

--- a/docs/src/snippets/integrations/fireworks_basic.mdx
+++ b/docs/src/snippets/integrations/fireworks_basic.mdx
@@ -2,16 +2,12 @@
 {/* @sniptest testers/integrations/fireworks_basic.py */}
 
 ```python fireworks_basic.py
-from notte_sdk import NotteClient
+import notte
 
-client = NotteClient()
-
-with client.Session() as session:
-    agent = client.Agent(
+with notte.Session() as session:
+    agent = notte.Agent(
         session=session,
         reasoning_model="fireworks_ai/accounts/fireworks/models/kimi-k2p5",
     )
-    response = agent.run(
-        task="Go to news.ycombinator.com and return the top three stories."
-    )
+    response = agent.run(task="Go to news.ycombinator.com and return the top three stories.")
 ```

--- a/docs/src/testers/integrations/fireworks_basic.py
+++ b/docs/src/testers/integrations/fireworks_basic.py
@@ -1,13 +1,9 @@
 # @sniptest filename=fireworks_basic.py
-from notte_sdk import NotteClient
+import notte
 
-client = NotteClient()
-
-with client.Session() as session:
-    agent = client.Agent(
+with notte.Session() as session:
+    agent = notte.Agent(
         session=session,
         reasoning_model="fireworks_ai/accounts/fireworks/models/kimi-k2p5",
     )
-    response = agent.run(
-        task="Go to news.ycombinator.com and return the top three stories."
-    )
+    response = agent.run(task="Go to news.ycombinator.com and return the top three stories.")

--- a/docs/src/testers/integrations/fireworks_basic.py
+++ b/docs/src/testers/integrations/fireworks_basic.py
@@ -1,0 +1,13 @@
+# @sniptest filename=fireworks_basic.py
+from notte_sdk import NotteClient
+
+client = NotteClient()
+
+with client.Session() as session:
+    agent = client.Agent(
+        session=session,
+        reasoning_model="fireworks_ai/accounts/fireworks/models/kimi-k2p5",
+    )
+    response = agent.run(
+        task="Go to news.ycombinator.com and return the top three stories."
+    )

--- a/docs/src/tests/test_snippets.py
+++ b/docs/src/tests/test_snippets.py
@@ -88,6 +88,7 @@ def test_no_snippets_outside_folder():
         "captcha-solving.mdx",  # CodeGroup wrappers for multi-language
         "stealth-mode.mdx",  # CodeGroup wrappers for multi-language
         "kernel.mdx",  # Integration-specific examples
+        "fireworks.mdx",  # Integration-specific examples
         "schedules.mdx",  # Comment-only cron examples
         "management.mdx",  # Comment-only metadata example
         "quickstart.mdx",  # CodeGroup with Python/JS tabs

--- a/docs/src/tests/test_snippets.py
+++ b/docs/src/tests/test_snippets.py
@@ -88,7 +88,6 @@ def test_no_snippets_outside_folder():
         "captcha-solving.mdx",  # CodeGroup wrappers for multi-language
         "stealth-mode.mdx",  # CodeGroup wrappers for multi-language
         "kernel.mdx",  # Integration-specific examples
-        "fireworks.mdx",  # Integration-specific examples
         "schedules.mdx",  # Comment-only cron examples
         "management.mdx",  # Comment-only metadata example
         "quickstart.mdx",  # CodeGroup with Python/JS tabs


### PR DESCRIPTION
## Summary

- Adds `docs/src/integrations/fireworks.mdx` documenting how to run Notte agents on Fireworks-served models (Kimi K2.5, GLM-5, MiniMax M2.5)
- Registers the page in `docs/src/docs.json` under the Integrations group (placed after `openai-cua`)
- Modelled on the existing `openai-cua.mdx` format: frontmatter + `AgentMdNotice` partial + `<Steps>` setup + validated-models table + reproducibility block + resources

## Why now

Companion docs page for the Fireworks ecosystem listing ask. Their [agent-frameworks page](https://docs.fireworks.ai/ecosystem/integrations/agent-frameworks) links out to each framework's own Fireworks integration docs (LangChain, LlamaIndex, and Pydantic all follow this pattern). Notte needs its own equivalent page live before pinging them to add Notte to the listing, otherwise the card has nothing to link to.

## Verified for merge

- All three benchmark model IDs are now present in the validated-models table (`kimi-k2p5`, `glm-5`, `minimax-m2p5`), verified against the [Fireworks model catalogue](https://fireworks.ai/models).
- The joint benchmark URL now points to the live post at `https://fireworks.ai/blog/agent-execution-tax`.
- The Notte explainer link at `https://notte.cc/blog/agent-execution-tax` is live (published 2026-05-19).

## Test plan

- [ ] Mintlify preview renders the page under Integrations
- [ ] External fireworks.ai links resolve
- [ ] Internal link to /blog/agent-execution-tax resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Fireworks AI integration guide covering setup prerequisites, installation steps, configuration, supported models (Kimi K2.5, GLM-5, MiniMax M2.5), and usage examples for Notte browser agents.
  * Included code snippets and resources for getting started with Fireworks integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->