### PR TITLE
Add orphan-model guard for SDK types

### DIFF
--- a/tests/sdk/test_no_orphan_models.py
+++ b/tests/sdk/test_no_orphan_models.py
@@ -1,0 +1,45 @@
+import inspect
+import re
+from pathlib import Path
+
+import notte_sdk
+from notte_sdk import types as types_module
+from notte_sdk.types import SdkRequest, SdkResponse
+
+SDK_SRC = Path(inspect.getfile(notte_sdk)).parent
+
+# Models intentionally defined but referenced nowhere else in the SDK.
+# Every entry needs a written reason. This dict should stay empty.
+ALLOWED_UNREFERENCED: dict[str, str] = {}
+
+
+def test_every_model_is_referenced_somewhere() -> None:
+    """Every SdkRequest/SdkResponse in types.py must be referenced outside its own class definition.
+
+    A model whose name appears exactly once in the SDK source (its `class X(...)` line)
+    is wired to nothing: no endpoint builds it, no other model embeds it. Wire it,
+    delete it, or add it to ALLOWED_UNREFERENCED with a reason.
+    """
+    models = {
+        name
+        for name, obj in vars(types_module).items()
+        if inspect.isclass(obj)
+        and issubclass(obj, (SdkRequest, SdkResponse))
+        and obj not in (SdkRequest, SdkResponse)
+        and obj.__module__ == types_module.__name__
+    }
+    code = "\n".join(p.read_text() for p in sorted(SDK_SRC.rglob("*.py")))
+    orphans = {
+        name for name in models if len(re.findall(rf"\b{name}\b", code)) <= 1 and name not in ALLOWED_UNREFERENCED
+    }
+    assert not orphans, (
+        f"Models defined in notte_sdk/types.py but referenced nowhere else in the SDK: {sorted(orphans)}. "
+        "Wire each to an endpoint, delete it, or add it to ALLOWED_UNREFERENCED with a reason."
+    )
+
+
+def test_allowlist_entries_are_still_orphans() -> None:
+    """Entries in ALLOWED_UNREFERENCED must be removed once the model gains a real reference."""
+    code = "\n".join(p.read_text() for p in sorted(SDK_SRC.rglob("*.py")))
+    stale = {name for name in ALLOWED_UNREFERENCED if len(re.findall(rf"\b{name}\b", code)) > 1}
+    assert not stale, f"Now referenced, remove from ALLOWED_UNREFERENCED: {sorted(stale)}"

--- a/tests/sdk/test_no_orphan_models.py
+++ b/tests/sdk/test_no_orphan_models.py
@@ -9,8 +9,31 @@ from notte_sdk.types import SdkRequest, SdkResponse
 SDK_SRC = Path(inspect.getfile(notte_sdk)).parent
 
 # Models intentionally defined but referenced nowhere else in the SDK.
-# Every entry needs a written reason. This dict should stay empty.
+# Every entry needs a non-empty reason. This dict should stay empty.
 ALLOWED_UNREFERENCED: dict[str, str] = {}
+
+
+def _models() -> set[str]:
+    return {
+        name
+        for name, obj in vars(types_module).items()
+        if inspect.isclass(obj)
+        and issubclass(obj, (SdkRequest, SdkResponse))
+        and obj not in (SdkRequest, SdkResponse)
+        and obj.__module__ == types_module.__name__
+    }
+
+
+def _sdk_code() -> str:
+    """SDK source with per-line comments stripped, so commented-out code never counts as a reference."""
+    lines: list[str] = []
+    for path in sorted(SDK_SRC.rglob("*.py")):
+        lines.extend(line.split("#", 1)[0] for line in path.read_text().splitlines())
+    return "\n".join(lines)
+
+
+def _reference_count(name: str, code: str) -> int:
+    return len(re.findall(rf"\b{name}\b", code))
 
 
 def test_every_model_is_referenced_somewhere() -> None:
@@ -20,26 +43,25 @@ def test_every_model_is_referenced_somewhere() -> None:
     is wired to nothing: no endpoint builds it, no other model embeds it. Wire it,
     delete it, or add it to ALLOWED_UNREFERENCED with a reason.
     """
-    models = {
-        name
-        for name, obj in vars(types_module).items()
-        if inspect.isclass(obj)
-        and issubclass(obj, (SdkRequest, SdkResponse))
-        and obj not in (SdkRequest, SdkResponse)
-        and obj.__module__ == types_module.__name__
-    }
-    code = "\n".join(p.read_text() for p in sorted(SDK_SRC.rglob("*.py")))
-    orphans = {
-        name for name in models if len(re.findall(rf"\b{name}\b", code)) <= 1 and name not in ALLOWED_UNREFERENCED
-    }
+    code = _sdk_code()
+    orphans = {name for name in _models() if _reference_count(name, code) <= 1 and name not in ALLOWED_UNREFERENCED}
     assert not orphans, (
         f"Models defined in notte_sdk/types.py but referenced nowhere else in the SDK: {sorted(orphans)}. "
         "Wire each to an endpoint, delete it, or add it to ALLOWED_UNREFERENCED with a reason."
     )
 
 
-def test_allowlist_entries_are_still_orphans() -> None:
-    """Entries in ALLOWED_UNREFERENCED must be removed once the model gains a real reference."""
-    code = "\n".join(p.read_text() for p in sorted(SDK_SRC.rglob("*.py")))
-    stale = {name for name in ALLOWED_UNREFERENCED if len(re.findall(rf"\b{name}\b", code)) > 1}
+def test_allowlist_is_valid_and_not_stale() -> None:
+    """ALLOWED_UNREFERENCED entries must name existing models, carry a reason, and still be orphans."""
+    models = _models()
+    unknown = set(ALLOWED_UNREFERENCED) - models
+    assert not unknown, (
+        f"Not models in types.py (deleted or renamed?), remove from ALLOWED_UNREFERENCED: {sorted(unknown)}"
+    )
+
+    missing_reason = {name for name, reason in ALLOWED_UNREFERENCED.items() if not reason.strip()}
+    assert not missing_reason, f"Empty reasons in ALLOWED_UNREFERENCED: {sorted(missing_reason)}"
+
+    code = _sdk_code()
+    stale = {name for name in ALLOWED_UNREFERENCED if _reference_count(name, code) > 1}
     assert not stale, f"Now referenced, remove from ALLOWED_UNREFERENCED: {sorted(stale)}"


### PR DESCRIPTION
Adds a static test asserting every `SdkRequest`/`SdkResponse` model in `notte_sdk/types.py` is referenced somewhere else in the SDK (an endpoint builder or another model). A model whose name appears only on its own `class` line is wired to nothing.

- Would have flagged `SessionStatusRequest` and `DownloadsListRequest` (removed in #867) the day they were introduced
- Pure source introspection: no network, no mocks, runs in ~1s inside the existing `pytest tests` job
- `ALLOWED_UNREFERENCED` requires a written reason per entry and starts empty; a companion test fails if an entry becomes referenced, so the allowlist cannot rot

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787898703&installation_model_id=8247&pr_number=871&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F871&signature=b0c78ffaf576b93dd19e535cc00f4d4142c359a10b56a832563a1b7d6eb8c7dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated checks to ensure SDK request and response models are referenced throughout the SDK.
  * Added validation to keep approved exceptions up to date and prevent unnecessary orphaned models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->