### PR TITLE
Add city targeting to Notte proxies

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -498,23 +498,31 @@ class NotteProxy(SdkRequest):
     type: Literal["notte"] = "notte"
     id: str | None = None
     country: ProxyGeolocationCountry | None = None
+    city: str | None = None
     # TODO: enable domainPattern later on
     # domainPattern: str | None = None
 
     @model_validator(mode="before")
     @classmethod
     def handle_legacy_geolocation(cls, values: Any) -> dict[str, Any]:
-        """Handle backward compatibility with old geolocation.country syntax."""
+        """Handle backward compatibility with old geolocation syntax."""
         if isinstance(values, dict) and "geolocation" in values:
             geolocation: Any = values.pop("geolocation")  # type: ignore[reportUnknownMemberType]
-            # Only set country if it's not already provided
-            if "country" not in values and isinstance(geolocation, dict) and "country" in geolocation:
-                values["country"] = geolocation["country"]
+            if isinstance(geolocation, dict):
+                # Only set fields if they're not already provided.
+                if "country" not in values and "country" in geolocation:
+                    values["country"] = geolocation["country"]
+                if "city" not in values and "city" in geolocation:
+                    values["city"] = geolocation["city"]
         return values  # type: ignore[return-value]
 
     @staticmethod
     def from_country(country: str, id: str | None = None) -> "NotteProxy":
         return NotteProxy(id=id, country=ProxyGeolocationCountry(country))
+
+    @staticmethod
+    def from_city(city: str, id: str | None = None) -> "NotteProxy":
+        return NotteProxy(id=id, city=city)
 
 
 class ExternalProxy(SdkRequest):
@@ -559,6 +567,7 @@ class NotteProxyDict(TypedDict, total=False):
     type: Literal["notte"]
     id: str | None
     country: ProxyGeolocationCountry | None
+    city: str | None
 
 
 class TailnetProxyDict(TypedDict, total=False):

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -516,13 +516,33 @@ class NotteProxy(SdkRequest):
                     values["city"] = geolocation["city"]
         return values  # type: ignore[return-value]
 
-    @staticmethod
-    def from_country(country: str, id: str | None = None) -> "NotteProxy":
-        return NotteProxy(id=id, country=ProxyGeolocationCountry(country))
+    @field_validator("city")
+    @classmethod
+    def validate_city(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        city = value.strip()
+        if not city:
+            raise ValueError("city must be a non-empty string")
+        return city
 
     @staticmethod
-    def from_city(city: str, id: str | None = None) -> "NotteProxy":
-        return NotteProxy(id=id, city=city)
+    def _resolve_proxy_id(proxy_id: str | None, kwargs: dict[str, Any]) -> str | None:
+        legacy_id = kwargs.pop("id", None)
+        if kwargs:
+            unexpected = next(iter(kwargs))
+            raise TypeError(f"Unexpected keyword argument: {unexpected}")
+        if proxy_id is not None and legacy_id is not None:
+            raise ValueError("Cannot provide both proxy_id and id")
+        return proxy_id if proxy_id is not None else legacy_id
+
+    @staticmethod
+    def from_country(country: str, proxy_id: str | None = None, **kwargs: Any) -> "NotteProxy":
+        return NotteProxy(id=NotteProxy._resolve_proxy_id(proxy_id, kwargs), country=ProxyGeolocationCountry(country))
+
+    @staticmethod
+    def from_city(city: str, proxy_id: str | None = None, **kwargs: Any) -> "NotteProxy":
+        return NotteProxy(id=NotteProxy._resolve_proxy_id(proxy_id, kwargs), city=city)
 
 
 class ExternalProxy(SdkRequest):

--- a/tests/sdk/test_proxy_settings.py
+++ b/tests/sdk/test_proxy_settings.py
@@ -40,6 +40,34 @@ class TestDirectProxyValidation:
         assert proxy.country is None
         assert proxy.city == "Madrid"
 
+    def test_notte_proxy_from_city_rejects_empty_city(self):
+        """Test NotteProxy.from_city rejects empty city names."""
+        with pytest.raises(ValidationError, match="city must be a non-empty string"):
+            NotteProxy.from_city("")
+
+    def test_notte_proxy_rejects_whitespace_city(self):
+        """Test NotteProxy rejects whitespace-only city names."""
+        with pytest.raises(ValidationError, match="city must be a non-empty string"):
+            NotteProxy.model_validate({"type": "notte", "city": "   "})
+
+    def test_notte_proxy_from_city_with_proxy_id(self):
+        """Test NotteProxy.from_city helper with proxy_id."""
+        proxy = NotteProxy.from_city("Madrid", proxy_id="my-proxy-id")
+        assert proxy.id == "my-proxy-id"
+        assert proxy.city == "Madrid"
+
+    def test_notte_proxy_from_city_with_legacy_id(self):
+        """Test NotteProxy.from_city helper with legacy id keyword."""
+        proxy = NotteProxy.from_city("Madrid", id="my-proxy-id")
+        assert proxy.id == "my-proxy-id"
+        assert proxy.city == "Madrid"
+
+    def test_notte_proxy_from_country_with_legacy_id(self):
+        """Test NotteProxy.from_country helper with legacy id keyword."""
+        proxy = NotteProxy.from_country("us", id="my-proxy-id")
+        assert proxy.id == "my-proxy-id"
+        assert proxy.country == ProxyGeolocationCountry.UNITED_STATES
+
     def test_notte_proxy_without_country(self):
         """Test NotteProxy without country (None)."""
         proxy = NotteProxy.model_validate({"type": "notte"})

--- a/tests/sdk/test_proxy_settings.py
+++ b/tests/sdk/test_proxy_settings.py
@@ -26,6 +26,20 @@ class TestDirectProxyValidation:
         assert proxy.type == "notte"
         assert proxy.country == ProxyGeolocationCountry.UNITED_KINGDOM
 
+    def test_notte_proxy_with_city_string(self):
+        """Test NotteProxy with city as unrestricted string."""
+        proxy = NotteProxy.model_validate({"type": "notte", "city": "New York"})
+        assert proxy.type == "notte"
+        assert proxy.country is None
+        assert proxy.city == "New York"
+
+    def test_notte_proxy_from_city(self):
+        """Test NotteProxy.from_city helper."""
+        proxy = NotteProxy.from_city("Madrid")
+        assert proxy.type == "notte"
+        assert proxy.country is None
+        assert proxy.city == "Madrid"
+
     def test_notte_proxy_without_country(self):
         """Test NotteProxy without country (None)."""
         proxy = NotteProxy.model_validate({"type": "notte"})
@@ -115,6 +129,15 @@ class TestSessionStartRequestWithDictConfigs:
         assert len(request.proxies) == 1
         assert request.proxies[0].type == "notte"
         assert request.proxies[0].country == ProxyGeolocationCountry.UNITED_STATES
+
+    def test_notte_proxy_dict_with_city(self):
+        """Test NotteProxy dict: {"type": "notte", "city": "Chicago"}."""
+        request = SessionStartRequest.model_validate({"proxies": [{"type": "notte", "city": "Chicago"}]})
+        assert isinstance(request.proxies, list)
+        assert len(request.proxies) == 1
+        assert request.proxies[0].type == "notte"
+        assert request.proxies[0].country is None
+        assert request.proxies[0].city == "Chicago"
 
     def test_notte_proxy_dict_with_typo_in_country(self):
         """Test NotteProxy dict with typo in 'country' field should fail validation."""
@@ -211,9 +234,10 @@ class TestBackwardCompatibility:
 
     def test_notte_proxy_with_geolocation_dict(self):
         """Test NotteProxy.model_validate with old geolocation syntax."""
-        proxy = NotteProxy.model_validate({"type": "notte", "geolocation": {"country": "us"}})
+        proxy = NotteProxy.model_validate({"type": "notte", "geolocation": {"country": "us", "city": "Seattle"}})
         assert proxy.type == "notte"
         assert proxy.country == ProxyGeolocationCountry.UNITED_STATES
+        assert proxy.city == "Seattle"
         # geolocation should not exist as a field
         assert not hasattr(proxy, "geolocation")
 
@@ -225,9 +249,12 @@ class TestBackwardCompatibility:
 
     def test_geolocation_with_country_already_set(self):
         """Test that country field takes precedence if both are provided."""
-        proxy = NotteProxy.model_validate({"type": "notte", "country": "us", "geolocation": {"country": "gb"}})
-        # country should take precedence over geolocation
+        proxy = NotteProxy.model_validate(
+            {"type": "notte", "country": "us", "city": "Austin", "geolocation": {"country": "gb", "city": "London"}}
+        )
+        # top-level fields should take precedence over geolocation
         assert proxy.country == ProxyGeolocationCountry.UNITED_STATES
+        assert proxy.city == "Austin"
 
     def test_geolocation_with_id(self):
         """Test old geolocation syntax with id field."""


### PR DESCRIPTION
## Summary
- add optional city targeting to NotteProxy without a city literal
- add a city-only NotteProxy.from_city helper
- preserve legacy geolocation handling for city and country
- cover city proxy validation in SDK tests

## Tests
- uv run ruff check packages/notte-sdk/src/notte_sdk/types.py packages/notte-sdk/src/notte_sdk/endpoints/sessions.py tests/sdk/test_proxy_settings.py
- uv run pytest tests/sdk/test_proxy_settings.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxy configuration now supports an optional city field in addition to country.
  * Added a convenience method to create proxy configurations from a city value.
  * Input for city is normalized and validated (trims and rejects empty/whitespace).

* **Compatibility/Bug Fixes**
  * Backward-compatibility handling updated to populate top-level city from legacy geolocation when missing and to ensure top-level values take precedence.

* **Tests**
  * Expanded test coverage for city-based proxy parsing, creation, validation, and legacy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->