### PR TITLE
Add Resources landing page

### DIFF
--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -342,6 +342,7 @@
               {
                 "group": "Resources",
                 "pages": [
+                  "resources",
                   "pricing",
                   "rate-limits",
                   "guides/vibe-coding"

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -432,8 +432,7 @@ The SDK docs below are for generated-code editing and reference. They are not th
 
 ## Resources
 
-- [Pricing](https://docs.notte.cc/pricing.md): Simple usage-based pricing with included hours on every plan
-- [Rate Limits](https://docs.notte.cc/rate-limits.md): Feature limits and quotas by plan
+- [Resources](https://docs.notte.cc/resources.md): Quick links to pricing, rate limits, and AI coding setup
 - [Vibe Coding](https://docs.notte.cc/guides/vibe-coding.md): Connect documentation to your AI coding assistant with MCP
 
 ## Legal

--- a/docs/src/pricing.mdx
+++ b/docs/src/pricing.mdx
@@ -1,11 +1,8 @@
 ---
 title: Pricing
 description: Simple usage-based pricing with included hours on every plan
+url: https://www.notte.cc/pricing
 ---
-import AgentMdNotice from '/partials/agent-md-notice.mdx';
-
-<AgentMdNotice />
-
 ## Usage Costs
 
 <CardGroup cols={3}>

--- a/docs/src/rate-limits.mdx
+++ b/docs/src/rate-limits.mdx
@@ -1,11 +1,8 @@
 ---
 title: Rate Limits
 description: Feature limits and quotas by plan
+url: https://www.notte.cc/pricing#rate-limits
 ---
-import AgentMdNotice from '/partials/agent-md-notice.mdx';
-
-<AgentMdNotice />
-
 ## Browsers
 
 | | Free | Developer | Startup | Enterprise |

--- a/docs/src/resources.mdx
+++ b/docs/src/resources.mdx
@@ -1,0 +1,21 @@
+---
+title: Resources
+description: Quick links to pricing, rate limits, and AI coding setup
+---
+import AgentMdNotice from '/partials/agent-md-notice.mdx';
+
+<AgentMdNotice />
+
+Start here for billing details, platform limits, and AI coding setup.
+
+<CardGroup cols={3}>
+  <Card title="Pricing" icon="credit-card" href="https://www.notte.cc/pricing">
+    Review plan pricing and usage costs.
+  </Card>
+  <Card title="Rate Limits" icon="gauge" href="https://www.notte.cc/pricing#rate-limits">
+    Compare limits and quotas by plan.
+  </Card>
+  <Card title="Vibe Coding" icon="sparkles" href="/guides/vibe-coding">
+    Connect Notte docs to your AI coding assistant with MCP.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- add a Resources landing page linking to pricing, rate limits, and vibe coding
- keep Pricing, Rate Limits, and Vibe Coding in the Resources sidebar
- point Pricing and Rate Limits sidebar entries to the public pricing page anchors

## Tests
- python3 -m json.tool docs/src/docs.json
- custom nav page existence check
- uv run pytest tests/test_docs_generation.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Resources page with direct links to Pricing, Rate Limits, and Vibe Coding for quicker access.
  * Updated site navigation to surface the Resources section more prominently.
  * Pricing and Rate Limits pages now have direct URLs and display content immediately (previous upstream notice removed).
  * Consolidated separate resource links into a single Resources entry for simpler discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->