### PR TITLE
[NOT-489] docs: regenerate llms.txt with GET /ready endpoint

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -208,6 +208,7 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 ## Health
 
 - [GET Health Check](https://docs.notte.cc/api-reference/health/health-check.md)
+- [GET Ready Check](https://docs.notte.cc/api-reference/health/ready-check.md)
 
 ## Personas
 


### PR DESCRIPTION
Regenerate `llms.txt` via `make docs-sdk docs-agent-notice` to include the `GET /ready` health endpoint. No manual edits.

Linear: NOT-489 https://linear.app/nottelabsinc/issue/NOT-489/notte-pr-856-docs-regenerate-llmstxt-with-get-ready-endpoint