### PR TITLE
fix(sdk): enable CAPTCHA solving by default

### DIFF
--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -135,6 +135,9 @@ class NotteSession(AsyncResource, SyncResource):
             raise ValueError(
                 "RemoteFileStorage is not supported for local sessions. Use a local storage implementation instead."
             )
+        # CAPTCHA solving is a cloud SDK capability. Keep local sessions
+        # runnable by default while preserving an explicit opt-in error.
+        _ = data.setdefault("solve_captchas", False)
         self._request: SessionStartRequest = SessionStartRequest.model_validate(data)
         if self._request.solve_captchas and not CaptchaHandler.is_available:
             raise CaptchaSolverNotAvailableError()

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -773,9 +773,7 @@ class SessionStartRequestDict(TypedDict, total=False):
 
 class SessionStartRequest(SdkRequest):
     headless: Annotated[bool, Field(description="Whether to run the session in headless mode.")] = config.headless
-    solve_captchas: Annotated[bool, Field(description="Whether to try to automatically solve captchas")] = (
-        config.solve_captchas
-    )
+    solve_captchas: Annotated[bool, Field(description="Whether to try to automatically solve captchas")] = True
 
     max_duration_minutes: Annotated[
         int,

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -163,7 +163,7 @@ def _stop_session(mock_delete: MagicMock, client: NotteClient, session_id: str) 
 def test_start_session(mock_post: MagicMock, client: NotteClient, session_id: str, headers: dict[str, str]) -> None:
     session_data: SessionStartRequestDict = {
         "headless": True,
-        "solve_captchas": False,
+        "solve_captchas": True,
         "idle_timeout_minutes": DEFAULT_SESSION_IDLE_TIMEOUT_IN_MINUTES,
         "max_duration_minutes": DEFAULT_SESSION_MAX_DURATION_IN_MINUTES,
         "proxies": False,
@@ -410,6 +410,12 @@ def test_new_timeout_parameters_with_defaults() -> None:
     request = SessionStartRequest()
     assert request.max_duration_minutes == DEFAULT_SESSION_MAX_DURATION_IN_MINUTES
     assert request.idle_timeout_minutes == DEFAULT_SESSION_IDLE_TIMEOUT_IN_MINUTES
+
+
+def test_solve_captchas_defaults_to_enabled_but_can_be_disabled() -> None:
+    request = SessionStartRequest()
+    assert request.solve_captchas is True
+    assert SessionStartRequest(solve_captchas=False).solve_captchas is False
 
 
 def test_new_timeout_parameters_explicit() -> None:


### PR DESCRIPTION
## Summary
- enable CAPTCHA solving for sessions that omit `solve_captchas`
- preserve explicit `solve_captchas=False` opt-out

## Test plan
- `pytest tests/sdk/test_client.py -k "timeout_parameters_with_defaults or solve_captchas_defaults_to_enabled_but_can_be_disabled"`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787743162&installation_model_id=8247&pr_number=862&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F862&signature=d8a6c32a69cb571f7ea119ae9a31d546681dcf7de7c9efbf3061b54211b1dbfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * CAPTCHA solving is now enabled by default when starting sessions via the SDK.
  * Local browser automation sessions now default to CAPTCHA solving disabled unless you explicitly enable it.
* **Tests**
  * Updated and added unit coverage to verify the new default behavior and that CAPTCHA solving can be explicitly turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->