### PR TITLE
[NOT-497] docs(mcp): document hosted MCP server at api.notte.cc/mcp

### DIFF
--- a/docs/src/integrations/mcp.mdx
+++ b/docs/src/integrations/mcp.mdx
@@ -25,7 +25,46 @@ The Notte-MCP implementation directly mirrors the [Notte API offering](https://d
 - Data collection from websites without available APIs
 - Streamlined research workflows with AI-assisted browsing
 
-## Setup: How to Integrate Notte with MCP Server
+## Hosted MCP Server
+
+The fastest way to get started is the **hosted MCP server**, which runs directly on the Notte API — no local install or running process required. It is available at:
+
+```
+https://api.notte.cc/mcp/
+```
+
+This endpoint exposes (almost) every public Notte API route as an MCP tool, so AI clients like Claude Desktop, Cursor, and custom agents can drive sessions, agents, scraping, web search, vaults, profiles, and more out of the box. It speaks the [Streamable HTTP](https://modelcontextprotocol.io/specification/draft/basic/transports) transport and authenticates with your Notte API key via a standard `Authorization: Bearer` header.
+
+To connect Claude Desktop to the hosted server, add the following to your configuration:
+
+```json
+{
+    "mcpServers": {
+        "notte-mcp": {
+          "command": "npx",
+          "args": [
+            "mcp-remote",
+            "https://api.notte.cc/mcp/",
+            "--header",
+            "Authorization:${AUTH_HEADER}"
+          ],
+          "env": {
+            "AUTH_HEADER": "Bearer <your-notte-api-key>"
+          }
+        }
+    }
+}
+```
+
+<Note>
+The `Authorization:${AUTH_HEADER}` form (with the token supplied via the `env` block) avoids an `mcp-remote` quirk where header values containing spaces can be split incorrectly. Restart Claude Desktop after editing the config and the Notte tools will appear under the 🔨 icon.
+</Note>
+
+You can grab your API key from the [Notte Console](https://console.notte.cc).
+
+## Setup: Running the MCP Server Locally
+
+Prefer to self-host? The MCP server is also available as a standalone package you can run on your own machine.
 
 <Steps>
   <Step title="(Optional) Running the MCP Server Locally">

--- a/docs/src/quickstart.mdx
+++ b/docs/src/quickstart.mdx
@@ -223,7 +223,7 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
           "",
           "**Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.",
           "",
-          "Session debugging and export:",
+          "Session debugging:",
           "",
           "```bash",
           "# Get network logs",
@@ -231,11 +231,49 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
           "",
           "# Get replay URL/data",
           "notte sessions replay",
+          "```",
           "",
+          "Session export:",
+          "",
+          "```bash",
           "# Export session steps as Python workflow code.",
           "# Use --session-id to export a specific session, including one that has been stopped.",
-          "notte sessions workflow-code",
           "notte sessions workflow-code --session-id <session-id>",
+          "",
+          "# example flow",
+          "notte sessions start",
+          "notte page goto news.ycombinator.com",
+          "notte page scrape --instructions \"Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments\" -o json",
+          "notte sessions workflow-code",
+          "",
+          "# returns",
+          "from __future__ import annotations",
+          "",
+          "from notte_sdk import NotteClient",
+          "from pydantic import BaseModel",
+          "",
+          "class Story(BaseModel):",
+          "    rank: int | None = None",
+          "    title: str | None = None",
+          "    url: str | None = None",
+          "    points: int | None = None",
+          "    author: str | None = None",
+          "    number_of_comments: int | None = None",
+          "",
+          "",
+          "class Model(BaseModel):",
+          "    stories: list[Story] | None = None",
+          "",
+          "client = NotteClient()",
+          "",
+          "def run() -> Model:",
+          "    with client.Session(use_file_storage=True) as session:",
+          "        _ = session.execute(type='goto', url='news.ycombinator.com')",
+          "",
+          "        # directly parses the output using response_format and returns the Model",
+          "        return session.scrape(instructions='Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments', only_main_content=False, only_images=False, scrape_links=True, scrape_images=False, response_format=Model)",
+          "",
+          "run()",
           "```",
           "",
           "Cookie management:",
@@ -1040,7 +1078,7 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
 
     **Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.
 
-    Session debugging and export:
+    Session debugging:
 
     ```bash
     # Get network logs
@@ -1048,11 +1086,49 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
 
     # Get replay URL/data
     notte sessions replay
+    ```
 
+    Session export:
+
+    ```bash
     # Export session steps as Python workflow code.
     # Use --session-id to export a specific session, including one that has been stopped.
-    notte sessions workflow-code
     notte sessions workflow-code --session-id <session-id>
+
+    # example flow
+    notte sessions start
+    notte page goto news.ycombinator.com
+    notte page scrape --instructions "Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments" -o json
+    notte sessions workflow-code
+
+    # returns
+    from __future__ import annotations
+
+    from notte_sdk import NotteClient
+    from pydantic import BaseModel
+
+    class Story(BaseModel):
+        rank: int | None = None
+        title: str | None = None
+        url: str | None = None
+        points: int | None = None
+        author: str | None = None
+        number_of_comments: int | None = None
+
+
+    class Model(BaseModel):
+        stories: list[Story] | None = None
+
+    client = NotteClient()
+
+    def run() -> Model:
+        with client.Session(use_file_storage=True) as session:
+            _ = session.execute(type='goto', url='news.ycombinator.com')
+
+            # directly parses the output using response_format and returns the Model
+            return session.scrape(instructions='Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments', only_main_content=False, only_images=False, scrape_links=True, scrape_images=False, response_format=Model)
+
+    run()
     ```
 
     Cookie management:
@@ -1838,7 +1914,7 @@ notte sessions list [--page N] [--page-size N] [--only-active]
 
 **Browser profiles:** Profiles store browser state such as cookies, `localStorage`, and `sessionStorage`. Start a session with `--profile-id <profile-id>` to load that saved state; add `--profile-persist` when starting the session if changes should be saved back to the profile when the session closes.
 
-Session debugging and export:
+Session debugging:
 
 ```bash
 # Get network logs
@@ -1846,11 +1922,49 @@ notte sessions network
 
 # Get replay URL/data
 notte sessions replay
+```
 
+Session export:
+
+```bash
 # Export session steps as Python workflow code.
 # Use --session-id to export a specific session, including one that has been stopped.
-notte sessions workflow-code
 notte sessions workflow-code --session-id <session-id>
+
+# example flow
+notte sessions start
+notte page goto news.ycombinator.com
+notte page scrape --instructions "Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments" -o json
+notte sessions workflow-code
+
+# returns
+from __future__ import annotations
+
+from notte_sdk import NotteClient
+from pydantic import BaseModel
+
+class Story(BaseModel):
+    rank: int | None = None
+    title: str | None = None
+    url: str | None = None
+    points: int | None = None
+    author: str | None = None
+    number_of_comments: int | None = None
+
+
+class Model(BaseModel):
+    stories: list[Story] | None = None
+
+client = NotteClient()
+
+def run() -> Model:
+    with client.Session(use_file_storage=True) as session:
+        _ = session.execute(type='goto', url='news.ycombinator.com')
+
+        # directly parses the output using response_format and returns the Model
+        return session.scrape(instructions='Extract the top 10 stories from Hacker News. For each story return: rank, title, URL, points, author, number of comments', only_main_content=False, only_images=False, scrape_links=True, scrape_images=False, response_format=Model)
+
+run()
 ```
 
 Cookie management:


### PR DESCRIPTION
## Summary
- Adds a **Hosted MCP Server** section to the MCP integration docs (`docs/src/integrations/mcp.mdx`) pointing AI clients at the newly deployed FastMCP endpoint: `https://api.notte.cc/mcp/`.
- This is the server from [monorepo#1527](https://github.com/nottelabs/monorepo/pull/1527), which mounts a FastMCP server on notte-api and auto-exposes (almost) every public API route as an MCP tool. It speaks Streamable HTTP and authenticates via a standard `Authorization: Bearer <api-key>` header.
- Provides a ready-to-paste Claude Desktop config using `mcp-remote`, and reframes the existing local `notte-mcp` instructions as the self-hosted option.

## Notes
- The Claude Desktop config uses the `"Authorization:${AUTH_HEADER}"` + `env` pattern to avoid an `mcp-remote` quirk where header values containing spaces can be split incorrectly (verified working against staging).
- This PR also regenerates `docs/src/quickstart.mdx`. That change is **pre-existing drift on `main`** unrelated to the MCP docs — it was required to satisfy the `docs-quickstart-setup-prompt` pre-commit hook so the commit would pass. Happy to split it out if preferred.

## Test plan
- [ ] Docs build renders the new "Hosted MCP Server" section correctly
- [ ] Claude Desktop config connects to `https://api.notte.cc/mcp/` and lists tools (verified against staging `us-staging.notte.cc`)

Made with [Cursor](https://cursor.com)

Linear: NOT-497 https://linear.app/nottelabsinc/issue/NOT-497/notte-pr-853-docsmcp-document-hosted-mcp-server-at-apinotteccmcp