### PR TITLE
[NOT-491] Skip live SDK tests without NOTTE_API_KEY

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import notte_core
+import pytest
 
 CONFIG_PATH = Path(__file__).parent / "test_notte_config.toml"
 notte_core.set_error_mode("developer")
@@ -49,3 +50,9 @@ def pytest_generate_tests(metafunc):
         # Apply parameterization only if any matching arguments exist
         if params:
             metafunc.parametrize(",".join(params.keys()), [next(iter(params.values()))])
+
+
+@pytest.fixture
+def require_notte_api_key():
+    if os.getenv("NOTTE_API_KEY") is None:
+        pytest.skip("NOTTE_API_KEY is required for live Notte API tests")

--- a/tests/sdk/test_list.py
+++ b/tests/sdk/test_list.py
@@ -2,7 +2,7 @@ from dotenv import load_dotenv
 from notte_sdk import NotteClient
 
 
-def test_simple_listing():
+def test_simple_listing(require_notte_api_key):
     _ = load_dotenv()
     notte = NotteClient()
 

--- a/tests/sdk/test_replay_frames.py
+++ b/tests/sdk/test_replay_frames.py
@@ -6,7 +6,7 @@ from PIL import Image
 import notte
 
 
-def test_sdk_screenshots():
+def test_sdk_screenshots(require_notte_api_key):
     """Make sure everything is in bytes (and not base64 encoded), all in JPEG"""
     client = NotteClient()
 

--- a/tests/sdk/test_validator.py
+++ b/tests/sdk/test_validator.py
@@ -12,7 +12,7 @@ class Product(BaseModel):
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
-def test_validator_message_received():
+def test_validator_message_received(require_notte_api_key):
     """Test that validation failures are logged and agent can recover with a valid response."""
     log_buffer = io.StringIO()
     _ = logger.add(log_buffer, format="{message}")


### PR DESCRIPTION
## Summary

- add a shared `require_notte_api_key` pytest fixture that skips live API tests when `NOTTE_API_KEY` is missing
- mark SDK tests that construct `NotteClient()` and call live Notte API endpoints with that fixture

Fixes #859

## Test plan

```bash
uv run pytest -q tests/sdk/test_list.py::test_simple_listing tests/sdk/test_replay_frames.py::test_sdk_screenshots tests/sdk/test_validator.py::test_validator_message_received
```

Result without `NOTTE_API_KEY` configured:

```text
3 skipped
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Live API tests now run only when the required API key is available.
  - Tests automatically skip when the API key is not configured, avoiding failures in environments without live API access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Linear: NOT-491 https://linear.app/nottelabsinc/issue/NOT-491/notte-pr-860-skip-live-sdk-tests-without-notte-api-key