### PR TITLE
docs: fix email notifier README wording

### DIFF
--- a/examples/email-notifier-agent/README.md
+++ b/examples/email-notifier-agent/README.md
@@ -1,9 +1,9 @@
 # Email Notifier Agent
 <img src="https://github.com/user-attachments/assets/23c821a7-af61-4e7a-bbba-e26508f6a091" width=600>
 
-This examples shows how you can recieve emails containing the agent's task output once the agent is done running.
+This example shows how you can receive emails containing the agent's task output once the agent is done running.
 
-To run this example, you will need to setup a Email SMTP server. You can use your own email provider or a service like [Mailtrap](https://mailtrap.io/).
+To run this example, you will need to set up an email SMTP server. You can use your own email provider or a service like [Mailtrap](https://mailtrap.io/).
 
 References:
 * [GMAIL SMTP](https://support.google.com/a/answer/176600?hl=en)


### PR DESCRIPTION
Fixes wording in the email notifier example README: "This examples" -> "This example", "recieve" -> "receive", and "setup a Email SMTP server" -> "set up an email SMTP server".

Documentation-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787820893&installation_model_id=8247&pr_number=865&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F865&signature=afbf3ac9b2fc1142bc3b4522d4a0579a02c0046b9f69200f71e4f9b8a3b84c12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling, grammar, and capitalization in the email notifier example.
  * Clarified that notification emails contain the agent’s task output after execution completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->