### PR TITLE
fix: make fallback errors observable

### DIFF
--- a/packages/notte-browser/src/notte_browser/dom/csspaths.py
+++ b/packages/notte-browser/src/notte_browser/dom/csspaths.py
@@ -1,6 +1,8 @@
 # functions from: https://github.com/browser-use/browser-use/blob/main/browser_use/browser/context.py
 import re
 
+from notte_core.common.logging import logger
+
 
 def xpath_to_css_path(xpath: str) -> str:
     """Converts simple XPath expressions to CSS selectors."""
@@ -151,5 +153,5 @@ def build_csspath(
         return css_selector
 
     except Exception:
-        # Fallback to a more basic selector if something goes wrong
+        logger.opt(exception=True).debug("Failed to build CSS path; using the fallback selector")
         return f"{tag_name}[highlight_index='{highlight_index}']"

--- a/packages/notte-browser/src/notte_browser/form_filling.py
+++ b/packages/notte-browser/src/notte_browser/form_filling.py
@@ -3,6 +3,7 @@ import random
 
 from notte_core.common.logging import logger
 
+from notte_browser.playwright_async_api import Error as PlaywrightError
 from notte_browser.playwright_async_api import Locator, Page
 
 
@@ -565,7 +566,14 @@ class FormFiller:
             logger.debug(f"Successfully filled {field_type} field (exact match)")
             await asyncio.sleep(random.uniform(0.1, 0.5))
             return True
-        except Exception:
+        except PlaywrightError as e:
+            # An exact value miss is expected when the caller supplied visible
+            # option text, so log context without a noisy traceback.
+            logger.debug(
+                "Exact match failed for {} field; trying case-insensitive option matching: {}",
+                field_type,
+                e,
+            )
             try:
                 # If exact match fails, try case-insensitive match
                 options: list[dict[str, str]] = await field.evaluate("""select => {

--- a/packages/notte-browser/src/notte_browser/tagging/action/llm_taging/base.py
+++ b/packages/notte-browser/src/notte_browser/tagging/action/llm_taging/base.py
@@ -16,6 +16,23 @@ from typing_extensions import override
 
 from notte_browser.tagging.type import PossibleAction, PossibleActionSpace
 
+_CONTEXT_SIZE_ERROR_MESSAGE = "Please reduce the length of the messages or completions"
+_CONTEXT_SIZE_PATTERN = re.compile(r"Current length is (\d+) while limit is (\d+)")
+
+
+def _context_size_error(error: Exception) -> ContextSizeTooLargeError | None:
+    if isinstance(error, ContextSizeTooLargeError):
+        return error
+
+    message = str(error)
+    if _CONTEXT_SIZE_ERROR_MESSAGE not in message:
+        return None
+
+    match = _CONTEXT_SIZE_PATTERN.search(message)
+    size = int(match.group(1)) if match is not None else None
+    max_size = int(match.group(2)) if match is not None else None
+    return ContextSizeTooLargeError(size=size, max_size=max_size)
+
 
 class BaseActionListingPipe(ABC):
     def __init__(self, llmserve: LLMService) -> None:
@@ -74,24 +91,12 @@ class RetryPipeWrapper(BaseActionListingPipe):
                 return out
             except Exception as e:
                 last_error = e
-                if "Please reduce the length of the messages or completions" in str(e):
-                    # this is a known error that happens when the context is too long
-                    # we should not retry in this case (nothing is going to change)
-                    pattern = r"Current length is (\d+) while limit is (\d+)"
-                    size: int | None = None
-                    max_size: int | None = None
-                    match = re.search(pattern, str(e))
-                    if match:
-                        size = int(match.group(1))
-                        max_size = int(match.group(2))
-                    else:
-                        if self.verbose:
-                            logger.debug(
-                                f"Failed to parse context size from error message: {str(e)}. Please fix this ASAP."
-                            )
-                        raise ContextSizeTooLargeError(size=size, max_size=max_size) from e
+                context_size_error = _context_size_error(e)
+                if context_size_error is not None:
+                    # Retrying cannot reduce the prompt, so fail immediately.
+                    raise context_size_error from e
                 if self.verbose:
-                    logger.debug(f"failed to parse action list but retrying. Start of error msg: {str(e)[:200]}...")
+                    logger.opt(exception=True).debug("Failed to parse action list; retrying")
                 errors.append(str(e))
         self.tracer.trace(
             status="failure",
@@ -109,13 +114,44 @@ class RetryPipeWrapper(BaseActionListingPipe):
         snapshot: BrowserSnapshot,
         previous_action_list: list[InteractionAction],
     ) -> PossibleActionSpace:
-        for _ in range(self.max_tries):
+        errors: list[str] = []
+        for attempt in range(1, self.max_tries + 1):
             try:
-                return await self.pipe.forward_incremental(snapshot, previous_action_list)
-            except Exception:
-                pass
+                out = await self.pipe.forward_incremental(snapshot, previous_action_list)
+                self.tracer.trace(
+                    status="success",
+                    pipe_name=self.pipe.__class__.__name__,
+                    nb_retries=len(errors),
+                    error_msgs=errors,
+                )
+                return out
+            except Exception as e:
+                errors.append(str(e))
+                context_size_error = _context_size_error(e)
+                if self.verbose:
+                    next_step = "using the previous action list" if context_size_error is not None else "retrying"
+                    logger.opt(exception=True).debug(
+                        "Incremental action listing attempt {}/{} failed; {}",
+                        attempt,
+                        self.max_tries,
+                        next_step,
+                    )
+                if context_size_error is not None:
+                    # Incremental listing can safely use its previous result, but
+                    # retrying the same oversized prompt would be wasted work.
+                    break
+
+        self.tracer.trace(
+            status="failure",
+            pipe_name=self.pipe.__class__.__name__,
+            nb_retries=len(errors),
+            error_msgs=errors,
+        )
         if self.verbose:
-            logger.debug("Failed to get action list after max tries => returning previous action list")
+            logger.debug(
+                "Incremental action listing failed after {} attempt(s); returning the previous action list",
+                len(errors),
+            )
         return PossibleActionSpace(
             # TODO: get description from previous action list
             description="",

--- a/packages/notte-browser/src/notte_browser/tagging/action/llm_taging/base.py
+++ b/packages/notte-browser/src/notte_browser/tagging/action/llm_taging/base.py
@@ -10,6 +10,7 @@ from notte_core.errors.llm import (
     LLMnoOutputCompletionError,
     LLMParsingError,
 )
+from notte_core.errors.provider import ContextWindowExceededError
 from notte_llm.service import LLMService
 from notte_llm.tracer import LlmParsingErrorFileTracer
 from typing_extensions import override
@@ -20,8 +21,8 @@ _CONTEXT_SIZE_ERROR_MESSAGE = "Please reduce the length of the messages or compl
 _CONTEXT_SIZE_PATTERN = re.compile(r"Current length is (\d+) while limit is (\d+)")
 
 
-def _context_size_error(error: Exception) -> ContextSizeTooLargeError | None:
-    if isinstance(error, ContextSizeTooLargeError):
+def _context_size_error(error: Exception) -> ContextSizeTooLargeError | ContextWindowExceededError | None:
+    if isinstance(error, (ContextSizeTooLargeError, ContextWindowExceededError)):
         return error
 
     message = str(error)
@@ -94,6 +95,8 @@ class RetryPipeWrapper(BaseActionListingPipe):
                 context_size_error = _context_size_error(e)
                 if context_size_error is not None:
                     # Retrying cannot reduce the prompt, so fail immediately.
+                    if context_size_error is e:
+                        raise
                     raise context_size_error from e
                 if self.verbose:
                     logger.opt(exception=True).debug("Failed to parse action list; retrying")

--- a/packages/notte-core/src/notte_core/browser/observation.py
+++ b/packages/notte-core/src/notte_core/browser/observation.py
@@ -16,6 +16,7 @@ from notte_core.actions import ActionUnion
 from notte_core.browser.highlighter import BoundingBox, ScreenshotHighlighter
 from notte_core.browser.snapshot import BrowserSnapshot, SnapshotMetadata, ViewportData
 from notte_core.common.config import ScreenshotType, config
+from notte_core.common.logging import logger
 from notte_core.data.space import DataSpace
 from notte_core.errors.base import NotteBaseError
 from notte_core.profiling import profiler
@@ -102,41 +103,36 @@ class Screenshot(BaseModel):
         if len(v) >= 2 and v[0:2] == b"\xff\xd8":
             # Valid JPEG, check if dimensions are even (required for video encoding)
             # Only use PIL if we need to pad - this is rare
-            try:
-                # Quick dimension check using JPEG header parsing (no full decode)
-                # SOF0 marker contains dimensions
-                pos = 2
-                while pos < len(v) - 9:
-                    if v[pos] != 0xFF:
+            # Quick dimension check using JPEG header parsing (no full decode).
+            # Every index is guarded by the loop bound, so malformed input
+            # falls through to Pillow without an exception-based control path.
+            pos = 2
+            while pos < len(v) - 9:
+                if v[pos] != 0xFF:
+                    break
+                marker = v[pos + 1]
+                # SOF markers (0xC0-0xCF except 0xC4, 0xC8, 0xCC)
+                if marker in (0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF):
+                    if pos + 8 >= len(v):  # Ensure we can read height and width
                         break
-                    marker = v[pos + 1]
-                    # SOF markers (0xC0-0xCF except 0xC4, 0xC8, 0xCC)
-                    if marker in (0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF):
-                        if pos + 8 >= len(v):  # Ensure we can read height and width
-                            break
-                        height = (v[pos + 5] << 8) | v[pos + 6]
-                        width = (v[pos + 7] << 8) | v[pos + 8]
-                        # If dimensions are even, return as-is (fast path)
-                        if width % 2 == 0 and height % 2 == 0:
-                            return v
-                        # Need to pad - fall through to PIL path
-                        break
-                    # Skip to next marker
-                    length = (v[pos + 2] << 8) | v[pos + 3]
-                    if length < 2:  # Invalid JPEG marker length
-                        break
-                    pos += 2 + length
-                else:
-                    # Couldn't parse dimensions, fall through to PIL for safety
-                    pass
-            except Exception:
-                # Parsing failed, fall through to PIL for safety
-                pass
+                    height = (v[pos + 5] << 8) | v[pos + 6]
+                    width = (v[pos + 7] << 8) | v[pos + 8]
+                    # If dimensions are even, return as-is (fast path)
+                    if width % 2 == 0 and height % 2 == 0:
+                        return v
+                    # Need to pad - fall through to PIL path
+                    break
+                # Skip to next marker
+                length = (v[pos + 2] << 8) | v[pos + 3]
+                if length < 2:  # Invalid JPEG marker length
+                    break
+                pos += 2 + length
 
         # Slow path: use PIL for non-JPEG or images that need padding
         try:
             img = Image.open(io.BytesIO(v))
-        except Exception:
+        except OSError:
+            logger.opt(exception=True).debug("Failed to decode screenshot data; using an empty screenshot")
             return Observation.empty().screenshot.raw
 
         orig_img = img

--- a/packages/notte-core/src/notte_core/browser/observation.py
+++ b/packages/notte-core/src/notte_core/browser/observation.py
@@ -117,8 +117,9 @@ class Screenshot(BaseModel):
                         break
                     height = (v[pos + 5] << 8) | v[pos + 6]
                     width = (v[pos + 7] << 8) | v[pos + 8]
-                    # If dimensions are even, return as-is (fast path)
-                    if width % 2 == 0 and height % 2 == 0:
+                    # If dimensions are even and the image has its end marker,
+                    # return as-is without forcing a full synchronous decode.
+                    if width % 2 == 0 and height % 2 == 0 and v.endswith(b"\xff\xd9"):
                         return v
                     # Need to pad - fall through to PIL path
                     break
@@ -131,35 +132,39 @@ class Screenshot(BaseModel):
         # Slow path: use PIL for non-JPEG or images that need padding
         try:
             img = Image.open(io.BytesIO(v))
+            # Image.open is lazy. Force decoding here so a truncated image
+            # cannot escape validation and fail later in display or replay code.
+            _ = img.load()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+            orig_img = img
+
+            # Pad to even width and height (required for video encoding)
+            width, height = img.size
+            new_width = width + (width % 2)
+            new_height = height + (height % 2)
+
+            if new_width != width or new_height != height:
+                new_img = Image.new(
+                    img.mode,
+                    (new_width, new_height),
+                    (255, 255, 255) if img.mode == "RGB" else (255, 255, 255, 255),
+                )
+                new_img.paste(img, (0, 0))
+                img = new_img
+
+            if img is orig_img and img.format == "JPEG":
+                return v
+
+            buffer = io.BytesIO()
+            # Convert to RGB if necessary (PNG with transparency needs this)
+            if img.mode in ("RGBA", "LA", "P"):
+                img = img.convert("RGB")
+
+            img.save(buffer, format="JPEG", quality=85)
+            _ = buffer.seek(0)
+            return buffer.getvalue()
         except OSError:
             logger.opt(exception=True).debug("Failed to decode screenshot data; using an empty screenshot")
             return Observation.empty().screenshot.raw
-
-        orig_img = img
-
-        # Pad to even width and height (required for video encoding)
-        width, height = img.size
-        new_width = width + (width % 2)
-        new_height = height + (height % 2)
-
-        if new_width != width or new_height != height:
-            new_img = Image.new(
-                img.mode, (new_width, new_height), (255, 255, 255) if img.mode == "RGB" else (255, 255, 255, 255)
-            )
-            new_img.paste(img, (0, 0))
-            img = new_img
-
-        if img is orig_img and img.format == "JPEG":
-            return v
-
-        buffer = io.BytesIO()
-        # Convert to RGB if necessary (PNG with transparency needs this)
-        if img.mode in ("RGBA", "LA", "P"):
-            img = img.convert("RGB")
-
-        img.save(buffer, format="JPEG", quality=85)
-        _ = buffer.seek(0)
-        return buffer.getvalue()
 
     @override
     def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:

--- a/tests/browser/test_fallback_logging.py
+++ b/tests/browser/test_fallback_logging.py
@@ -1,0 +1,64 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from notte_browser.dom.csspaths import build_csspath
+from notte_browser.form_filling import FormFiller
+from notte_browser.playwright_async_api import Error as PlaywrightError
+from notte_core.browser.observation import Screenshot
+
+
+def test_build_csspath_logs_traceback_before_using_fallback() -> None:
+    with patch("notte_browser.dom.csspaths.logger") as logger:
+        result = build_csspath(
+            tag_name="button",
+            xpath="//button",
+            attributes={"title": None},  # type: ignore[dict-item]
+            highlight_index=3,
+        )
+
+    assert result == "button[highlight_index='3']"
+    logger.opt.assert_called_once_with(exception=True)
+    logger.opt.return_value.debug.assert_called_once_with("Failed to build CSS path; using the fallback selector")
+
+
+@pytest.mark.asyncio
+async def test_select_field_uses_quiet_log_for_expected_exact_match_failure() -> None:
+    exact_match_error = PlaywrightError("No exact match")
+    field = MagicMock()
+    field.select_option = AsyncMock(side_effect=[exact_match_error, None])
+    field.evaluate = AsyncMock(return_value=[{"value": "CH", "text": "Switzerland"}])
+    filler = FormFiller(page=MagicMock())
+
+    with (
+        patch("notte_browser.form_filling.logger") as logger,
+        patch("notte_browser.form_filling.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await filler._fill_select_field(
+            field=field,
+            field_type="country",
+            value="switzerland",
+        )
+
+    assert result is True
+    assert field.select_option.await_count == 2
+    logger.opt.assert_not_called()
+    logger.debug.assert_any_call(
+        "Exact match failed for {} field; trying case-insensitive option matching: {}",
+        "country",
+        exact_match_error,
+    )
+
+
+def test_invalid_screenshot_logs_traceback_before_using_empty_screenshot() -> None:
+    with patch("notte_core.browser.observation.logger") as logger:
+        screenshot = Screenshot(raw=b"not an image")
+
+    assert screenshot.raw
+    logger.opt.assert_called_once_with(exception=True)
+    logger.opt.return_value.debug.assert_called_once_with("Failed to decode screenshot data; using an empty screenshot")
+
+
+def test_unexpected_screenshot_error_is_not_swallowed() -> None:
+    with patch("notte_core.browser.observation.Image.open", side_effect=RuntimeError("unexpected")):
+        with pytest.raises(RuntimeError, match="unexpected"):
+            Screenshot(raw=b"not an image")

--- a/tests/browser/test_fallback_logging.py
+++ b/tests/browser/test_fallback_logging.py
@@ -1,3 +1,4 @@
+import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -5,6 +6,7 @@ from notte_browser.dom.csspaths import build_csspath
 from notte_browser.form_filling import FormFiller
 from notte_browser.playwright_async_api import Error as PlaywrightError
 from notte_core.browser.observation import Screenshot
+from PIL import Image
 
 
 def test_build_csspath_logs_traceback_before_using_fallback() -> None:
@@ -54,6 +56,20 @@ def test_invalid_screenshot_logs_traceback_before_using_empty_screenshot() -> No
         screenshot = Screenshot(raw=b"not an image")
 
     assert screenshot.raw
+    logger.opt.assert_called_once_with(exception=True)
+    logger.opt.return_value.debug.assert_called_once_with("Failed to decode screenshot data; using an empty screenshot")
+
+
+def test_truncated_jpeg_logs_traceback_before_using_empty_screenshot() -> None:
+    buffer = io.BytesIO()
+    Image.new("RGB", (1024, 1024), "white").save(buffer, format="JPEG")
+    encoded = buffer.getvalue()
+    truncated = encoded[: len(encoded) // 2]
+
+    with patch("notte_core.browser.observation.logger") as logger:
+        screenshot = Screenshot(raw=truncated)
+
+    assert screenshot.raw != truncated
     logger.opt.assert_called_once_with(exception=True)
     logger.opt.return_value.debug.assert_called_once_with("Failed to decode screenshot data; using an empty screenshot")
 

--- a/tests/pipe/action/test_retry.py
+++ b/tests/pipe/action/test_retry.py
@@ -7,6 +7,7 @@ from notte_browser.tagging.type import PossibleAction, PossibleActionSpace
 from notte_core.actions import ClickAction
 from notte_core.browser.snapshot import BrowserSnapshot
 from notte_core.errors.llm import ContextSizeTooLargeError
+from notte_core.errors.provider import ContextWindowExceededError
 
 from tests.mock.mock_service import MockLLMService
 
@@ -138,6 +139,21 @@ async def test_incremental_typed_context_size_failure_skips_pointless_retries() 
 
 
 @pytest.mark.asyncio
+async def test_engine_context_window_failure_skips_pointless_retries() -> None:
+    error = ContextWindowExceededError(provider="test/model", current_size=200, max_size=100)
+    wrapper, pipe = make_wrapper(incremental_side_effect=error, max_tries=3)
+
+    with patch.object(RetryPipeWrapper, "tracer", MagicMock()):
+        result = await wrapper.forward_incremental(
+            snapshot=MagicMock(spec=BrowserSnapshot),
+            previous_action_list=previous_actions(),
+        )
+
+    assert [action.id for action in result.actions] == ["B1"]
+    assert pipe.forward_incremental.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_forward_raises_parsed_context_size_error_without_retrying() -> None:
     error = RuntimeError(
         "Please reduce the length of the messages or completions. Current length is 200 while limit is 100"
@@ -147,4 +163,16 @@ async def test_forward_raises_parsed_context_size_error_without_retrying() -> No
     with pytest.raises(ContextSizeTooLargeError, match="200.*100"):
         await wrapper.forward(snapshot=MagicMock(spec=BrowserSnapshot))
 
+    assert pipe.forward.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_forward_preserves_engine_context_window_error_without_retrying() -> None:
+    error = ContextWindowExceededError(provider="test/model", current_size=200, max_size=100)
+    wrapper, pipe = make_wrapper(forward_side_effect=error, max_tries=3)
+
+    with pytest.raises(ContextWindowExceededError) as exc_info:
+        await wrapper.forward(snapshot=MagicMock(spec=BrowserSnapshot))
+
+    assert exc_info.value is error
     assert pipe.forward.await_count == 1

--- a/tests/pipe/action/test_retry.py
+++ b/tests/pipe/action/test_retry.py
@@ -1,0 +1,150 @@
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from notte_browser.tagging.action.llm_taging.base import BaseActionListingPipe, RetryPipeWrapper
+from notte_browser.tagging.type import PossibleAction, PossibleActionSpace
+from notte_core.actions import ClickAction
+from notte_core.browser.snapshot import BrowserSnapshot
+from notte_core.errors.llm import ContextSizeTooLargeError
+
+from tests.mock.mock_service import MockLLMService
+
+
+def make_wrapper(
+    *,
+    incremental_side_effect: object | None = None,
+    forward_side_effect: object | None = None,
+    max_tries: int = 3,
+    verbose: bool = False,
+) -> tuple[RetryPipeWrapper, MagicMock]:
+    pipe = MagicMock(spec=BaseActionListingPipe)
+    pipe.llmserve = MockLLMService(mock_response="")
+    pipe.forward_incremental = AsyncMock(side_effect=incremental_side_effect)
+    pipe.forward = AsyncMock(side_effect=forward_side_effect)
+    return (
+        RetryPipeWrapper(
+            pipe=cast(BaseActionListingPipe, pipe),
+            max_tries=max_tries,
+            verbose=verbose,
+        ),
+        pipe,
+    )
+
+
+def previous_actions() -> list[ClickAction]:
+    return [
+        ClickAction(
+            id="B1",
+            description="Click the button",
+            category="Interaction Actions",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_incremental_retry_traces_recovery() -> None:
+    expected = PossibleActionSpace(
+        description="Recovered",
+        actions=[PossibleAction(id="B2", description="Click another button", category="Interaction Actions")],
+    )
+    wrapper, pipe = make_wrapper(incremental_side_effect=[ValueError("invalid response"), expected])
+    tracer = MagicMock()
+
+    with patch.object(RetryPipeWrapper, "tracer", tracer):
+        result = await wrapper.forward_incremental(
+            snapshot=MagicMock(spec=BrowserSnapshot),
+            previous_action_list=previous_actions(),
+        )
+
+    assert result is expected
+    assert pipe.forward_incremental.await_count == 2
+    tracer.trace.assert_called_once_with(
+        status="success",
+        pipe_name="BaseActionListingPipe",
+        nb_retries=1,
+        error_msgs=["invalid response"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_incremental_retry_logs_and_traces_fallback() -> None:
+    wrapper, pipe = make_wrapper(
+        incremental_side_effect=ValueError("invalid response"),
+        max_tries=2,
+        verbose=True,
+    )
+    tracer = MagicMock()
+
+    with (
+        patch.object(RetryPipeWrapper, "tracer", tracer),
+        patch("notte_browser.tagging.action.llm_taging.base.logger") as logger,
+    ):
+        result = await wrapper.forward_incremental(
+            snapshot=MagicMock(spec=BrowserSnapshot),
+            previous_action_list=previous_actions(),
+        )
+
+    assert [action.id for action in result.actions] == ["B1"]
+    assert pipe.forward_incremental.await_count == 2
+    assert logger.opt.call_count == 2
+    logger.opt.assert_called_with(exception=True)
+    assert logger.opt.return_value.debug.call_count == 2
+    tracer.trace.assert_called_once_with(
+        status="failure",
+        pipe_name="BaseActionListingPipe",
+        nb_retries=2,
+        error_msgs=["invalid response", "invalid response"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_incremental_context_size_failure_skips_pointless_retries() -> None:
+    error = RuntimeError(
+        "Please reduce the length of the messages or completions. Current length is 200 while limit is 100"
+    )
+    wrapper, pipe = make_wrapper(incremental_side_effect=error, max_tries=3)
+    tracer = MagicMock()
+
+    with patch.object(RetryPipeWrapper, "tracer", tracer):
+        result = await wrapper.forward_incremental(
+            snapshot=MagicMock(spec=BrowserSnapshot),
+            previous_action_list=previous_actions(),
+        )
+
+    assert [action.id for action in result.actions] == ["B1"]
+    assert pipe.forward_incremental.await_count == 1
+    tracer.trace.assert_called_once_with(
+        status="failure",
+        pipe_name="BaseActionListingPipe",
+        nb_retries=1,
+        error_msgs=[str(error)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_incremental_typed_context_size_failure_skips_pointless_retries() -> None:
+    error = ContextSizeTooLargeError(size=200, max_size=100)
+    wrapper, pipe = make_wrapper(incremental_side_effect=error, max_tries=3)
+
+    with patch.object(RetryPipeWrapper, "tracer", MagicMock()):
+        result = await wrapper.forward_incremental(
+            snapshot=MagicMock(spec=BrowserSnapshot),
+            previous_action_list=previous_actions(),
+        )
+
+    assert [action.id for action in result.actions] == ["B1"]
+    assert pipe.forward_incremental.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_forward_raises_parsed_context_size_error_without_retrying() -> None:
+    error = RuntimeError(
+        "Please reduce the length of the messages or completions. Current length is 200 while limit is 100"
+    )
+    wrapper, pipe = make_wrapper(forward_side_effect=error, max_tries=3)
+
+    with pytest.raises(ContextSizeTooLargeError, match="200.*100"):
+        await wrapper.forward(snapshot=MagicMock(spec=BrowserSnapshot))
+
+    assert pipe.forward.await_count == 1


### PR DESCRIPTION
## Summary

- use Loguru-native `logger.opt(exception=True)` where fallback paths need a traceback
- keep expected select-option misses at debug level without noisy stack traces, and catch only Playwright errors there
- remove exception-driven JPEG header parsing and only swallow expected Pillow decode errors
- trace incremental action-listing recoveries and exhausted retries while preserving the previous-action fallback
- stop retrying non-retryable context-size failures, including fixing the existing parsed-size path in `forward()`

## Tests

- `uv run pytest tests/pipe/action tests/browser/test_fallback_logging.py -q` — 17 passed
- focused Ruff and BasedPyright checks
- all pre-commit hooks for changed files

Supersedes #802 and #803. Thanks @dashitongzhi for identifying both observability gaps and providing the original implementations; this PR builds on that work while incorporating the Loguru and fallback-semantics fixes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787832438&installation_model_id=8247&pr_number=868&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F868&signature=995f5cd2f5d4bccdce39a4984ea174b8260d19fad25981d127b61816aff939a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved screenshot validation for fast-path JPEG parsing and narrowed failure handling to safely return an empty fallback image.
  - Form select filling now treats only expected Playwright “no exact match” errors as recoverable, continuing with case-insensitive matching.
  - CSS selector generation now falls back more safely and logs selector-construction failures with full debug context.

- **Reliability**
  - Enhanced retry behavior to detect context-length/window issues early and stop retries appropriately, preserving useful error details.

- **Tests**
  - Expanded coverage for fallback behavior and retry/diagnostic logging across screenshots, CSS paths, and select filling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->