### PR TITLE
Add profile duplication SDK support

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/profiles.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/profiles.py
@@ -11,6 +11,8 @@ from notte_sdk.types import (
     ExecutionResponse,
     ProfileCreateRequest,
     ProfileCreateRequestDict,
+    ProfileDuplicateRequest,
+    ProfileDuplicateRequestDict,
     ProfileListRequest,
     ProfileListRequestDict,
     ProfileResponse,
@@ -28,6 +30,7 @@ class ProfilesClient(BaseClient):
     CREATE_PROFILE = "create"
     GET_PROFILE = "{profile_id}"
     DELETE_PROFILE = "{profile_id}"
+    DUPLICATE_PROFILE = "{profile_id}/duplicate"
     LIST_PROFILES = ""
 
     def __init__(
@@ -78,6 +81,15 @@ class ProfilesClient(BaseClient):
             path=ProfilesClient.DELETE_PROFILE.format(profile_id=profile_id),
             response=ExecutionResponse,
             method="DELETE",
+        )
+
+    @staticmethod
+    def _duplicate_profile_endpoint(profile_id: str) -> NotteEndpoint[ProfileResponse]:
+        """Returns a NotteEndpoint configured for duplicating a profile."""
+        return NotteEndpoint(
+            path=ProfilesClient.DUPLICATE_PROFILE.format(profile_id=profile_id),
+            response=ProfileResponse,
+            method="POST",
         )
 
     @staticmethod
@@ -138,6 +150,21 @@ class ProfilesClient(BaseClient):
         """
         result = self.request(ProfilesClient._delete_profile_endpoint(profile_id))
         return result.success
+
+    @track_usage("cloud.profile.duplicate")
+    def duplicate(self, profile_id: str, **data: Unpack[ProfileDuplicateRequestDict]) -> ProfileResponse:
+        """Duplicate a profile and its last persisted browser state.
+
+        Args:
+            profile_id: Source profile ID
+            **data: Optional destination name. The source name is reused when omitted.
+
+        Returns:
+            ProfileResponse: The newly created profile
+        """
+        request = ProfileDuplicateRequest.model_validate(data)
+        endpoint = ProfilesClient._duplicate_profile_endpoint(profile_id).with_request(request)
+        return self.request(endpoint)
 
     @track_usage("cloud.profile.list")
     def list(self, **data: Unpack[ProfileListRequestDict]) -> Sequence[ProfileResponse]:

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1380,6 +1380,19 @@ class ProfileCreateRequest(SdkRequest):
     name: Annotated[str | None, Field(description="Name of the profile")] = None
 
 
+class ProfileDuplicateRequestDict(TypedDict, total=False):
+    """Request dictionary for duplicating a profile."""
+
+    name: str
+
+
+class ProfileDuplicateRequest(SdkRequest):
+    name: Annotated[
+        str | None,
+        Field(description="Optional name for the duplicate; defaults to the source profile name"),
+    ] = None
+
+
 class ProfileResponse(SdkResponse):
     profile_id: Annotated[str, Field(description="Profile ID (format: notte-profile-{16 hex chars})")]
     name: Annotated[str | None, Field(description="Profile name")]

--- a/tests/sdk/test_profile_endpoint_paths.py
+++ b/tests/sdk/test_profile_endpoint_paths.py
@@ -1,0 +1,32 @@
+import datetime as dt
+from unittest.mock import patch
+
+from notte_sdk import NotteClient
+from notte_sdk.endpoints.profiles import ProfilesClient
+from notte_sdk.types import ProfileDuplicateRequest, ProfileResponse
+
+
+def test_profile_duplicate_endpoint_uses_source_id() -> None:
+    endpoint = ProfilesClient._duplicate_profile_endpoint("notte-profile-source")
+
+    assert endpoint.method == "POST"
+    assert endpoint.path == "notte-profile-source/duplicate"
+    assert endpoint.response is ProfileResponse
+
+
+def test_profile_duplicate_sends_optional_destination_name() -> None:
+    client = NotteClient(api_key="test-api-key", server_url="https://api.notte.cc")
+    expected = ProfileResponse(
+        profile_id="notte-profile-copy",
+        name="Copied login",
+        created_at=dt.datetime(2026, 7, 27, tzinfo=dt.UTC),
+        updated_at=dt.datetime(2026, 7, 27, tzinfo=dt.UTC),
+    )
+
+    with patch.object(client.profiles, "request", return_value=expected) as request:
+        result = client.profiles.duplicate("notte-profile-source", name="Copied login")
+
+    assert result is expected
+    endpoint = request.call_args.args[0]
+    assert endpoint.path == "notte-profile-source/duplicate"
+    assert endpoint.request == ProfileDuplicateRequest(name="Copied login")


### PR DESCRIPTION
## Summary

- add `ProfilesClient.duplicate`
- accept an optional destination name
- send `POST /profiles/{profile_id}/duplicate`
- cover endpoint construction and request payloads

Companion to nottelabs/monorepo#1918.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787756288&installation_model_id=8247&pr_number=863&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F863&signature=01f7beab87d18f79510c1924bda6f37ed8e7c9017f0c2eb0a77e327392d479ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->