### PR TITLE
fix: harden usage telemetry and generated-code docs

### DIFF
--- a/docs/src/features/agents/workflows.mdx
+++ b/docs/src/features/agents/workflows.mdx
@@ -81,6 +81,13 @@ Review the generated Python before running it:
 
 <ExecuteGeneratedCode />
 
+Before testing the saved file:
+
+1. Use a disposable container or virtual machine with no host or home-directory mounts.
+2. Provide only short-lived, minimum-scope credentials; generated code can read and transmit every value you expose.
+3. Restrict network access to the destinations the workflow requires, when possible.
+4. Destroy the environment and revoke its credentials after the test.
+
 ### Use Function API
 
 Run via the function endpoint:

--- a/docs/src/features/agents/workflows.mdx
+++ b/docs/src/features/agents/workflows.mdx
@@ -70,7 +70,14 @@ Create a reusable function:
 
 ### Execute Generated Code
 
-Copy and run the generated Python:
+Review the generated Python before running it:
+
+<Warning>
+  Generated workflows contain LLM-produced code and should be treated as untrusted. Inspect the entire file, then run
+  it only in an isolated environment with the minimum required permissions.
+</Warning>
+
+{/* Unsafe generated-code execution was reported in #794 by @sebastiondev. */}
 
 <ExecuteGeneratedCode />
 

--- a/docs/src/snippets/agents/workflows/test-generated-functions.mdx
+++ b/docs/src/snippets/agents/workflows/test-generated-functions.mdx
@@ -7,9 +7,9 @@
     # Generate function code
     code = agent.workflow.code()
 
-# Save for review before testing in a fresh session
+# Save for review before isolated execution
 with open("generated_function.py", "w", encoding="utf-8") as generated_file:
     generated_file.write(code.python_script)
 
-print("Saved generated_function.py. Review it before running it in an isolated environment.")
+print("Saved generated_function.py. Review it, then run it in a disposable container or virtual machine.")
 ```

--- a/docs/src/snippets/agents/workflows/test-generated-functions.mdx
+++ b/docs/src/snippets/agents/workflows/test-generated-functions.mdx
@@ -7,7 +7,9 @@
     # Generate function code
     code = agent.workflow.code()
 
-# Test in fresh session
-with client.Session() as session:
-    exec(code.python_script)
+# Save for review before testing in a fresh session
+with open("generated_function.py", "w", encoding="utf-8") as generated_file:
+    generated_file.write(code.python_script)
+
+print("Saved generated_function.py. Review it before running it in an isolated environment.")
 ```

--- a/docs/src/testers/agents/workflows/test-generated-functions.py
+++ b/docs/src/testers/agents/workflows/test-generated-functions.py
@@ -1,5 +1,5 @@
 # @sniptest filename=test-generated-functions.py
-# @sniptest show=6-13
+# @sniptest show=6-15
 from notte_sdk import NotteClient
 
 client = NotteClient()
@@ -10,7 +10,8 @@ with client.Session() as session:
     # Generate function code
     code = agent.workflow.code()
 
-# Test in fresh session
-with client.Session() as session:
-    exec(code.python_script)
-    # Verify it works
+# Save for review before testing in a fresh session
+with open("generated_function.py", "w", encoding="utf-8") as generated_file:
+    generated_file.write(code.python_script)
+
+print("Saved generated_function.py. Review it before running it in an isolated environment.")

--- a/docs/src/testers/agents/workflows/test-generated-functions.py
+++ b/docs/src/testers/agents/workflows/test-generated-functions.py
@@ -10,8 +10,8 @@ with client.Session() as session:
     # Generate function code
     code = agent.workflow.code()
 
-# Save for review before testing in a fresh session
+# Save for review before isolated execution
 with open("generated_function.py", "w", encoding="utf-8") as generated_file:
     generated_file.write(code.python_script)
 
-print("Saved generated_function.py. Review it before running it in an isolated environment.")
+print("Saved generated_function.py. Review it, then run it in a disposable container or virtual machine.")

--- a/packages/notte-core/src/notte_core/common/telemetry.py
+++ b/packages/notte-core/src/notte_core/common/telemetry.py
@@ -1,4 +1,5 @@
 import importlib.metadata as metadata
+import inspect
 import logging
 import os
 import platform
@@ -228,23 +229,44 @@ def capture_event(event_name: str, properties: dict[str, Any] | None = None) -> 
             logger.debug(f"Failed to send telemetry event {event_name}: {e}")
 
 
+def _capture_usage_event(method_name: str, error: Exception | None = None) -> None:
+    # Usage-decorated calls may contain credentials, payment details, cookies, or API tokens.
+    # Keep telemetry metadata-only. The unsafe error-path payload was reported in #826 by @sebastiondev.
+    properties: dict[str, Any] = {"status": "error" if error is not None else "success"}
+    if error is not None:
+        properties["error_type"] = type(error).__name__
+    capture_event(method_name, properties=properties)
+
+
 def track_usage(method_name: str) -> Callable[[F], F]:
-    """Decorator to track usage of a method."""
+    """Track a call without including argument values or exception messages."""
 
     def decorator(func: F) -> F:
-        exclude_kwargs = set(["email", "username", "password", "mfa_secret"])
+        if inspect.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    result = await func(*args, **kwargs)
+                except Exception as e:
+                    _capture_usage_event(method_name, error=e)
+                    raise
+                else:
+                    _capture_usage_event(method_name)
+                    return result
+
+            return async_wrapper  # type: ignore
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            event_name = method_name
             try:
                 result = func(*args, **kwargs)
-                filtered_kwargs = {k: v for k, v in kwargs.items() if k not in exclude_kwargs}
-                capture_event(event_name, properties={"input": {"args": args, "kwargs": filtered_kwargs}})
-                return result
             except Exception as e:
-                capture_event(event_name, properties={"input": {"args": args, "kwargs": kwargs}, "error": str(e)})
-                raise e
+                _capture_usage_event(method_name, error=e)
+                raise
+            else:
+                _capture_usage_event(method_name)
+                return result
 
         return wrapper  # type: ignore
 

--- a/tests/integration/test_telemetry.py
+++ b/tests/integration/test_telemetry.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+import pytest
+from notte_core.common import telemetry
+
+
+def test_track_usage_delivers_metadata_only_to_telemetry_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+    posthog_events: list[tuple[str, str, dict[str, Any]]] = []
+    scarf_events: list[dict[str, Any]] = []
+
+    class RecordingPosthogClient:
+        def capture(self, *, distinct_id: str, event: str, properties: dict[str, Any]) -> None:
+            posthog_events.append((distinct_id, event, properties.copy()))
+
+    class RecordingScarfClient:
+        def log_event(self, *, properties: dict[str, Any]) -> None:
+            scarf_events.append(properties.copy())
+
+    monkeypatch.setattr(telemetry, "DISABLE_TELEMETRY", False)
+    monkeypatch.setattr(telemetry, "INSTALLATION_ID", "test-installation")
+    monkeypatch.setattr(telemetry, "get_system_info", lambda: {})
+    monkeypatch.setattr(telemetry, "posthog_client", RecordingPosthogClient())
+    monkeypatch.setattr(telemetry, "scarf_client", RecordingScarfClient())
+
+    secret = "delivery-boundary-secret"  # noqa: S105  # pragma: allowlist secret
+
+    @telemetry.track_usage("test.delivery_boundary")
+    def decorated(*, api_token: str) -> None:
+        raise RuntimeError(f"request failed with {api_token}")
+
+    with pytest.raises(RuntimeError, match=secret):
+        decorated(api_token=secret)
+
+    assert posthog_events == [
+        (
+            "test-installation",
+            "test.delivery_boundary",
+            {
+                "status": "error",
+                "error_type": "RuntimeError",
+                "process_person_profile": True,
+            },
+        )
+    ]
+    assert scarf_events == [
+        {
+            "status": "error",
+            "error_type": "RuntimeError",
+            "process_person_profile": True,
+            "event": "test.delivery_boundary",
+            "installation_id": "test-installation",
+        }
+    ]
+    assert secret not in repr(posthog_events)
+    assert secret not in repr(scarf_events)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,77 @@
+from typing import Any
+
+import pytest
+from notte_core.common import telemetry
+
+
+def capture_usage_events(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, Any] | None]]:
+    events: list[tuple[str, dict[str, Any] | None]] = []
+
+    def capture_event(event_name: str, properties: dict[str, Any] | None = None) -> None:
+        events.append((event_name, properties))
+
+    monkeypatch.setattr(telemetry, "capture_event", capture_event)
+    return events
+
+
+def test_track_usage_does_not_capture_argument_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    events = capture_usage_events(monkeypatch)
+    sensitive_values = {
+        "positional-secret",
+        "password-secret",
+        "card-number-secret",
+        "card-cvv-secret",
+        "api-token-secret",
+    }
+
+    @telemetry.track_usage("test.success")
+    def decorated(positional_value: str, **kwargs: str) -> str:
+        assert positional_value in sensitive_values
+        assert kwargs
+        return "ok"
+
+    result = decorated(
+        "positional-secret",
+        password="password-secret",  # pragma: allowlist secret
+        card_number="card-number-secret",
+        card_cvv="card-cvv-secret",
+        api_token="api-token-secret",
+    )
+
+    assert result == "ok"
+    assert events == [("test.success", {"status": "success"})]
+    assert all(secret not in repr(events) for secret in sensitive_values)
+
+
+def test_track_usage_does_not_capture_exception_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    events = capture_usage_events(monkeypatch)
+    secret = "exception-secret"  # pragma: allowlist secret
+
+    @telemetry.track_usage("test.error")
+    def decorated() -> None:
+        raise RuntimeError(f"request failed with {secret}")
+
+    with pytest.raises(RuntimeError, match=secret):
+        decorated()
+
+    assert events == [("test.error", {"status": "error", "error_type": "RuntimeError"})]
+    assert secret not in repr(events)
+
+
+@pytest.mark.asyncio
+async def test_track_usage_captures_async_failures_after_await(monkeypatch: pytest.MonkeyPatch) -> None:
+    events = capture_usage_events(monkeypatch)
+    secret = "async-secret"  # pragma: allowlist secret
+
+    @telemetry.track_usage("test.async_error")
+    async def decorated(*, token: str) -> None:
+        raise ValueError(f"request failed with {token}")
+
+    coroutine = decorated(token=secret)
+    assert events == []
+
+    with pytest.raises(ValueError, match=secret):
+        await coroutine
+
+    assert events == [("test.async_error", {"status": "error", "error_type": "ValueError"})]
+    assert secret not in repr(events)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -32,10 +32,10 @@ def test_track_usage_does_not_capture_argument_values(monkeypatch: pytest.Monkey
 
     result = decorated(
         "positional-secret",
-        password="password-secret",  # pragma: allowlist secret
+        password="password-secret",  # noqa: S106  # pragma: allowlist secret
         card_number="card-number-secret",
         card_cvv="card-cvv-secret",
-        api_token="api-token-secret",
+        api_token="api-token-secret",  # noqa: S106  # pragma: allowlist secret
     )
 
     assert result == "ok"
@@ -45,7 +45,7 @@ def test_track_usage_does_not_capture_argument_values(monkeypatch: pytest.Monkey
 
 def test_track_usage_does_not_capture_exception_messages(monkeypatch: pytest.MonkeyPatch) -> None:
     events = capture_usage_events(monkeypatch)
-    secret = "exception-secret"  # pragma: allowlist secret
+    secret = "exception-secret"  # noqa: S105  # pragma: allowlist secret
 
     @telemetry.track_usage("test.error")
     def decorated() -> None:
@@ -61,7 +61,7 @@ def test_track_usage_does_not_capture_exception_messages(monkeypatch: pytest.Mon
 @pytest.mark.asyncio
 async def test_track_usage_captures_async_failures_after_await(monkeypatch: pytest.MonkeyPatch) -> None:
     events = capture_usage_events(monkeypatch)
-    secret = "async-secret"  # pragma: allowlist secret
+    secret = "async-secret"  # noqa: S105  # pragma: allowlist secret
 
     @telemetry.track_usage("test.async_error")
     async def decorated(*, token: str) -> None:


### PR DESCRIPTION
## Summary

- stop sending positional arguments, keyword values, payment details, tokens, and exception messages through usage telemetry
- retain metadata-only success/error events, including the exception class
- correctly capture async failures after the decorated coroutine runs
- replace the documentation's direct `exec()` of LLM-generated code with a save, review, and isolated-execution flow
- add regression coverage for synchronous and asynchronous sensitive-data paths

## Context

This supersedes the narrower fixes proposed in #826 and #794. The underlying problems were reported by @sebastiondev; thank you for identifying them.

The telemetry change deliberately uses a metadata allowlist rather than extending the existing sensitive-key denylist. Decorated calls can carry credentials, payment information, cookies, API tokens, and sensitive exception text under arbitrary names, so argument values are no longer collected at all.

## Validation

- `pytest -q tests/test_telemetry.py`
- Ruff check and format
- basedpyright
- detect-secrets
- documentation broken-link and SDK checks
- sniptest generation and verification
- all pre-commit hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787824463&installation_model_id=8247&pr_number=866&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F866&signature=54118cdc55195f7609461ee0540e95fce745b1a608de9156a5603b3e37e196da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated AI-generated workflow execution guidance with a strong “untrusted code” warning and a checklist for safe, isolated testing.
  - Adjusted the “test generated functions” snippet to save generated Python to a local file and prompt users to review before running.

- **Bug Fixes**
  - Enhanced telemetry to emit only high-level success/error metadata (no argument values or exception message contents).
  - Improved usage tracking to correctly handle both synchronous and async callables.

- **Tests**
  - Added unit and integration coverage to verify telemetry privacy guarantees for both success and error cases, including async flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->