### PR TITLE
[NOT-699] docs: add migrate to Notte guide

### DIFF
--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -45,7 +45,8 @@
                   "index",
                   "quickstart",
                   "templates",
-                  "mcp-server"
+                  "mcp-server",
+                  "migrate-to-notte"
                 ]
               },
               {

--- a/docs/src/migrate-to-notte.mdx
+++ b/docs/src/migrate-to-notte.mdx
@@ -1,0 +1,61 @@
+---
+title: Migrate to Notte
+description: Safely migrate browser automation from another provider to Notte with an AI coding agent.
+---
+
+Use the Notte migration skills to move an existing browser-automation codebase
+to Notte with a visible plan, measured baseline, safe proof, tests, and a
+reversible rollout.
+
+## Install the skills
+
+```bash
+npx skills add nottelabs/notte-skills -y -g
+```
+
+The skills support migrations from Browserbase + Stagehand, Kernel, Anchor
+Browser, Browser Use Cloud, Steel, Hyperbrowser, and Skyvern.
+
+## Give this prompt to your AI coding agent
+
+Copy the prompt below into Codex, Claude Code, Cursor, or another supported
+coding agent from the root of the repository you want to migrate.
+
+```text
+Use $migrate-to-notte to assess and migrate this codebase to Notte.
+
+Start by publishing a clear, user-visible phase plan. Complete the Notte
+Quickstart before inspecting the repository. Detect the current browser
+provider, inventory every workflow and dependency, measure the current cost and
+latency where data is available, and run a safe read-only Notte proof.
+
+Build the replacement progressively in an isolated area, add tests, run static
+analysis and the full relevant test suite, and preserve public contracts. Keep
+every change reversible. Do not touch production resources, credentials,
+billing, or deploy to production without my explicit approval.
+```
+
+The skill routes the agent to the right provider-specific migration reference
+and keeps progress visible throughout the work.
+
+## Build a cost case first
+
+Use the read-only cost-comparison companion when you want a migration business
+case before implementation:
+
+```text
+Use $compare-to-notte-costs to scan this codebase and estimate the current
+browser-automation provider's cost against an equivalent Notte workload.
+
+Use current official pricing and my invoice or telemetry when available. Show
+monthly and annual low/base/high scenarios, required concurrency, assumptions,
+and excluded costs. Keep Browser Arena results separate as external benchmark
+context; do not treat them as a forecast of this application's performance.
+```
+
+## Skill source
+
+- [Migration skill](https://github.com/nottelabs/notte-skills/tree/main/plugins/notte-cli/skills/migrate-to-notte)
+- [Cost-comparison skill](https://github.com/nottelabs/notte-skills/tree/main/plugins/notte-cli/skills/compare-to-notte-costs)
+
+Need help with a migration? Join the [Notte community Slack](https://join.slack.com/t/nottelabs-dev/shared_invite/zt-39a8n6hr9-d_BG7RNfytimSpVo5H03mA).


### PR DESCRIPTION
## Summary
- add a Documentation-tab page, immediately after MCP Server, for AI-assisted migration to Notte
- provide a copyable migration prompt and a read-only cost-comparison prompt
- link the provider-agnostic skills and Notte community Slack

## Validation
- `mintlify broken-links` — passed
- `git diff --check` — passed
- staged secret-pattern scan — no sensitive values found

## Dependency
This page links to the skills introduced in nottelabs/notte-skills#20. Merge that PR before, or alongside, this one so the linked skill paths are available on `main`.

Linear: NOT-699 https://linear.app/nottelabsinc/issue/NOT-699/notte-pr-876-docs-add-migrate-to-notte-guide

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787992489&installation_model_id=8247&pr_number=876&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F876&signature=a75e31dc1c102c678c702dc6bb4176699ed4650f14be8db3bf36ec392fd4873c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Migrate to Notte” guide under Getting Started.
  * Included step-by-step migration guidance, an AI coding-agent prompt, validation requirements, and links to related resources.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->