### PR TITLE
feat(storage): download uploaded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ with client.Session(proxies=[proxy_settings]) as session:
 
 ## File download / upload
 
-File Storage allows you to upload files to a session and download files that agents retrieve during their work. Files are session-scoped and persist beyond the session lifecycle.
+File Storage allows you to upload files for your agents and download files that agents retrieve during their work.
+Uploaded files are user-scoped, while files downloaded by an agent are session-scoped.
 
 ```python
 from notte_sdk import NotteClient
@@ -200,6 +201,12 @@ storage = client.FileStorage()
 
 # Upload files before agent execution
 storage.upload("/path/to/document.pdf")
+
+# Download a user-uploaded file without starting a session
+storage.download_uploaded_file(
+    file_name="document.pdf",
+    local_dir="./inputs",
+)
 
 # Create session with storage attached
 with client.Session(storage=storage) as session:

--- a/docs/src/sdk-reference/misc/remotefilestorage.mdx
+++ b/docs/src/sdk-reference/misc/remotefilestorage.mdx
@@ -49,6 +49,20 @@ Stores a file that has been downloaded from a website in the current session
 
 ---
 
+### download_uploaded_file
+
+```python
+download_uploaded_file(file_name: str, local_dir: str, force: bool = False) -> bool
+```
+
+Downloads a user-uploaded file to the local filesystem
+
+**Returns:**
+
+`bool`
+
+---
+
 ### get_file
 
 ```python

--- a/docs/src/sdk-reference/misc/remotefilestorage.mdx
+++ b/docs/src/sdk-reference/misc/remotefilestorage.mdx
@@ -57,6 +57,12 @@ download_uploaded_file(file_name: str, local_dir: str, force: bool = False) -> b
 
 Downloads a user-uploaded file to the local filesystem
 
+**Parameters:**
+
+- `file_name`: The name of the uploaded file to download.
+- `local_dir`: The directory to download the file to.
+- `force`: Overwrite an existing destination file. Defaults to ``False``; set ``True`` to replace it.
+
 **Returns:**
 
 `bool`

--- a/docs/src/sdk-reference/misc/remotefilestorage.mdx
+++ b/docs/src/sdk-reference/misc/remotefilestorage.mdx
@@ -55,7 +55,7 @@ Stores a file that has been downloaded from a website in the current session
 download_uploaded_file(file_name: str, local_dir: str, force: bool = False) -> bool
 ```
 
-Downloads a user-uploaded file to the local filesystem
+Downloads a user-uploaded file to the local filesystem without requiring a session attachment
 
 **Parameters:**
 

--- a/docs/src/sdk-reference/remotefilestorage/download_uploaded_file.mdx
+++ b/docs/src/sdk-reference/remotefilestorage/download_uploaded_file.mdx
@@ -1,11 +1,9 @@
 ---
 title: "download_uploaded_file"
-description: "Downloads a user-uploaded file to the local filesystem"
+description: "Downloads a user-uploaded file to the local filesystem without requiring a session attachment"
 ---
 
 
-
-This does not require the storage object to be attached to a session.
 
 ```python
 storage = notte.FileStorage()

--- a/docs/src/sdk-reference/remotefilestorage/download_uploaded_file.mdx
+++ b/docs/src/sdk-reference/remotefilestorage/download_uploaded_file.mdx
@@ -1,0 +1,30 @@
+---
+title: "download_uploaded_file"
+description: "Downloads a user-uploaded file to the local filesystem"
+---
+
+
+
+This does not require the storage object to be attached to a session.
+
+```python
+storage = notte.FileStorage()
+storage.upload(file_path="<local_file_path>")
+storage.download_uploaded_file(file_name="<uploaded_file_name>", local_dir="<local_download_dir>")
+```
+
+
+## Parameters
+
+<ParamField path="file_name" type="str" required>
+</ParamField>
+
+<ParamField path="local_dir" type="str" required>
+</ParamField>
+
+<ParamField path="force" type="bool" default="False">
+</ParamField>
+
+## Returns
+
+`bool`

--- a/docs/src/sdk-reference/remotefilestorage/download_uploaded_file.mdx
+++ b/docs/src/sdk-reference/remotefilestorage/download_uploaded_file.mdx
@@ -14,15 +14,19 @@ storage.download_uploaded_file(file_name="<uploaded_file_name>", local_dir="<loc
 ```
 
 
+
 ## Parameters
 
 <ParamField path="file_name" type="str" required>
+  The name of the uploaded file to download.
 </ParamField>
 
 <ParamField path="local_dir" type="str" required>
+  The directory to download the file to.
 </ParamField>
 
 <ParamField path="force" type="bool" default="False">
+  Overwrite an existing destination file. Defaults to ``False``; set ``True`` to replace it.
 </ParamField>
 
 ## Returns

--- a/docs/src/sdk-reference/remotefilestorage/index.mdx
+++ b/docs/src/sdk-reference/remotefilestorage/index.mdx
@@ -84,6 +84,24 @@ Base class for storage implementations that handle upload and download file stor
   </Visibility>
   <Visibility for="humans">
     <Card
+      title="download_uploaded_file"
+      icon="function"
+      href="/sdk-reference/remotefilestorage/download_uploaded_file"
+    >
+      Downloads a user-uploaded file to the local filesystem
+    </Card>
+  </Visibility>
+  <Visibility for="agents">
+    <Card
+      title="download_uploaded_file"
+      icon="function"
+      href="/sdk-reference/remotefilestorage/download_uploaded_file.md"
+    >
+      Downloads a user-uploaded file to the local filesystem
+    </Card>
+  </Visibility>
+  <Visibility for="humans">
+    <Card
       title="get_file"
       icon="function"
       href="/sdk-reference/remotefilestorage/get_file"

--- a/docs/src/sdk-reference/remotefilestorage/index.mdx
+++ b/docs/src/sdk-reference/remotefilestorage/index.mdx
@@ -88,7 +88,7 @@ Base class for storage implementations that handle upload and download file stor
       icon="function"
       href="/sdk-reference/remotefilestorage/download_uploaded_file"
     >
-      Downloads a user-uploaded file to the local filesystem
+      Downloads a user-uploaded file to the local filesystem without requiring a session attachment
     </Card>
   </Visibility>
   <Visibility for="agents">
@@ -97,7 +97,7 @@ Base class for storage implementations that handle upload and download file stor
       icon="function"
       href="/sdk-reference/remotefilestorage/download_uploaded_file.md"
     >
-      Downloads a user-uploaded file to the local filesystem
+      Downloads a user-uploaded file to the local filesystem without requiring a session attachment
     </Card>
   </Visibility>
   <Visibility for="humans">

--- a/packages/notte-sdk/src/notte_sdk/endpoints/files.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/files.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING
 
 from notte_core.common.cache import CacheDirectory, ensure_cache_directory
@@ -139,6 +139,9 @@ class FileStorageClient(BaseClient):
         endpoint: NotteEndpoint[FileLinkResponse],
         force: bool = False,
     ) -> bool:
+        if Path(file_name).name != file_name or PureWindowsPath(file_name).name != file_name:
+            raise ValueError("file_name must be a filename, not a path")
+
         local_dir_path = Path(local_dir)
         if not local_dir_path.exists():
             local_dir_path.mkdir(parents=True, exist_ok=True)
@@ -279,6 +282,11 @@ class RemoteFileStorage(BaseStorage):
         storage.upload(file_path="<local_file_path>")
         storage.download_uploaded_file(file_name="<uploaded_file_name>", local_dir="<local_download_dir>")
         ```
+
+        Args:
+            file_name: The name of the uploaded file to download.
+            local_dir: The directory to download the file to.
+            force: Overwrite an existing destination file. Defaults to ``False``; set ``True`` to replace it.
         """
         return self.client.download_uploaded_file(file_name=file_name, local_dir=local_dir, force=force)
 

--- a/packages/notte-sdk/src/notte_sdk/endpoints/files.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/files.py
@@ -273,9 +273,7 @@ class RemoteFileStorage(BaseStorage):
 
     def download_uploaded_file(self, file_name: str, local_dir: str, force: bool = False) -> bool:
         """
-        Downloads a user-uploaded file to the local filesystem.
-
-        This does not require the storage object to be attached to a session.
+        Downloads a user-uploaded file to the local filesystem without requiring a session attachment.
 
         ```python
         storage = notte.FileStorage()

--- a/packages/notte-sdk/src/notte_sdk/endpoints/files.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/files.py
@@ -43,6 +43,7 @@ class FileStorageClient(BaseClient):
 
     STORAGE_UPLOAD = "uploads/{file_name}"
     STORAGE_UPLOAD_LIST = "uploads"
+    STORAGE_UPLOADED_FILE_DOWNLOAD = "uploads/{file_name}"
     STORAGE_DOWNLOAD = "{session_id}/downloads/{file_name}"
     STORAGE_UPLOAD_DOWNLOADED_FILE = "{session_id}/downloads/{file_name}"
     STORAGE_DOWNLOAD_LIST = "{session_id}/downloads"
@@ -81,6 +82,14 @@ class FileStorageClient(BaseClient):
         """
         path = FileStorageClient.STORAGE_UPLOAD_LIST
         return NotteEndpoint(path=path, response=ListFilesResponse, method="GET")
+
+    @staticmethod
+    def _storage_uploaded_file_download_endpoint(file_name: str) -> NotteEndpoint[FileLinkResponse]:
+        """
+        Returns a NotteEndpoint for getting a user-uploaded file link.
+        """
+        path = FileStorageClient.STORAGE_UPLOADED_FILE_DOWNLOAD.format(file_name=file_name)
+        return NotteEndpoint(path=path, response=FileLinkResponse, method="GET")
 
     @staticmethod
     def _storage_download_endpoint(
@@ -122,6 +131,26 @@ class FileStorageClient(BaseClient):
                 f"Cannot upload file {file_path} because it does not exist in the local file system."
             )
         return self.request(endpoint.with_file(file_path))
+
+    def _download_file(
+        self,
+        file_name: str,
+        local_dir: str,
+        endpoint: NotteEndpoint[FileLinkResponse],
+        force: bool = False,
+    ) -> bool:
+        local_dir_path = Path(local_dir)
+        if not local_dir_path.exists():
+            local_dir_path.mkdir(parents=True, exist_ok=True)
+
+        file_path = local_dir_path / file_name
+
+        if file_path.exists() and not force:
+            raise ValueError(f"A file with name '{file_name}' is already at the path! Use force=True to overwrite.")
+
+        _ = DownloadFileRequest.model_validate({"filename": file_name})
+        resp: FileLinkResponse = self.request(endpoint)
+        return self.request_download(resp.url, str(file_path))
 
     @track_usage("cloud.files.upload")
     def upload(self, file_path: str, upload_file_name: str | None = None) -> FileUploadResponse:
@@ -166,19 +195,24 @@ class FileStorageClient(BaseClient):
             True if the file was downloaded successfully, False otherwise.
         """
 
-        local_dir_path = Path(local_dir)
-        if not local_dir_path.exists():
-            local_dir_path.mkdir(parents=True, exist_ok=True)
-
-        file_path = local_dir_path / file_name
-
-        if file_path.exists() and not force:
-            raise ValueError(f"A file with name '{file_name}' is already at the path! Use force=True to overwrite.")
-
         endpoint = self._storage_download_endpoint(session_id=session_id, file_name=file_name)
-        _ = DownloadFileRequest.model_validate({"filename": file_name})
-        resp: FileLinkResponse = self.request(endpoint)
-        return self.request_download(resp.url, str(file_path))
+        return self._download_file(file_name=file_name, local_dir=local_dir, endpoint=endpoint, force=force)
+
+    @track_usage("cloud.files.download_uploaded_file")
+    def download_uploaded_file(self, file_name: str, local_dir: str, force: bool = False) -> bool:
+        """
+        Downloads a user-uploaded file from storage.
+
+        Args:
+            file_name: The name of the uploaded file to download.
+            local_dir: The directory to download the file to.
+            force: Whether to overwrite the file if it already exists.
+
+        Returns:
+            True if the file was downloaded successfully, False otherwise.
+        """
+        endpoint = self._storage_uploaded_file_download_endpoint(file_name=file_name)
+        return self._download_file(file_name=file_name, local_dir=local_dir, endpoint=endpoint, force=force)
 
     def list_uploaded_files(self) -> list[FileInfo]:
         """
@@ -233,6 +267,20 @@ class RemoteFileStorage(BaseStorage):
 
         """
         return self.client.download(session_id=self.session_id, file_name=file_name, local_dir=local_dir, force=force)
+
+    def download_uploaded_file(self, file_name: str, local_dir: str, force: bool = False) -> bool:
+        """
+        Downloads a user-uploaded file to the local filesystem.
+
+        This does not require the storage object to be attached to a session.
+
+        ```python
+        storage = notte.FileStorage()
+        storage.upload(file_path="<local_file_path>")
+        storage.download_uploaded_file(file_name="<uploaded_file_name>", local_dir="<local_download_dir>")
+        ```
+        """
+        return self.client.download_uploaded_file(file_name=file_name, local_dir=local_dir, force=force)
 
     def upload(self, file_path: str, upload_file_name: str | None = None) -> bool:
         """

--- a/tests/sdk/test_file_storage.py
+++ b/tests/sdk/test_file_storage.py
@@ -53,6 +53,35 @@ def test_download_uploaded_file_refuses_to_overwrite(files_client: FileStorageCl
     request.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        "../outside.txt",
+        "/tmp/outside.txt",
+        r"..\outside.txt",
+        r"C:\tmp\outside.txt",
+    ],
+)
+def test_download_uploaded_file_rejects_paths(
+    files_client: FileStorageClient,
+    tmp_path: Path,
+    file_name: str,
+) -> None:
+    with (
+        patch.object(files_client, "request") as request,
+        patch.object(files_client, "request_download") as request_download,
+        pytest.raises(ValueError, match="filename, not a path"),
+    ):
+        files_client.download_uploaded_file(
+            file_name=file_name,
+            local_dir=str(tmp_path),
+            force=True,
+        )
+
+    request.assert_not_called()
+    request_download.assert_not_called()
+
+
 def test_remote_storage_downloads_uploaded_file_without_session(tmp_path: Path) -> None:
     client = Mock(spec=FileStorageClient)
     client.download_uploaded_file.return_value = True

--- a/tests/sdk/test_file_storage.py
+++ b/tests/sdk/test_file_storage.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from notte_sdk.endpoints.files import FileStorageClient, RemoteFileStorage
+from notte_sdk.types import FileLinkResponse
+
+
+@pytest.fixture
+def files_client() -> FileStorageClient:
+    with patch.object(FileStorageClient, "check_and_warn_version_mismatch"):
+        return FileStorageClient(
+            root_client=Mock(),
+            api_key="test-api-key",  # pragma: allowlist secret
+            server_url="https://api.notte.test",
+        )
+
+
+def test_uploaded_file_download_endpoint() -> None:
+    endpoint = FileStorageClient._storage_uploaded_file_download_endpoint("input.txt")
+
+    assert endpoint.path == "uploads/input.txt"
+    assert endpoint.method == "GET"
+    assert endpoint.response is FileLinkResponse
+
+
+def test_download_uploaded_file(files_client: FileStorageClient, tmp_path: Path) -> None:
+    response = FileLinkResponse(url="https://storage.notte.test/input.txt")
+
+    with (
+        patch.object(files_client, "request", return_value=response) as request,
+        patch.object(files_client, "request_download", return_value=True) as request_download,
+    ):
+        result = files_client.download_uploaded_file(file_name="input.txt", local_dir=str(tmp_path))
+
+    assert result is True
+    endpoint = request.call_args.args[0]
+    assert endpoint.path == "uploads/input.txt"
+    assert endpoint.method == "GET"
+    request_download.assert_called_once_with(response.url, str(tmp_path / "input.txt"))
+
+
+def test_download_uploaded_file_refuses_to_overwrite(files_client: FileStorageClient, tmp_path: Path) -> None:
+    file_path = tmp_path / "input.txt"
+    _ = file_path.write_text("existing")
+
+    with (
+        patch.object(files_client, "request") as request,
+        pytest.raises(ValueError, match="force=True"),
+    ):
+        files_client.download_uploaded_file(file_name=file_path.name, local_dir=str(tmp_path))
+
+    request.assert_not_called()
+
+
+def test_remote_storage_downloads_uploaded_file_without_session(tmp_path: Path) -> None:
+    client = Mock(spec=FileStorageClient)
+    client.download_uploaded_file.return_value = True
+    storage = RemoteFileStorage(_client=client)
+
+    result = storage.download_uploaded_file(file_name="input.txt", local_dir=str(tmp_path), force=True)
+
+    assert result is True
+    client.download_uploaded_file.assert_called_once_with(
+        file_name="input.txt",
+        local_dir=str(tmp_path),
+        force=True,
+    )

--- a/tests/sdk/test_file_storage.py
+++ b/tests/sdk/test_file_storage.py
@@ -57,7 +57,7 @@ def test_download_uploaded_file_refuses_to_overwrite(files_client: FileStorageCl
     "file_name",
     [
         "../outside.txt",
-        "/tmp/outside.txt",
+        "/absolute/outside.txt",
         r"..\outside.txt",
         r"C:\tmp\outside.txt",
     ],


### PR DESCRIPTION
## Summary

- add `FileStorageClient.download_uploaded_file(...)` for user-uploaded files
- expose the operation as `storage.download_uploaded_file(...)` without requiring a session
- preserve overwrite protection and reuse the existing streamed-download path
- add SDK reference docs, README usage, and focused unit coverage

## Companion PRs

- Backend: https://github.com/nottelabs/monorepo/pull/1946
- CLI: https://github.com/nottelabs/notte-cli/pull/54

## Validation

- focused unit coverage: 4 passed (run earlier)
- commit hooks: Ruff, formatting, basedpyright, secrets, docs generation, and documentation checks passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787919351&installation_model_id=8247&pr_number=873&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F873&signature=6224fa92d259b559b57e1d0f4cbd5d44da6def806190d62e53139fd6c11e8756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `download_uploaded_file(file_name, local_dir, force=False)` to download user-uploaded files to a local directory without requiring a session.
  * Added `force` option to control whether an existing local file can be overwritten.
  * Added validation to reject unsafe/path-like `file_name` inputs.
* **Documentation**
  * Updated file upload/download scoping guidance: uploads are user-scoped; downloads are session-scoped.
  * Added SDK reference pages and a usage example for downloading uploaded files without starting a session.
* **Tests**
  * Added SDK and wrapper coverage for the uploaded-file download flow, overwrite protection, filename validation, and session-free usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->