### PR TITLE
feat(core): add Fireworks provider with prefix-based validation

### DIFF
--- a/packages/notte-core/src/notte_core/common/config.py
+++ b/packages/notte-core/src/notte_core/common/config.py
@@ -92,7 +92,7 @@ class LlmProvider(StrEnum):
 
     @property
     def apikey_name(self) -> str:
-        if enable_openrouter():
+        if enable_openrouter() and self != LlmProvider.fireworks_ai:
             return "OPENROUTER_API_KEY"
         match self:
             case LlmProvider.gemini:
@@ -265,7 +265,8 @@ class LlmModel(StrEnum):
             return True
         try:
             provider = LlmModel.get_provider(model)
-            return provider.is_prefix_provider and provider.has_apikey_in_env()
+            _, _, suffix = model.partition("/")
+            return provider.is_prefix_provider and bool(suffix) and provider.has_apikey_in_env()
         except ValueError:
             return False
 

--- a/packages/notte-core/src/notte_core/common/config.py
+++ b/packages/notte-core/src/notte_core/common/config.py
@@ -71,6 +71,12 @@ class LlmProvider(StrEnum):
     zai = "zai"
     qwen = "qwen"
     minimax = "minimax"
+    fireworks_ai = "fireworks_ai"
+
+    @property
+    def is_prefix_provider(self) -> bool:
+        """Whether this provider accepts arbitrary model paths (not just enum entries)."""
+        return self in {LlmProvider.fireworks_ai}
 
     @property
     def context_length(self) -> int:
@@ -121,6 +127,8 @@ class LlmProvider(StrEnum):
                 return "QWEN_API_KEY"
             case LlmProvider.minimax:
                 return "MINIMAX_API_KEY"
+            case LlmProvider.fireworks_ai:
+                return "FIREWORKS_API_KEY"
             case _:  # pyright: ignore[reportUnnecessaryComparison]
                 raise ValueError(f"No API key name found for provider: {self}")  # pyright: ignore[reportUnreachable]
 
@@ -218,6 +226,7 @@ class LlmModel(StrEnum):
         unsupported_providers = [
             str(LlmProvider.cerebras),
             str(LlmProvider.moonshot),
+            str(LlmProvider.fireworks_ai),
         ]
         unsupported_models = [
             "gemini-2.0-flash",
@@ -248,6 +257,17 @@ class LlmModel(StrEnum):
     @staticmethod
     def valid() -> set[str]:
         return {model.value for model in LlmModel if model.provider.has_apikey_in_env()}
+
+    @staticmethod
+    def is_valid(model: str) -> bool:
+        """Check if a model string is valid (either a known enum model or a prefix provider path)."""
+        if model in LlmModel.valid():
+            return True
+        try:
+            provider = LlmModel.get_provider(model)
+            return provider.is_prefix_provider and provider.has_apikey_in_env()
+        except ValueError:
+            return False
 
 
 BrowserType = Literal["chromium", "chrome", "firefox", "chrome-nightly", "chrome-turbo"]

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1888,6 +1888,12 @@ class AgentCreateRequest(__AgentCreateRequest):
     @classmethod
     def validate_reasoning_model(cls, value: LlmModel) -> LlmModel:
         provider = LlmModel.get_provider(value)
+        if provider.is_prefix_provider:
+            if not LlmModel.is_valid(value):
+                raise ValueError(
+                    f"Model '{value}' requires the {provider.apikey_name} variable to be configured in the environment"
+                )
+            return value
         if not provider.has_apikey_in_env():
             raise ValueError(
                 f"Model '{value}' requires the {provider.apikey_name} variable to be configured in the environment"

--- a/tests/config/test_fireworks_provider.py
+++ b/tests/config/test_fireworks_provider.py
@@ -69,6 +69,20 @@ class TestFireworksResponseFormat:
         assert not LlmModel.use_strict_response_format("fireworks_ai/accounts/fireworks/models/any-model")
 
 
+class TestFireworksEdgeCases:
+    @patch.dict(os.environ, {"FIREWORKS_API_KEY": "test-key"})
+    def test_bare_provider_prefix_is_invalid(self) -> None:
+        assert not LlmModel.is_valid("fireworks_ai")
+
+    @patch.dict(os.environ, {"FIREWORKS_API_KEY": "test-key"})
+    def test_provider_with_trailing_slash_is_invalid(self) -> None:
+        assert not LlmModel.is_valid("fireworks_ai/")
+
+    @patch.dict(os.environ, {"FIREWORKS_API_KEY": "test-key", "ENABLE_OPENROUTER": "true"})
+    def test_apikey_not_masked_by_openrouter(self) -> None:
+        assert LlmProvider.fireworks_ai.apikey_name == "FIREWORKS_API_KEY"
+
+
 class TestFireworksHasApiKeyInEnv:
     @patch.dict(os.environ, {"FIREWORKS_API_KEY": "test-key"})
     def test_has_apikey_when_set(self) -> None:

--- a/tests/config/test_fireworks_provider.py
+++ b/tests/config/test_fireworks_provider.py
@@ -1,0 +1,80 @@
+import os
+from unittest.mock import patch
+
+from notte_core.common.config import LlmModel, LlmProvider
+
+
+class TestFireworksProviderRegistration:
+    def test_fireworks_ai_is_valid_provider(self) -> None:
+        assert LlmProvider.fireworks_ai == "fireworks_ai"
+        assert LlmProvider.fireworks_ai in list(LlmProvider)
+
+    def test_apikey_name(self) -> None:
+        assert LlmProvider.fireworks_ai.apikey_name == "FIREWORKS_API_KEY"
+
+    def test_is_prefix_provider(self) -> None:
+        assert LlmProvider.fireworks_ai.is_prefix_provider is True
+
+    def test_other_providers_are_not_prefix_providers(self) -> None:
+        non_prefix = [p for p in LlmProvider if p != LlmProvider.fireworks_ai]
+        for provider in non_prefix:
+            assert provider.is_prefix_provider is False, f"{provider} should not be a prefix provider"
+
+    def test_context_length_uses_default(self) -> None:
+        assert LlmProvider.fireworks_ai.context_length == 128_000
+
+
+class TestFireworksModelResolution:
+    def test_get_provider_from_fireworks_path(self) -> None:
+        model = "fireworks_ai/accounts/fireworks/models/kimi-k2p5"
+        assert LlmModel.get_provider(model) == LlmProvider.fireworks_ai
+
+    def test_get_provider_from_various_fireworks_models(self) -> None:
+        models = [
+            "fireworks_ai/accounts/fireworks/models/glm-5p2",
+            "fireworks_ai/accounts/fireworks/models/minimax-m3",
+            "fireworks_ai/accounts/fireworks/models/some-future-model",
+        ]
+        for model in models:
+            assert LlmModel.get_provider(model) == LlmProvider.fireworks_ai
+
+
+class TestFireworksValidation:
+    @patch.dict(os.environ, {"FIREWORKS_API_KEY": "test-key"})
+    def test_arbitrary_fireworks_model_is_valid(self) -> None:
+        assert LlmModel.is_valid("fireworks_ai/accounts/fireworks/models/kimi-k2p5")
+        assert LlmModel.is_valid("fireworks_ai/accounts/fireworks/models/glm-5p2")
+        assert LlmModel.is_valid("fireworks_ai/accounts/fireworks/models/any-future-model")
+
+    def test_fireworks_model_invalid_without_api_key(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != "FIREWORKS_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            assert not LlmModel.is_valid("fireworks_ai/accounts/fireworks/models/kimi-k2p5")
+
+    def test_unknown_provider_is_invalid(self) -> None:
+        assert not LlmModel.is_valid("notavalidprovider/some-model")
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_enum_model_still_valid_via_is_valid(self) -> None:
+        assert LlmModel.is_valid("openai/gpt-4o")
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    def test_non_prefix_provider_rejects_arbitrary_models(self) -> None:
+        assert not LlmModel.is_valid("openai/some-unknown-model")
+
+
+class TestFireworksResponseFormat:
+    def test_fireworks_does_not_use_strict_response_format(self) -> None:
+        assert not LlmModel.use_strict_response_format("fireworks_ai/accounts/fireworks/models/kimi-k2p5")
+        assert not LlmModel.use_strict_response_format("fireworks_ai/accounts/fireworks/models/any-model")
+
+
+class TestFireworksHasApiKeyInEnv:
+    @patch.dict(os.environ, {"FIREWORKS_API_KEY": "test-key"})
+    def test_has_apikey_when_set(self) -> None:
+        assert LlmProvider.fireworks_ai.has_apikey_in_env()
+
+    def test_no_apikey_when_not_set(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != "FIREWORKS_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            assert not LlmProvider.fireworks_ai.has_apikey_in_env()


### PR DESCRIPTION
**Summary**
Fireworks models rotate pretty frequently and the current approach of hardcoding each one as a LlmModel enum entry means every rotation needs an SDK change and a release. This PR fixes that by validating at the provider level instead.
**What changed**

- packages/notte-core/src/notte_core/common/config.py
- Added LlmProvider.fireworks_ai with FIREWORKS_API_KEY mapping
- Added is_prefix_provider property on LlmProvider to flag providers that accept arbitrary model paths
- Added LlmModel.is_valid(model) which handles both enum models and prefix providers. Cloud can migrate from model in LlmModel.valid() to LlmModel.is_valid(model)
- Added fireworks_ai to the use_strict_response_format unsupported list
- No new LlmModel enum entries for Fireworks, that's kind of the point
- tests/config/test_fireworks_provider.py

15 tests covering provider registration, arbitrary path validation, API key gating, response format, and making sure non-prefix providers still reject unknown models

**How it addresses #854**

Any fireworks_ai/* path is accepted when FIREWORKS_API_KEY is set, no SDK release needed for model rotations
No hardcoded slugs in the enum so docs and SDK can't drift independently
is_valid() confirms the string is structurally valid and the key exists, whether the model is actually deployed is on the provider at runtime

Migration note
valid() is unchanged for backwards compat. The cloud endpoint just needs to swap model in LlmModel.valid() for LlmModel.is_valid(model).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fireworks AI as a supported LLM provider, including environment-based API key handling and wider model path matching.
  * Expanded model validation to accept Fireworks AI–prefixed models when the required API key is present.
* **Bug Fixes**
  * Applied correct response-format handling and stricter validation for unsupported/unknown model names.
  * Improved request validation for “prefix providers” to ensure models are only accepted when their environment requirements are satisfied.
* **Tests**
  * Added coverage for Fireworks AI provider behavior, including edge cases and environment-variable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->