### PR TITLE
feat(core): add Fireworks AI as an LLM provider

### DIFF
--- a/packages/notte-core/src/notte_core/common/config.py
+++ b/packages/notte-core/src/notte_core/common/config.py
@@ -240,6 +240,7 @@ class LlmModel(StrEnum):
         # Model-specific temperature overrides
         temperature_overrides: dict[str, float] = {
             "kimi-k2.5": 1.0,
+            "kimi-k2p5": 1.0,
         }
         for model_pattern, temp in temperature_overrides.items():
             if model_pattern in val_str:

--- a/packages/notte-core/src/notte_core/common/config.py
+++ b/packages/notte-core/src/notte_core/common/config.py
@@ -71,6 +71,7 @@ class LlmProvider(StrEnum):
     zai = "zai"
     qwen = "qwen"
     minimax = "minimax"
+    fireworks_ai = "fireworks_ai"
 
     @property
     def context_length(self) -> int:
@@ -121,6 +122,8 @@ class LlmProvider(StrEnum):
                 return "QWEN_API_KEY"
             case LlmProvider.minimax:
                 return "MINIMAX_API_KEY"
+            case LlmProvider.fireworks_ai:
+                return "FIREWORKS_API_KEY"
             case _:  # pyright: ignore[reportUnnecessaryComparison]
                 raise ValueError(f"No API key name found for provider: {self}")  # pyright: ignore[reportUnreachable]
 
@@ -144,6 +147,9 @@ class LlmModel(StrEnum):
     kimi2_5 = "moonshot/kimi-k2.5"
     grok = "xai/grok-4-1-fast-non-reasoning"
     minimax = "minimax/minimax-m2.5"
+    fireworks_kimi_k2p5 = "fireworks_ai/accounts/fireworks/models/kimi-k2p5"
+    fireworks_glm_5 = "fireworks_ai/accounts/fireworks/models/glm-5"
+    fireworks_minimax_m2p5 = "fireworks_ai/accounts/fireworks/models/minimax-m2p5"
 
     @property
     def provider(self) -> LlmProvider:
@@ -218,6 +224,7 @@ class LlmModel(StrEnum):
         unsupported_providers = [
             str(LlmProvider.cerebras),
             str(LlmProvider.moonshot),
+            str(LlmProvider.fireworks_ai),
         ]
         unsupported_models = [
             "gemini-2.0-flash",

--- a/packages/notte-core/src/notte_core/common/config.py
+++ b/packages/notte-core/src/notte_core/common/config.py
@@ -147,9 +147,9 @@ class LlmModel(StrEnum):
     kimi2_5 = "moonshot/kimi-k2.5"
     grok = "xai/grok-4-1-fast-non-reasoning"
     minimax = "minimax/minimax-m2.5"
-    fireworks_kimi_k2p5 = "fireworks_ai/accounts/fireworks/models/kimi-k2p5"
-    fireworks_glm_5 = "fireworks_ai/accounts/fireworks/models/glm-5"
-    fireworks_minimax_m2p5 = "fireworks_ai/accounts/fireworks/models/minimax-m2p5"
+    fireworks_kimi = "fireworks_ai/accounts/fireworks/models/kimi-k2p5"
+    fireworks_glm = "fireworks_ai/accounts/fireworks/models/glm-5p2"
+    fireworks_minimax = "fireworks_ai/accounts/fireworks/models/minimax-m3"
 
     @property
     def provider(self) -> LlmProvider:

--- a/tests/config/test_fireworks_provider.py
+++ b/tests/config/test_fireworks_provider.py
@@ -1,0 +1,38 @@
+from notte_core.common.config import LlmModel, LlmProvider
+
+
+FIREWORKS_MODELS: list[str] = [
+    LlmModel.fireworks_kimi_k2p5,
+    LlmModel.fireworks_glm_5,
+    LlmModel.fireworks_minimax_m2p5,
+]
+
+
+def test_fireworks_provider_registered():
+    assert LlmProvider.fireworks_ai in list(LlmProvider)
+    assert str(LlmProvider.fireworks_ai) == "fireworks_ai"
+
+
+def test_fireworks_provider_apikey_name():
+    assert LlmProvider.fireworks_ai.apikey_name == "FIREWORKS_API_KEY"
+
+
+def test_fireworks_get_provider_resolves():
+    provider = LlmModel.get_provider("fireworks_ai/accounts/fireworks/models/kimi-k2p5")
+    assert provider == LlmProvider.fireworks_ai
+
+
+def test_fireworks_models_resolve_to_fireworks_provider():
+    for model in FIREWORKS_MODELS:
+        assert LlmModel.get_provider(model) == LlmProvider.fireworks_ai
+
+
+def test_fireworks_models_use_non_strict_response_format():
+    for model in FIREWORKS_MODELS:
+        assert LlmModel.use_strict_response_format(model) is False
+
+
+def test_fireworks_kimi_temperature_override_matches_moonshot():
+    # Same underlying model, both paths should pick up the 1.0 override.
+    assert LlmModel.get_temperature(LlmModel.fireworks_kimi_k2p5, default=0.0) == 1.0
+    assert LlmModel.get_temperature(LlmModel.kimi2_5, default=0.0) == 1.0

--- a/tests/config/test_fireworks_provider.py
+++ b/tests/config/test_fireworks_provider.py
@@ -2,9 +2,9 @@ from notte_core.common.config import LlmModel, LlmProvider
 
 
 FIREWORKS_MODELS: list[str] = [
-    LlmModel.fireworks_kimi_k2p5,
-    LlmModel.fireworks_glm_5,
-    LlmModel.fireworks_minimax_m2p5,
+    LlmModel.fireworks_kimi,
+    LlmModel.fireworks_glm,
+    LlmModel.fireworks_minimax,
 ]
 
 
@@ -34,5 +34,5 @@ def test_fireworks_models_use_non_strict_response_format():
 
 def test_fireworks_kimi_temperature_override_matches_moonshot():
     # Same underlying model, both paths should pick up the 1.0 override.
-    assert LlmModel.get_temperature(LlmModel.fireworks_kimi_k2p5, default=0.0) == 1.0
+    assert LlmModel.get_temperature(LlmModel.fireworks_kimi, default=0.0) == 1.0
     assert LlmModel.get_temperature(LlmModel.kimi2_5, default=0.0) == 1.0


### PR DESCRIPTION
## Summary

Adds Fireworks AI as a supported LLM provider in `notte-core`, with three `LlmModel` aliases for the Fireworks-hosted models validated in the joint Notte × Fireworks benchmark (Kimi K2.5, GLM-5, MiniMax M2.5).

## Why

Companion to the Fireworks docs PR at #846, which documents the integration and uses `reasoning_model` strings of the form `fireworks_ai/accounts/fireworks/models/<slug>`. Without this change, the cloud rejects those strings at `/agents/start` with a 422 because the `LlmProvider` enum has no `fireworks_ai` entry, so `LlmModel.get_provider()` raises and the validator returns "not supported."

Empirically confirmed by running `agent.run()` against the cloud with `reasoning_model="fireworks_ai/accounts/fireworks/models/kimi-k2p5"`:

> 422: Model 'fireworks_ai/accounts/fireworks/models/kimi-k2p5' is not supported. Available models are: {openai/gpt-4o, ..., moonshot/kimi-k2.5, minimax/minimax-m2.5, ...}

Cloud validation reads its allowlist via `LlmModel.valid()` in this same file, so this single SDK change unlocks the docs example once the package is deployed and `FIREWORKS_API_KEY` is set in the cloud's environment.

## Diff

`packages/notte-core/src/notte_core/common/config.py`:

- `LlmProvider.fireworks_ai = "fireworks_ai"`
- `apikey_name` match arm returning `"FIREWORKS_API_KEY"`
- Three `LlmModel` aliases:
  - `fireworks_kimi_k2p5 = "fireworks_ai/accounts/fireworks/models/kimi-k2p5"`
  - `fireworks_glm_5 = "fireworks_ai/accounts/fireworks/models/glm-5"`
  - `fireworks_minimax_m2p5 = "fireworks_ai/accounts/fireworks/models/minimax-m2p5"`
- Adds `fireworks_ai` to `unsupported_providers` in `use_strict_response_format`, matching the benchmark configuration (which used non-strict `json_object`)

## Cloud requirement

After merge + redeploy, the cloud needs `FIREWORKS_API_KEY` set in its production environment for these models to appear in `LlmModel.valid()`. Without that env var, `has_apikey_in_env()` filters them out.

## Naming

The model aliases (`fireworks_kimi_k2p5`, `fireworks_glm_5`, `fireworks_minimax_m2p5`) follow the convention of prefixing with the provider to avoid collision with the existing `kimi2_5` (Moonshot direct) and `minimax` (MiniMax direct) entries. Happy to rename to any preferred convention.

## Test plan

- [ ] CI passes (syntax, type check, unit tests)
- [ ] After merge + cloud redeploy with `FIREWORKS_API_KEY` set, `agent.run(reasoning_model="fireworks_ai/accounts/fireworks/models/kimi-k2p5")` succeeds against the cloud
- [ ] Docs PR #846 example renders and runs end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fireworks AI as an LLM provider (configured via `FIREWORKS_API_KEY`)
  * Added Fireworks-backed models: Kimi K2.5, GLM 5, and Minimax M2.5

* **Behavior Changes**
  * Fireworks-backed models do not enforce strict response formatting
  * Kimi K2.5 now uses a temperature override of `1.0`

* **Tests**
  * Added coverage for provider registration, model resolution, response-format behavior, and temperature override
<!-- end of auto-generated comment: release notes by coderabbit.ai -->