### PR TITLE
Fix Integrations tab navigation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,12 @@ repos:
         language: system
         files: ^docs/src/(docs\.json|.*\.mdx|scripts/apply_agent_md_notice\.py|partials/agent-md-notice\.mdx)$
         pass_filenames: false
+      - id: docs-nav-conflicts
+        name: Check docs navigation for link/page conflicts
+        entry: bash -c "cd docs/src && uv run python scripts/check_docs_nav.py"
+        language: system
+        files: ^docs/src/(docs\.json|scripts/check_docs_nav\.py)$
+        pass_filenames: false
       - id: docs-quickstart-setup-prompt
         name: Inline Quickstart setup prompt
         entry: bash -c "cd docs/src && uv run python scripts/inline_quickstart_setup_prompt.py --check"

--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -150,7 +150,6 @@
           },
           {
             "tab": "Integrations",
-            "href": "/integrations",
             "groups": [
               {
                 "group": "Integrations",

--- a/docs/src/scripts/check_docs_nav.py
+++ b/docs/src/scripts/check_docs_nav.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Check `docs.json` navigation entries for conflicting link and child fields.
+
+A navigation entry is either a link (`href`) or a container of nested pages
+(`groups`, `pages`, `menu`, `anchors`, `tabs`, `dropdowns`, `versions`,
+`languages`). Mintlify treats those as mutually exclusive: when an entry
+declares both, the build keeps the link and silently drops every nested page,
+so the entry becomes a dead link and its pages lose their sidebar.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SRC_DIR = Path(__file__).resolve().parent.parent
+DOCS_JSON = SRC_DIR / "docs.json"
+CHILD_FIELDS = (
+    "anchors",
+    "dropdowns",
+    "groups",
+    "languages",
+    "menu",
+    "pages",
+    "tabs",
+    "versions",
+)
+LABEL_FIELDS = ("tab", "group", "anchor", "dropdown", "language", "version")
+
+
+def label(entry: dict[str, Any]) -> str:
+    for field in LABEL_FIELDS:
+        value = entry.get(field)
+        if isinstance(value, str):
+            return f"{field} '{value}'"
+    return "navigation entry"
+
+
+def check(node: Any, path: str, errors: list[str]) -> None:
+    if isinstance(node, list):
+        for index, item in enumerate(node):
+            check(item, f"{path}[{index}]", errors)
+        return
+    if not isinstance(node, dict):
+        return
+
+    children = [field for field in CHILD_FIELDS if field in node]
+    if "href" in node and children:
+        errors.append(
+            f"{path}: {label(node)} declares both 'href' and {', '.join(repr(c) for c in children)}. "
+            "Drop 'href' so the nested pages survive the build."
+        )
+
+    for key, value in node.items():
+        check(value, f"{path}.{key}", errors)
+
+
+def main() -> int:
+    navigation = json.loads(DOCS_JSON.read_text())["navigation"]
+    errors: list[str] = []
+    check(navigation, "navigation", errors)
+    for error in errors:
+        print(f"docs.json: {error}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The Integrations tab defined both `href` and `groups` in `docs.json`. Those are mutually exclusive, so the build kept only the `href` and dropped every page under the tab: the tab rendered as a link to `/` and the Integrations pages lost their sidebar.

Removing `href` restores the tab, which now resolves to its first page (`/integrations`).

## Validation
- docs.json JSON parse
- local `mint dev`: Integrations tab links to /integrations, landing page and sidebar render

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787926490&installation_model_id=8247&pr_number=874&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F874&signature=8b42e3bbc457e08f8d6c78a0276f27b6c009617051c5ae8214e4e1ace41fe989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Integrations tab navigation to remove its direct link while preserving its label and grouped content.
* **Chores**
  * Added a local documentation navigation validation step to detect conflicting navigation entries during pre-commit checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->