### PR TITLE
[NOT-556] feat(sdk): support managed auth session ids

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -80,6 +80,7 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 - [Introduction](https://docs.notte.cc/index.md)
 - [Quickstart](https://docs.notte.cc/quickstart.md): Get started in a few seconds
 - [MCP Server](https://docs.notte.cc/mcp-server.md): Give your AI agents access to the Notte MCP server
+- [Migrate to Notte](https://docs.notte.cc/migrate-to-notte.md): Safely migrate browser automation from another provider to Notte with an AI coding agent.
 
 ## Sessions
 
@@ -225,6 +226,7 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 - [POST Profile Cookies Set](https://docs.notte.cc/api-reference/profiles/profile-cookies-set.md)
 - [POST Profile Create](https://docs.notte.cc/api-reference/profiles/profile-create.md)
 - [DELETE Profile Delete](https://docs.notte.cc/api-reference/profiles/profile-delete.md)
+- [POST Profile Duplicate](https://docs.notte.cc/api-reference/profiles/profile-duplicate.md)
 - [GET Profile Get](https://docs.notte.cc/api-reference/profiles/profile-get.md)
 - [GET Profile List](https://docs.notte.cc/api-reference/profiles/profile-list.md)
 

--- a/docs/src/migrate-to-notte.mdx
+++ b/docs/src/migrate-to-notte.mdx
@@ -2,6 +2,9 @@
 title: Migrate to Notte
 description: Safely migrate browser automation from another provider to Notte with an AI coding agent.
 ---
+import AgentMdNotice from '/partials/agent-md-notice.mdx';
+
+<AgentMdNotice />
 
 Use the Notte migration skills to move an existing browser-automation codebase
 to Notte with a visible plan, measured baseline, safe proof, tests, and a

--- a/docs/src/sdk-reference/manual/session.mdx
+++ b/docs/src/sdk-reference/manual/session.mdx
@@ -131,3 +131,7 @@ You can use the default parameters to create your session, or customize them:
 
 <ParamField path="vault_id" type="str | None">
 </ParamField>
+
+<ParamField path="auth_ids" type="list">
+  Up to 10 unique Managed Auth connection IDs to authenticate before the session is returned.
+</ParamField>

--- a/docs/src/sdk-reference/misc/sessionresponse.mdx
+++ b/docs/src/sdk-reference/misc/sessionresponse.mdx
@@ -98,7 +98,7 @@ description: ""
   Whether to use web bot authentication.
 </ParamField>
 
-<ParamField path="auth_ids" type="list[str]" required>
+<ParamField path="auth_ids" type="list[str]" default="[]">
   Managed Auth connection IDs attached to this session.
 </ParamField>
 

--- a/docs/src/sdk-reference/misc/sessionresponse.mdx
+++ b/docs/src/sdk-reference/misc/sessionresponse.mdx
@@ -98,6 +98,10 @@ description: ""
   Whether to use web bot authentication.
 </ParamField>
 
+<ParamField path="auth_ids" type="list[str]" required>
+  Managed Auth connection IDs attached to this session.
+</ParamField>
+
 
 ## Module
 

--- a/docs/src/sdk-reference/remotesession/__init__.mdx
+++ b/docs/src/sdk-reference/remotesession/__init__.mdx
@@ -102,7 +102,7 @@ RemoteSession instance configured with the specified parameters.
 </ParamField>
 
 <ParamField path="auth_ids" type="list">
-  Managed Auth connection IDs to authenticate before the session is returned.
+  Up to 10 unique Managed Auth connection IDs to authenticate before the session is returned.
 </ParamField>
 
 ## Returns

--- a/docs/src/sdk-reference/remotesession/__init__.mdx
+++ b/docs/src/sdk-reference/remotesession/__init__.mdx
@@ -101,6 +101,10 @@ RemoteSession instance configured with the specified parameters.
 <ParamField path="vault_id" type="str | None">
 </ParamField>
 
+<ParamField path="auth_ids" type="list">
+  Managed Auth connection IDs to authenticate before the session is returned.
+</ParamField>
+
 ## Returns
 
 `None`: A new RemoteSession instance configured with the specified parameters.

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -851,7 +851,7 @@ class SessionStartRequest(SdkRequest):
 
     vault_id: Annotated[str | None, Field(description="The vault to use for the session")] = None
     auth_ids: Annotated[
-        list[str],
+        list[str] | None,
         Field(
             max_length=10,
             description=(
@@ -859,7 +859,7 @@ class SessionStartRequest(SdkRequest):
                 "inside this session before it is returned."
             ),
         ),
-    ] = Field(default_factory=list)
+    ] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -871,7 +871,7 @@ class SessionStartRequest(SdkRequest):
 
     @model_validator(mode="after")
     def validate_unique_auth_ids(self) -> "SessionStartRequest":
-        if len(self.auth_ids) != len(set(self.auth_ids)):
+        if self.auth_ids is not None and len(self.auth_ids) != len(set(self.auth_ids)):
             raise ValueError("auth_ids must not contain duplicates")
         return self
 

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -753,6 +753,7 @@ class SessionStartRequestDict(TypedDict, total=False):
         use_file_storage: Whether FileStorage should be attached to the session.
         screenshot_type: The type of screenshot to use for the session.
         profile: Browser profile configuration for state persistence.
+        auth_ids: Managed Auth connection IDs to authenticate before the session is returned.
     """
 
     headless: bool
@@ -775,6 +776,7 @@ class SessionStartRequestDict(TypedDict, total=False):
     web_bot_auth: bool
     extra_http_headers: dict[str, str] | None
     vault_id: str | None
+    auth_ids: list[str]
 
 
 class SessionStartRequest(SdkRequest):
@@ -848,6 +850,16 @@ class SessionStartRequest(SdkRequest):
     ] = None
 
     vault_id: Annotated[str | None, Field(description="The vault to use for the session")] = None
+    auth_ids: Annotated[
+        list[str],
+        Field(
+            max_length=10,
+            description=(
+                "Managed Auth connection IDs to verify and, when necessary, authenticate "
+                "inside this session before it is returned."
+            ),
+        ),
+    ] = Field(default_factory=list)
 
     @model_validator(mode="before")
     @classmethod
@@ -856,6 +868,12 @@ class SessionStartRequest(SdkRequest):
             if "max_duration_minutes" not in values:
                 values["max_duration_minutes"] = DEFAULT_SESSION_MAX_DURATION_IN_MINUTES
         return values  # pyright: ignore[reportUnknownVariableType]
+
+    @model_validator(mode="after")
+    def validate_unique_auth_ids(self) -> "SessionStartRequest":
+        if len(self.auth_ids) != len(set(self.auth_ids)):
+            raise ValueError("auth_ids must not contain duplicates")
+        return self
 
     @model_validator(mode="before")
     @classmethod

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -776,7 +776,7 @@ class SessionStartRequestDict(TypedDict, total=False):
     web_bot_auth: bool
     extra_http_headers: dict[str, str] | None
     vault_id: str | None
-    auth_ids: list[str]
+    auth_ids: list[str] | None
 
 
 class SessionStartRequest(SdkRequest):

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1065,6 +1065,10 @@ class SessionResponse(SdkResponse):
     cdp_url: Annotated[str | None, Field(description="The URL to connect to the CDP server.")] = None
     viewer_url: Annotated[str | None, Field(description="The remote session viewer URL.")] = None
     web_bot_auth: Annotated[bool, Field(description="Whether to use web bot authentication.")] = False
+    auth_ids: Annotated[
+        list[str],
+        Field(description="Managed Auth connection IDs attached to this session."),
+    ] = Field(default_factory=list)
 
     @field_validator("closed_at", mode="before")
     @classmethod

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -753,7 +753,7 @@ class SessionStartRequestDict(TypedDict, total=False):
         use_file_storage: Whether FileStorage should be attached to the session.
         screenshot_type: The type of screenshot to use for the session.
         profile: Browser profile configuration for state persistence.
-        auth_ids: Managed Auth connection IDs to authenticate before the session is returned.
+        auth_ids: Up to 10 unique Managed Auth connection IDs to authenticate before the session is returned.
     """
 
     headless: bool
@@ -1068,7 +1068,7 @@ class SessionResponse(SdkResponse):
     auth_ids: Annotated[
         list[str],
         Field(description="Managed Auth connection IDs attached to this session."),
-    ] = Field(default_factory=list)
+    ] = []
 
     @field_validator("closed_at", mode="before")
     @classmethod

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -418,6 +418,22 @@ def test_solve_captchas_defaults_to_enabled_but_can_be_disabled() -> None:
     assert SessionStartRequest(solve_captchas=False).solve_captchas is False
 
 
+def test_managed_auth_ids_are_serialized_and_must_be_unique() -> None:
+    from pydantic import ValidationError
+
+    auth_ids = [
+        "55555555-5555-5555-5555-555555555555",
+        "66666666-6666-6666-6666-666666666666",
+    ]
+    request = SessionStartRequest(auth_ids=auth_ids)
+
+    assert request.auth_ids == auth_ids
+    assert request.model_dump(mode="json")["auth_ids"] == auth_ids
+
+    with pytest.raises(ValidationError, match="auth_ids must not contain duplicates"):
+        SessionStartRequest(auth_ids=[auth_ids[0], auth_ids[0]])
+
+
 def test_new_timeout_parameters_explicit() -> None:
     """Test new explicit timeout parameters."""
     request = SessionStartRequest(max_duration_minutes=10, idle_timeout_minutes=5)

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -430,6 +430,12 @@ def test_managed_auth_ids_are_serialized_and_must_be_unique() -> None:
     assert request.auth_ids == auth_ids
     assert request.model_dump(mode="json")["auth_ids"] == auth_ids
 
+    ten_auth_ids = [f"{index:08d}-0000-0000-0000-000000000000" for index in range(10)]
+    assert SessionStartRequest(auth_ids=ten_auth_ids).auth_ids == ten_auth_ids
+
+    with pytest.raises(ValidationError):
+        SessionStartRequest(auth_ids=[*ten_auth_ids, "00000010-0000-0000-0000-000000000000"])
+
     with pytest.raises(ValidationError, match="auth_ids must not contain duplicates"):
         SessionStartRequest(auth_ids=[auth_ids[0], auth_ids[0]])
 

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -421,6 +421,8 @@ def test_solve_captchas_defaults_to_enabled_but_can_be_disabled() -> None:
 def test_managed_auth_ids_are_serialized_and_must_be_unique() -> None:
     from pydantic import ValidationError
 
+    assert "auth_ids" not in SessionStartRequest().model_dump(mode="json", exclude_none=True)
+
     auth_ids = [
         "55555555-5555-5555-5555-555555555555",
         "66666666-6666-6666-6666-666666666666",


### PR DESCRIPTION
Adds `auth_ids` to `SessionStartRequest` and `SessionStartRequestDict`, enabling `client.Session(auth_ids=[...])`. The SDK validates a maximum of 10 unique IDs and serializes them in the session start request.\n\nThis is the SDK half of nottelabs/monorepo#1714.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787759536&installation_model_id=8247&pr_number=864&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F864&signature=e84429291ef3a9af4063b4808c45c80651062f8952f0dd35ed03ec395a1055ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session startup supports up to 10 optional, unique managed authentication connection IDs.
  * Session details include the managed authentication IDs attached to each session.
  * Authentication IDs are preserved during serialization, with duplicate values rejected during validation.
* **Documentation**
  * Updated session and RemoteSession references with authentication ID configuration details.
  * Added migration guidance and links for migrating to Notte and duplicating profiles.
* **Tests**
  * Added coverage for authentication ID serialization, limits, and duplicate validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->