### PR TITLE
[NOT-811] Select a database branch with NOTTE_DB_PREVIEW_BRANCH

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
@@ -349,6 +349,7 @@ class AgentsClient(BaseClient):
         endpoint = NotteEndpoint(path=AgentsClient.AGENT_LOGS_WS, response=BaseModel, method="GET")
         wss_url = self.request_path(endpoint).format(agent_id=agent_id, token=self.token, session_id=session_id)
         wss_url = wss_url.replace("https://", "wss://").replace("http://", "ws://")
+        wss_url = self._with_db_preview(wss_url)
 
         counter = [0]  # mutable container for step count
 
@@ -471,6 +472,7 @@ class AgentsClient(BaseClient):
         endpoint = NotteEndpoint(path=AgentsClient.AGENT_LOGS_WS, response=BaseModel, method="GET")
         wss_url = self.request_path(endpoint).format(agent_id=agent_id, token=self.token, session_id=session_id)
         wss_url = wss_url.replace("https://", "wss://").replace("http://", "ws://")
+        wss_url = self._with_db_preview(wss_url)
 
         counter = [0]  # mutable container for step count
 

--- a/packages/notte-sdk/src/notte_sdk/endpoints/base.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/base.py
@@ -5,7 +5,7 @@ from abc import ABC
 from collections.abc import Sequence
 from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, Self, TypeVar
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin
 
 import requests
 from notte_core import __version__ as notte_core_version
@@ -85,6 +85,10 @@ class BaseClient(ABC):
     HEALTH_CHECK_ENDPOINT: ClassVar[str] = "health"
     REQUEST_ORIGIN: ClassVar[str] = "sdk-python"
 
+    # Set per instance in __init__. Declared here with a default so clients
+    # built without running __init__ still resolve it.
+    db_preview: str | None = None
+
     def __init__(
         self,
         root_client: "NotteClient",
@@ -118,6 +122,7 @@ class BaseClient(ABC):
         self.server_url: str = server_url or os.getenv("NOTTE_API_URL") or self.DEFAULT_NOTTE_API_URL
         self.base_endpoint_path: str | None = base_endpoint_path
         self.verbose: bool = verbose
+        self.db_preview = (os.getenv("NOTTE_DB_PREVIEW") or "").strip() or None
 
         # Check for version mismatch and warn user if needed
         self.check_and_warn_version_mismatch()
@@ -311,12 +316,30 @@ class BaseClient(ABC):
         which is formatted as a Bearer token using the API key stored in self.token.
         Also includes headers to identify the request as coming from the SDK.
         """
+        # Internal: when NOTTE_DB_PREVIEW names a branch, forward it so the API
+        # serves the request from that branch's database. Only meaningful
+        # against our own non-production deployments, which is why it is not
+        # part of the documented interface.
+        preview = {"x-db-preview": self.db_preview} if self.db_preview else {}
         return {
             "Authorization": f"Bearer {self.token}",
             "x-notte-sdk-version": notte_core_version,
             "x-notte-request-origin": self.REQUEST_ORIGIN,
+            **preview,
             **(headers or {}),
         }
+
+    def _with_db_preview(self, url: str) -> str:
+        """Add the preview-branch selector to a websocket URL.
+
+        A WebSocket handshake carries no request headers when it is opened from
+        a browser, so the branch travels in the query string instead. Returns
+        the URL unchanged when no branch is configured.
+        """
+        if not self.db_preview:
+            return url
+        separator = "&" if "?" in url else "?"
+        return f"{url}{separator}db_preview={quote(self.db_preview, safe='')}"
 
     def request_path(self, endpoint: NotteEndpoint[TResponse]) -> str:
         """

--- a/packages/notte-sdk/src/notte_sdk/endpoints/base.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/base.py
@@ -122,7 +122,7 @@ class BaseClient(ABC):
         self.server_url: str = server_url or os.getenv("NOTTE_API_URL") or self.DEFAULT_NOTTE_API_URL
         self.base_endpoint_path: str | None = base_endpoint_path
         self.verbose: bool = verbose
-        self.db_preview = (os.getenv("NOTTE_DB_PREVIEW") or "").strip() or None
+        self.db_preview = (os.getenv("NOTTE_DB_PREVIEW_BRANCH") or "").strip() or None
 
         # Check for version mismatch and warn user if needed
         self.check_and_warn_version_mismatch()
@@ -316,8 +316,8 @@ class BaseClient(ABC):
         which is formatted as a Bearer token using the API key stored in self.token.
         Also includes headers to identify the request as coming from the SDK.
         """
-        # Internal: when NOTTE_DB_PREVIEW names a branch, forward it so the API
-        # serves the request from that branch's database. Only meaningful
+        # Internal: when NOTTE_DB_PREVIEW_BRANCH names a branch, forward it so the
+        # API serves the request from that branch's database. Only meaningful
         # against our own non-production deployments, which is why it is not
         # part of the documented interface.
         preview = {"x-db-preview": self.db_preview} if self.db_preview else {}
@@ -335,6 +335,10 @@ class BaseClient(ABC):
         A WebSocket handshake carries no request headers when it is opened from
         a browser, so the branch travels in the query string instead. Returns
         the URL unchanged when no branch is configured.
+
+        Only pass urls served by this API. A session can be backed by a
+        third-party browser provider, and handing that provider an internal
+        branch name is both meaningless to it and more than it needs to know.
         """
         if not self.db_preview:
             return url

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -538,7 +538,9 @@ class SessionsClient(BaseClient):
         Returns a WebsocketJupyterDisplay for displaying live session replay in Jupyter notebook.
         """
         debug_info = self.debug_info(session_id=session_id)
-        return WebsocketService(wss_url=debug_info.ws.recording, process=display_image_in_notebook)
+        return WebsocketService(
+            wss_url=self._with_db_preview(debug_info.ws.recording), process=display_image_in_notebook
+        )
 
     @track_usage("cloud.session.viewer.cdp")
     def viewer_cdp(self, session_id: str) -> None:
@@ -1076,13 +1078,17 @@ class RemoteSession(SyncResource):
         if self.response is None:
             raise ValueError("You need to start the session first to get the cdp url")
         if self.request.cdp_url is not None:
-            # cdp url from another session provider
+            # cdp url from another session provider. It is handed to us by the
+            # caller and served by someone else, so it gets no preview selector.
             return self.request.cdp_url
+        # The remaining urls are websocket endpoints on our own API, which reads
+        # the preview branch from the query string. Without it the handshake is
+        # served from the default database and rejects a preview-branch session.
         if self.response.cdp_url is not None:
-            return self.response.cdp_url
+            return self.client._with_db_preview(self.response.cdp_url)  # pyright: ignore [reportPrivateUsage]
         # cdp url from the session provider
         debug = self.debug_info()
-        return debug.ws.cdp
+        return self.client._with_db_preview(debug.ws.cdp)  # pyright: ignore [reportPrivateUsage]
 
     @property
     def page(self) -> "PageSync":

--- a/tests/sdk/test_db_preview_routing.py
+++ b/tests/sdk/test_db_preview_routing.py
@@ -1,0 +1,70 @@
+"""NOTTE_DB_PREVIEW selects a database branch for a client's requests."""
+
+import pytest
+from notte_sdk.endpoints.base import BaseClient
+
+
+class MockNotteClient:
+    pass
+
+
+def _client(api_key: str = "test-api-key") -> BaseClient:
+    return BaseClient(MockNotteClient(), None, api_key=api_key)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NOTTE_DB_PREVIEW", raising=False)
+
+
+def test_no_preview_header_by_default() -> None:
+    assert "x-db-preview" not in _client().headers()
+
+
+def test_preview_branch_is_sent_as_a_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTTE_DB_PREVIEW", "feature/my-branch")
+    assert _client().headers()["x-db-preview"] == "feature/my-branch"
+
+
+def test_blank_values_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTTE_DB_PREVIEW", "   ")
+    assert "x-db-preview" not in _client().headers()
+
+
+def test_branch_is_trimmed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTTE_DB_PREVIEW", "  feature/my-branch  ")
+    assert _client().headers()["x-db-preview"] == "feature/my-branch"
+
+
+def test_explicit_headers_still_win(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTTE_DB_PREVIEW", "feature/my-branch")
+    headers = _client().headers({"x-db-preview": "explicit"})
+    assert headers["x-db-preview"] == "explicit"
+
+
+def test_websocket_url_is_unchanged_without_a_branch() -> None:
+    url = "wss://api.notte.cc/agents/a/debug/logs?token=t"
+    assert _client()._with_db_preview(url) == url
+
+
+def test_websocket_url_carries_the_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTTE_DB_PREVIEW", "feature/my-branch")
+    url = "wss://api.notte.cc/agents/a/debug/logs?token=t"
+    assert (
+        _client()._with_db_preview(url)
+        == "wss://api.notte.cc/agents/a/debug/logs?token=t&db_preview=feature%2Fmy-branch"
+    )
+
+
+def test_websocket_url_without_a_query_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTTE_DB_PREVIEW", "main")
+    assert _client()._with_db_preview("wss://api.notte.cc/ws") == "wss://api.notte.cc/ws?db_preview=main"
+
+
+def test_branch_survives_a_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The server parses this back out, so the encoding has to be recoverable."""
+    from urllib.parse import parse_qsl, urlparse
+
+    monkeypatch.setenv("NOTTE_DB_PREVIEW", "feature/a+b c")
+    url = _client()._with_db_preview("wss://api.notte.cc/ws?token=t")
+    assert dict(parse_qsl(urlparse(url).query))["db_preview"] == "feature/a+b c"

--- a/tests/sdk/test_db_preview_routing.py
+++ b/tests/sdk/test_db_preview_routing.py
@@ -1,7 +1,15 @@
-"""NOTTE_DB_PREVIEW selects a database branch for a client's requests."""
+"""NOTTE_DB_PREVIEW_BRANCH selects a database branch for a client's requests."""
+
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from notte_sdk.endpoints.base import BaseClient
+from notte_sdk.endpoints.sessions import RemoteSession, SessionsClient
+from notte_sdk.types import SessionResponse, SessionStartRequest
+
+BRANCH = "feature/my-branch"
+ENV_VAR = "NOTTE_DB_PREVIEW_BRANCH"
 
 
 class MockNotteClient:
@@ -12,8 +20,32 @@ def _client(api_key: str = "test-api-key") -> BaseClient:
     return BaseClient(MockNotteClient(), None, api_key=api_key)
 
 
+def _sessions_client(recording_url: str) -> SessionsClient:
+    """A SessionsClient whose debug info reports ``recording_url``."""
+    client = SessionsClient(MockNotteClient(), api_key="test-api-key")  # pyright: ignore [reportArgumentType]
+    client.debug_info = lambda session_id: SimpleNamespace(  # pyright: ignore [reportAttributeAccessIssue]
+        ws=SimpleNamespace(recording=recording_url)
+    )
+    return client
+
+
+def _session(*, request_cdp: str | None = None, response_cdp: str | None = None, debug_cdp: str = "") -> RemoteSession:
+    """A started RemoteSession with the three cdp url sources under our control.
+
+    ``cdp_url`` prefers a caller-supplied url, then the one on the start
+    response, then a debug-info lookup, so each source needs its own case.
+    """
+    session = object.__new__(RemoteSession)
+    session.client = _client()  # pyright: ignore [reportAttributeAccessIssue]
+    session.request = SessionStartRequest.model_construct(cdp_url=request_cdp)
+    session.response = SessionResponse.model_construct(cdp_url=response_cdp)
+    session.debug_info = lambda: SimpleNamespace(ws=SimpleNamespace(cdp=debug_cdp))  # pyright: ignore [reportAttributeAccessIssue]
+    return session
+
+
 @pytest.fixture(autouse=True)
 def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_VAR, raising=False)
     monkeypatch.delenv("NOTTE_DB_PREVIEW", raising=False)
 
 
@@ -22,22 +54,28 @@ def test_no_preview_header_by_default() -> None:
 
 
 def test_preview_branch_is_sent_as_a_header(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NOTTE_DB_PREVIEW", "feature/my-branch")
-    assert _client().headers()["x-db-preview"] == "feature/my-branch"
+    monkeypatch.setenv(ENV_VAR, BRANCH)
+    assert _client().headers()["x-db-preview"] == BRANCH
+
+
+def test_the_shorter_variable_name_is_not_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The console and CI both export NOTTE_DB_PREVIEW_BRANCH; only that name counts."""
+    monkeypatch.setenv("NOTTE_DB_PREVIEW", BRANCH)
+    assert "x-db-preview" not in _client().headers()
 
 
 def test_blank_values_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NOTTE_DB_PREVIEW", "   ")
+    monkeypatch.setenv(ENV_VAR, "   ")
     assert "x-db-preview" not in _client().headers()
 
 
 def test_branch_is_trimmed(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NOTTE_DB_PREVIEW", "  feature/my-branch  ")
-    assert _client().headers()["x-db-preview"] == "feature/my-branch"
+    monkeypatch.setenv(ENV_VAR, f"  {BRANCH}  ")
+    assert _client().headers()["x-db-preview"] == BRANCH
 
 
 def test_explicit_headers_still_win(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NOTTE_DB_PREVIEW", "feature/my-branch")
+    monkeypatch.setenv(ENV_VAR, BRANCH)
     headers = _client().headers({"x-db-preview": "explicit"})
     assert headers["x-db-preview"] == "explicit"
 
@@ -48,7 +86,7 @@ def test_websocket_url_is_unchanged_without_a_branch() -> None:
 
 
 def test_websocket_url_carries_the_branch(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NOTTE_DB_PREVIEW", "feature/my-branch")
+    monkeypatch.setenv(ENV_VAR, BRANCH)
     url = "wss://api.notte.cc/agents/a/debug/logs?token=t"
     assert (
         _client()._with_db_preview(url)
@@ -57,7 +95,7 @@ def test_websocket_url_carries_the_branch(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_websocket_url_without_a_query_string(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("NOTTE_DB_PREVIEW", "main")
+    monkeypatch.setenv(ENV_VAR, "main")
     assert _client()._with_db_preview("wss://api.notte.cc/ws") == "wss://api.notte.cc/ws?db_preview=main"
 
 
@@ -65,6 +103,48 @@ def test_branch_survives_a_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
     """The server parses this back out, so the encoding has to be recoverable."""
     from urllib.parse import parse_qsl, urlparse
 
-    monkeypatch.setenv("NOTTE_DB_PREVIEW", "feature/a+b c")
+    monkeypatch.setenv(ENV_VAR, "feature/a+b c")
     url = _client()._with_db_preview("wss://api.notte.cc/ws?token=t")
     assert dict(parse_qsl(urlparse(url).query))["db_preview"] == "feature/a+b c"
+
+
+# The cdp url is what session.page connects to. A preview-branch session is
+# unknown to the default database, so a handshake without the selector is
+# rejected and every managed auth verifier fails before it reads the page.
+
+
+def test_cdp_url_from_debug_info_carries_the_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_VAR, BRANCH)
+    session = _session(debug_cdp="wss://api.notte.cc/sessions/s/debug?token=t")
+    assert session.cdp_url() == "wss://api.notte.cc/sessions/s/debug?token=t&db_preview=feature%2Fmy-branch"
+
+
+def test_cdp_url_from_the_start_response_carries_the_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_VAR, BRANCH)
+    session = _session(response_cdp="wss://api.notte.cc/sessions/s/debug?token=t")
+    assert session.cdp_url() == "wss://api.notte.cc/sessions/s/debug?token=t&db_preview=feature%2Fmy-branch"
+
+
+def test_a_caller_supplied_cdp_url_is_left_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """That url belongs to another browser provider, not to our API."""
+    monkeypatch.setenv(ENV_VAR, BRANCH)
+    external = "wss://connect.browserbase.com/?apiKey=k"
+    assert _session(request_cdp=external).cdp_url() == external
+
+
+def test_cdp_url_is_unchanged_without_a_branch() -> None:
+    url = "wss://api.notte.cc/sessions/s/debug?token=t"
+    assert _session(debug_cdp=url).cdp_url() == url
+
+
+def test_the_recording_stream_carries_the_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_VAR, BRANCH)
+    url = "wss://api.notte.cc/sessions/s/debug/recording?token=t"
+    service: Any = _sessions_client(url).viewer_notebook(session_id="s")
+    assert service.wss_url == f"{url}&db_preview=feature%2Fmy-branch"
+
+
+def test_the_recording_stream_is_unchanged_without_a_branch() -> None:
+    url = "wss://api.notte.cc/sessions/s/debug/recording?token=t"
+    service: Any = _sessions_client(url).viewer_notebook(session_id="s")
+    assert service.wss_url == url


### PR DESCRIPTION
The API can serve a request from a preview database branch when the request names one. The SDK had no way to ask for that, so anything running against a branch had to patch the client at runtime.

Setting `NOTTE_DB_PREVIEW_BRANCH ` to a branch name now does it:

- API requests carry it as an `x-db-preview` header.
- The agent log stream carries it as a `db_preview` query parameter, because a WebSocket handshake cannot carry request headers - that stream is opened directly by the client, including from a browser.

Inert unless the variable is set: with it unset, requests are byte-identical to before. An explicit `headers={"x-db-preview": ...}` still takes precedence.

This is an internal facility - the branch only means anything against our own non-production deployments - so the URL helper is private and nothing is added to the public reference docs.

Tests cover: absent by default, header set from the variable, blank and untrimmed values, explicit headers winning, both query-string shapes, and that the encoded branch parses back out unchanged server-side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for routing SDK requests and WebSocket connections to a configured database preview.
  * Database preview settings can be supplied through configuration and are safely encoded in connection URLs.
  * Preview settings are included in request headers when configured.
  * Explicitly provided external connection URLs remain unchanged.

* **Bug Fixes**
  * Improved handling of blank, missing, and special-character database preview values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Linear: NOT-811 — https://linear.app/nottelabsinc/issue/NOT-811/notte-pr-878-select-a-database-branch-with-notte-db-preview-branch
Auto-linked by Quaso GitHub PR ↔ Linear reconciler.