### PR TITLE
docs: refresh generated documentation

### DIFF
--- a/docs/src/integrations/index.mdx
+++ b/docs/src/integrations/index.mdx
@@ -2,6 +2,9 @@
 title: Integrations
 description: Connect Notte to the tools your team already uses.
 ---
+import AgentMdNotice from '/partials/agent-md-notice.mdx';
+
+<AgentMdNotice />
 
 Connect Notte to your AI agents, browser automation stack, and developer tools.
 

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -79,7 +79,7 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 
 - [Introduction](https://docs.notte.cc/index.md)
 - [Quickstart](https://docs.notte.cc/quickstart.md): Get started in a few seconds
-- [Concepts](https://docs.notte.cc/concepts.md): Core concepts in the Notte platform
+- [MCP Server](https://docs.notte.cc/mcp-server.md): Give your AI agents access to the Notte MCP server
 
 ## Sessions
 
@@ -152,11 +152,14 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 - [Anti-Detection Playbook](https://docs.notte.cc/guides/stealth.md): How to avoid CAPTCHAs and bot detection in Notte Sessions
 - [Create accounts with Personas](https://docs.notte.cc/guides/account_creation.md): How to use notte personas for account creation
 
+
+# Integrations
+
 ## Integrations
 
+- [Integrations](https://docs.notte.cc/integrations/index.md): Connect Notte to the tools your team already uses.
+- [MCP Server](https://docs.notte.cc/mcp-server.md): Give your AI agents access to the Notte MCP server
 - [Claude Code & AI Agents](https://docs.notte.cc/integrations/claude-code-ai-agents.md): Use Notte with AI coding assistants like Claude Code, Cursor, and Windsurf
-
-- [MCP Server](https://docs.notte.cc/mcp-server.md): Give your AI assistant a hosted browser with Notte MCP
 - [Kernel.sh](https://docs.notte.cc/integrations/kernel.md): Integrate with Kernel browsers
 - [Steel](https://docs.notte.cc/integrations/steel.md): Run Notte with Steel cloud browsers (CDP)
 - [Massive](https://docs.notte.cc/integrations/massive.md): Use Massive residential proxies with Notte sessions
@@ -433,7 +436,6 @@ The SDK docs below are for generated-code editing and reference. They are not th
 ## Resources
 
 - [Resources](https://docs.notte.cc/resources.md): Quick links to pricing, rate limits, and AI coding setup
-- [MCP Server](https://docs.notte.cc/mcp-server.md): Give your AI assistant a hosted browser with Notte MCP
 
 ## Legal
 


### PR DESCRIPTION
## Summary

- refresh `llms.txt` from the current documentation navigation and production OpenAPI schema
- add the generated agent Markdown notice to the integrations landing page

## Validation

- `make docs-check`
- docs snippet suite: 439 passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787989776&installation_model_id=8247&pr_number=875&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F875&signature=f3a830716e52f875393913596cf9f4f164f0a672aa8f271ecaa2869a0652babe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an informational notice to the Integrations documentation.
  * Reorganized MCP Server and AI agent links across the documentation navigation.
  * Updated the MCP Server description and removed a duplicate navigation entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->