### PR TITLE
Fix scrape schema RootModel handling

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -220,6 +220,8 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 
 ## Profiles
 
+- [GET Profile Cookies Get](https://docs.notte.cc/api-reference/profiles/profile-cookies-get.md)
+- [POST Profile Cookies Set](https://docs.notte.cc/api-reference/profiles/profile-cookies-set.md)
 - [POST Profile Create](https://docs.notte.cc/api-reference/profiles/profile-create.md)
 - [DELETE Profile Delete](https://docs.notte.cc/api-reference/profiles/profile-delete.md)
 - [GET Profile Get](https://docs.notte.cc/api-reference/profiles/profile-get.md)

--- a/docs/src/quickstart.mdx
+++ b/docs/src/quickstart.mdx
@@ -201,6 +201,8 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
           "  --proxy                    Use default proxies",
           "  --proxy-country <code>     Proxy country code (e.g. us, gb, fr)",
           "  --solve-captchas           Automatically solve captchas",
+          "  --profile-id <profile-id>  Load browser state from a profile",
+          "  --profile-persist          Save browser state back to the profile on session close",
           "  --viewport-width           Viewport width in pixels",
           "  --viewport-height          Viewport height in pixels",
           "  --user-agent               Custom user agent string",
@@ -218,6 +220,8 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
           "```",
           "",
           "**Note:** When you start a session, it automatically becomes the \"current\" session (i.e NOTTE_SESSION_ID environment variable is set). All subsequent commands use this session by default. Use `--session-id <session-id>` only when you need to manage multiple sessions simultaneously or reference a specific session.",
+          "",
+          "**Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.",
           "",
           "Session debugging and export:",
           "",
@@ -1014,6 +1018,8 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
       --proxy                    Use default proxies
       --proxy-country <code>     Proxy country code (e.g. us, gb, fr)
       --solve-captchas           Automatically solve captchas
+      --profile-id <profile-id>  Load browser state from a profile
+      --profile-persist          Save browser state back to the profile on session close
       --viewport-width           Viewport width in pixels
       --viewport-height          Viewport height in pixels
       --user-agent               Custom user agent string
@@ -1031,6 +1037,8 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
     ```
 
     **Note:** When you start a session, it automatically becomes the "current" session (i.e NOTTE_SESSION_ID environment variable is set). All subsequent commands use this session by default. Use `--session-id <session-id>` only when you need to manage multiple sessions simultaneously or reference a specific session.
+
+    **Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.
 
     Session debugging and export:
 
@@ -1808,6 +1816,8 @@ notte sessions start [flags]
   --proxy                    Use default proxies
   --proxy-country <code>     Proxy country code (e.g. us, gb, fr)
   --solve-captchas           Automatically solve captchas
+  --profile-id <profile-id>  Load browser state from a profile
+  --profile-persist          Save browser state back to the profile on session close
   --viewport-width           Viewport width in pixels
   --viewport-height          Viewport height in pixels
   --user-agent               Custom user agent string
@@ -1825,6 +1835,8 @@ notte sessions list [--page N] [--page-size N] [--only-active]
 ```
 
 **Note:** When you start a session, it automatically becomes the "current" session (i.e NOTTE_SESSION_ID environment variable is set). All subsequent commands use this session by default. Use `--session-id <session-id>` only when you need to manage multiple sessions simultaneously or reference a specific session.
+
+**Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.
 
 Session debugging and export:
 

--- a/docs/src/sdk-reference/misc/rootmodel.mdx
+++ b/docs/src/sdk-reference/misc/rootmodel.mdx
@@ -7,7 +7,7 @@ description: ""
 
 ## Fields
 
-<ParamField path="root" type="Dict[str, Any] | list[Dict[str, Any]]" required>
+<ParamField path="root" type="Any" required>
 </ParamField>
 
 

--- a/docs/src/sdk-reference/misc/structureddata.mdx
+++ b/docs/src/sdk-reference/misc/structureddata.mdx
@@ -15,7 +15,7 @@ description: ""
   Error message if the data was not extracted successfully
 </ParamField>
 
-<ParamField path="data" type="BaseModel | RootModel[Union[dict[str, Any], list[dict[str, Any]]]] | None">
+<ParamField path="data" type="BaseModel | RootModel[Any] | None">
   Structured data extracted from the page in JSON format
 </ParamField>
 

--- a/packages/notte-browser/src/notte_browser/scraping/pruning.py
+++ b/packages/notte-browser/src/notte_browser/scraping/pruning.py
@@ -1,6 +1,6 @@
 import functools
 import re
-from typing import Any, Callable, ClassVar, TypeVar
+from typing import Any, Callable, ClassVar, TypeVar, cast
 
 from notte_core.common.logging import logger
 from pydantic import BaseModel
@@ -140,18 +140,18 @@ class MarkdownPruningPipe:
             logger.debug(f"Failed to unmask the JSON string: {e}")
 
         # Step 2: look for string fields in the model that are exactly the same as the masked document
-        def recursive_unmask(data: dict[str, Any]) -> dict[str, Any]:
-            for key, value in data.items():
-                if isinstance(value, str):
-                    if value in document.links:
-                        data[key] = document.links[value]
-                    elif value in document.images:
-                        data[key] = document.images[value]
-                elif isinstance(value, dict):
-                    data[key] = recursive_unmask(value)  # pyright: ignore[reportUnknownArgumentType]
-                elif isinstance(value, list):
-                    data[key] = [recursive_unmask(item) for item in value]  # pyright: ignore[reportUnknownArgumentType, reportUnknownVariableType]
-            return data
+        def recursive_unmask(value: Any) -> Any:
+            if isinstance(value, str):
+                if value in document.links:
+                    return document.links[value]
+                if value in document.images:
+                    return document.images[value]
+                return value
+            if isinstance(value, dict):
+                return {key: recursive_unmask(item) for key, item in cast(dict[str, Any], value).items()}
+            if isinstance(value, list):
+                return [recursive_unmask(item) for item in cast(list[Any], value)]
+            return value
 
         unmasked_data = recursive_unmask(data.model_dump())
         return data.__class__.model_validate(unmasked_data)

--- a/packages/notte-browser/src/notte_browser/scraping/schema.py
+++ b/packages/notte-browser/src/notte_browser/scraping/schema.py
@@ -127,12 +127,6 @@ class SchemaScrapingPipe:
                 if not response.success or response.data is None:
                     return response
                 try:
-                    if isinstance(response.data.root, list):
-                        return StructuredData(
-                            success=False,
-                            error="The response is a list, but the schema is not a list",
-                            data=None,
-                        )
                     data: BaseModel = _response_format.model_validate(response.data.root)
                     if use_link_placeholders:
                         data = MarkdownPruningPipe.unmask_pydantic(document=masked_document, data=data)

--- a/packages/notte-core/src/notte_core/data/space.py
+++ b/packages/notte-core/src/notte_core/data/space.py
@@ -7,7 +7,9 @@ from pydantic import BaseModel, Field, RootModel, model_serializer, model_valida
 from notte_core.errors.processing import InvalidInternalCheckError, ScrapeFailedError
 
 TBaseModel = TypeVar("TBaseModel", bound=BaseModel, covariant=True)
-DictBaseModel = RootModel[dict[str, Any] | list[dict[str, Any]]]
+# Legacy name: used as the raw structured-data wrapper before validating
+# against a user-provided schema, so it must preserve any JSON root shape.
+DictBaseModel = RootModel[Any]
 
 
 class NoStructuredData(BaseModel):
@@ -56,7 +58,7 @@ class StructuredData(BaseModel, Generic[TBaseModel]):
     @model_validator(mode="before")
     def wrap_dict_in_root_model(cls, values: dict[str, Any]) -> dict[str, Any]:
         if isinstance(values, dict) and "data" in values and isinstance(values["data"], (dict, list)):  # type: ignore[arg-type]
-            values["data"] = DictBaseModel(values["data"])  # type: ignore[arg-type]
+            values["data"] = DictBaseModel(values["data"])
         # if error and is not empty, set success to False
         error = values.get("error")
         if error is not None and len(error.strip()) > 0:

--- a/packages/notte-sdk/src/notte_sdk/endpoints/page.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/page.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Literal, Unpack, overload
+from typing import TYPE_CHECKING, Any, Literal, Unpack, cast, overload
 
 from notte_core.actions import ActionUnion, CaptchaSolveAction, InteractionActionUnion
 from notte_core.common.config import PerceptionType
@@ -211,11 +211,13 @@ class PageClient(BaseClient):
                     )
                     extracted_data = request.response_format.model_validate(extracted_data_dict)
                 return extracted_data
-            if isinstance(structured.data, RootModel):
+            structured_data = cast(Any, structured.data)
+            if isinstance(structured_data, RootModel):
                 # unwrap RootModel
-                structured.data = structured.data.root  # type: ignore[attr-defined]
-            if request.response_format is not None and structured.data is not None:
-                structured.data = request.response_format.model_validate(structured.data)
+                structured_data = cast(Any, structured_data.root)
+                structured.data = structured_data
+            if request.response_format is not None and structured_data is not None:
+                structured.data = request.response_format.model_validate(structured_data)
             return structured
         return response.markdown
 

--- a/tests/integration/sdk/test_agent.py
+++ b/tests/integration/sdk/test_agent.py
@@ -65,7 +65,7 @@ def test_start_agent_with_gemini_reasoning():
     _ = load_dotenv()
     notte = NotteClient()
     with notte.Session() as session:
-        agent = notte.Agent(session=session, reasoning_model="gemini/gemini-2.0-flash-001", max_steps=3)
+        agent = notte.Agent(session=session, reasoning_model="gemini/gemini-2.5-flash", max_steps=3)
         _ = agent.run(task="Go notte.cc and describe the page")
     resp = agent.status()
     assert resp.status == "closed"

--- a/tests/pipe/scraping/test_schema.py
+++ b/tests/pipe/scraping/test_schema.py
@@ -7,13 +7,14 @@ from notte_browser.scraping.pruning import MarkdownPruningPipe
 from notte_browser.scraping.schema import SchemaScrapingPipe
 from notte_core.data.space import DictBaseModel, StructuredData
 from notte_llm.service import LLMService
+from pydantic import BaseModel, RootModel
 from typing_extensions import override
 
 
 class MockLLMServiceForSchema(LLMService):
     """Mock LLM service that returns structured data with placeholders."""
 
-    def __init__(self, mock_data: dict[str, Any]) -> None:
+    def __init__(self, mock_data: Any) -> None:
         """Initialize with mock data that contains placeholders."""
         self.mock_data = mock_data
         self.tokenizer = None  # type: ignore[assignment]
@@ -38,6 +39,116 @@ class MockLLMServiceForSchema(LLMService):
             error=None,
             data=DictBaseModel(self.mock_data),
         )
+
+
+class ScrapedItem(BaseModel):
+    rank: int | None = None
+    title: str | None = None
+    url: str | None = None
+
+
+class RootItemList(RootModel[list[ScrapedItem]]):
+    root: list[ScrapedItem]
+
+
+class RootStringList(RootModel[list[str]]):
+    root: list[str]
+
+
+class RootString(RootModel[str]):
+    root: str
+
+
+class RootDict(RootModel[dict[str, int]]):
+    root: dict[str, int]
+
+
+class WrappedItemList(BaseModel):
+    items: list[ScrapedItem]
+
+
+class PlainItem(BaseModel):
+    rank: int | None = None
+    title: str | None = None
+
+
+class LinkList(RootModel[list[str]]):
+    root: list[str]
+
+
+class WeirdWrappedRoots(BaseModel):
+    primary: ScrapedItem
+    links: LinkList
+
+
+@pytest.mark.parametrize(
+    ("response_format", "mock_data", "expected_success"),
+    [
+        (RootItemList, [{"rank": 1, "title": "A"}, {"rank": 2, "title": "B"}], True),
+        (RootItemList, {"items": [{"rank": 1, "title": "A"}]}, False),
+        (RootStringList, ["alpha", "beta"], True),
+        (RootString, "alpha", True),
+        (RootDict, {"a": 1, "b": 2}, True),
+        (RootDict, [{"a": 1}], False),
+        (WrappedItemList, {"items": [{"rank": 1, "title": "A"}]}, True),
+        (WrappedItemList, [{"rank": 1, "title": "A"}], False),
+        (PlainItem, {"rank": 1, "title": "A"}, True),
+        (PlainItem, [{"rank": 1, "title": "A"}], False),
+        (
+            WeirdWrappedRoots,
+            {"primary": {"rank": 1, "title": "A", "url": "link1"}, "links": ["link1", "link2"]},
+            True,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_schema_scraping_validates_root_model_and_base_model_shapes(
+    response_format: type[BaseModel], mock_data: Any, expected_success: bool
+) -> None:
+    schema_pipe = SchemaScrapingPipe(llmserve=MockLLMServiceForSchema(mock_data))
+
+    result = await schema_pipe.forward(
+        url="https://example.com",
+        document="[A](https://example.com/a) [B](https://example.com/b)",
+        response_format=response_format,
+        instructions="Extract test data",
+        verbose=False,
+        use_link_placeholders=True,
+    )
+
+    assert result.success is expected_success
+    if expected_success:
+        assert result.data is not None
+        assert isinstance(result.data, response_format)
+    else:
+        assert result.data is None
+        assert result.error is not None
+        assert "Cannot validate response into the provided schema" in result.error
+
+
+@pytest.mark.asyncio
+async def test_schema_scraping_unmasks_root_model_list() -> None:
+    schema_pipe = SchemaScrapingPipe(
+        llmserve=MockLLMServiceForSchema(
+            [
+                {"rank": 1, "title": "A", "url": "link1"},
+                {"rank": 2, "title": "B", "url": "link2"},
+            ]
+        )
+    )
+
+    result = await schema_pipe.forward(
+        url="https://example.com",
+        document="[A](https://example.com/a) [B](https://example.com/b)",
+        response_format=RootItemList,
+        instructions="Extract items",
+        verbose=False,
+        use_link_placeholders=True,
+    )
+
+    assert result.success is True
+    assert isinstance(result.data, RootItemList)
+    assert [item.url for item in result.data.root] == ["https://example.com/a", "https://example.com/b"]
 
 
 @pytest.mark.asyncio

--- a/tests/pipe/scraping/test_schema.py
+++ b/tests/pipe/scraping/test_schema.py
@@ -1,14 +1,19 @@
 """Tests for schema scraping pipe."""
 
+import os
 from typing import Any
 
 import pytest
+from dotenv import load_dotenv
 from notte_browser.scraping.pruning import MarkdownPruningPipe
 from notte_browser.scraping.schema import SchemaScrapingPipe
+from notte_core.common.config import LlmModel
 from notte_core.data.space import DictBaseModel, StructuredData
 from notte_llm.service import LLMService
 from pydantic import BaseModel, RootModel
 from typing_extensions import override
+
+_ = load_dotenv()
 
 
 class MockLLMServiceForSchema(LLMService):
@@ -149,6 +154,36 @@ async def test_schema_scraping_unmasks_root_model_list() -> None:
     assert result.success is True
     assert isinstance(result.data, RootItemList)
     assert [item.url for item in result.data.root] == ["https://example.com/a", "https://example.com/b"]
+
+
+@pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="requires OPENAI_API_KEY")
+@pytest.mark.asyncio
+async def test_schema_scraping_root_model_list_with_real_llm_round_trip() -> None:
+    schema_pipe = SchemaScrapingPipe(llmserve=LLMService(base_model=LlmModel.openai))
+
+    result = await schema_pipe.forward(
+        url="https://example.com/products",
+        document="""
+        # Product ranking
+
+        1. Atlas Notebook - https://example.com/atlas
+        2. Beacon Pen - https://example.com/beacon
+        """,
+        response_format=RootItemList,
+        instructions=(
+            "Extract the two product ranking entries. Return only the ranked items from the document with rank, "
+            "title, and url populated."
+        ),
+        verbose=False,
+        use_link_placeholders=False,
+    )
+
+    assert result.success is True, result.error
+    assert isinstance(result.data, RootItemList)
+    assert result.data.root == [
+        ScrapedItem(rank=1, title="Atlas Notebook", url="https://example.com/atlas"),
+        ScrapedItem(rank=2, title="Beacon Pen", url="https://example.com/beacon"),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- let schema scraping validate top-level list responses against the user-provided schema instead of rejecting them up front
- preserve arbitrary root JSON shapes in the intermediate structured-data wrapper
- make placeholder unmasking recurse through dict, list, and scalar model dumps
- add coverage for RootModel and BaseModel shape combinations, including nested RootModel fields

## Tests
- uv run pytest tests/pipe/scraping/test_schema.py -q
- uv run ruff check packages/notte-core/src/notte_core/data/space.py packages/notte-browser/src/notte_browser/scraping/schema.py packages/notte-browser/src/notte_browser/scraping/pruning.py tests/pipe/scraping/test_schema.py
- uv run basedpyright packages/notte-core/src/notte_core/data/space.py packages/notte-browser/src/notte_browser/scraping/pruning.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust unmasking and validation of nested scraped content; schema validation now accepts root-models previously rejected.

* **Tests**
  * Added comprehensive tests for many root-model shapes, unmasking, and validation scenarios (including an optional real LLM round trip).

* **Documentation**
  * Added browser profile CLI flags and docs; updated API reference links and RootModel/StructuredData type descriptions.

* **Chores**
  * Minor SDK/client post-processing and test harness improvements; updated test fixture signatures and a test model reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->