### PR TITLE
Support hidden system sessions

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/client.py
+++ b/packages/notte-sdk/src/notte_sdk/client.py
@@ -14,6 +14,7 @@ from notte_sdk.agent_fallback import RemoteAgentFallback
 from notte_sdk.endpoints.agents import AgentsClient, RemoteAgent
 from notte_sdk.endpoints.files import FileStorageClient, RemoteFileStorage
 from notte_sdk.endpoints.functions import NotteFunction
+from notte_sdk.endpoints.managed_auth import ManagedAuthClient
 from notte_sdk.endpoints.personas import NottePersona, PersonasClient
 from notte_sdk.endpoints.profiles import ProfilesClient
 from notte_sdk.endpoints.sessions import RemoteSession, SessionsClient, SessionViewerType
@@ -62,6 +63,9 @@ class NotteClient:
             root_client=self, api_key=api_key, server_url=server_url, verbose=verbose
         )
         self.profiles: ProfilesClient = ProfilesClient(
+            root_client=self, api_key=api_key, server_url=server_url, verbose=verbose
+        )
+        self.managed_auth: ManagedAuthClient = ManagedAuthClient(
             root_client=self, api_key=api_key, server_url=server_url, verbose=verbose
         )
         self.files: FileStorageClient = FileStorageClient(

--- a/packages/notte-sdk/src/notte_sdk/endpoints/managed_auth.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/managed_auth.py
@@ -1,0 +1,38 @@
+from typing import TYPE_CHECKING, final
+
+from notte_sdk.endpoints.base import BaseClient, NotteEndpoint
+from notte_sdk.types import ManagedAuthRunResponse, SdkRequest
+
+if TYPE_CHECKING:
+    from notte_sdk.client import NotteClient
+
+
+class _EmptyRequest(SdkRequest):
+    """Empty JSON body required by the SDK's POST transport."""
+
+
+@final
+class ManagedAuthClient(BaseClient):
+    def __init__(
+        self,
+        root_client: "NotteClient",
+        api_key: str | None = None,
+        server_url: str | None = None,
+        verbose: bool = False,
+    ) -> None:
+        super().__init__(
+            root_client=root_client,
+            base_endpoint_path="managed-auth",
+            api_key=api_key,
+            server_url=server_url,
+            verbose=verbose,
+        )
+
+    def check_connection(self, connection_id: str) -> ManagedAuthRunResponse:
+        endpoint = NotteEndpoint(
+            path=f"connections/{connection_id}/check",
+            response=ManagedAuthRunResponse,
+            request=_EmptyRequest(),
+            method="POST",
+        )
+        return self.request(endpoint)

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -777,7 +777,6 @@ class SessionStartRequestDict(TypedDict, total=False):
     vault_id: str | None
     auth_ids: list[str]
     wait_for_authentication: bool
-    system_hidden: bool
 
 
 class SessionStartRequest(SdkRequest):
@@ -859,10 +858,6 @@ class SessionStartRequest(SdkRequest):
         bool,
         Field(description="Whether to wait for Managed Auth authentication before returning the session"),
     ] = True
-    system_hidden: Annotated[
-        bool,
-        Field(description="Whether this session is an internal system run hidden from normal console lists"),
-    ] = False
 
     @model_validator(mode="before")
     @classmethod
@@ -1003,6 +998,12 @@ class SessionListRequest(SdkRequest):
     page_size: int = DEFAULT_LIMIT_LIST_ITEMS
     page: int = 1
     include_system: bool = True
+
+
+class ManagedAuthRunResponse(SdkResponse):
+    connection_id: str
+    status: str
+    message: str
 
 
 class SessionResponse(SdkResponse):

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -775,6 +775,9 @@ class SessionStartRequestDict(TypedDict, total=False):
     web_bot_auth: bool
     extra_http_headers: dict[str, str] | None
     vault_id: str | None
+    auth_ids: list[str]
+    wait_for_authentication: bool
+    system_hidden: bool
 
 
 class SessionStartRequest(SdkRequest):
@@ -848,6 +851,18 @@ class SessionStartRequest(SdkRequest):
     ] = None
 
     vault_id: Annotated[str | None, Field(description="The vault to use for the session")] = None
+    auth_ids: Annotated[
+        list[str],
+        Field(description="Managed Auth connection IDs to authenticate inside this session", max_length=10),
+    ] = Field(default_factory=list)
+    wait_for_authentication: Annotated[
+        bool,
+        Field(description="Whether to wait for Managed Auth authentication before returning the session"),
+    ] = True
+    system_hidden: Annotated[
+        bool,
+        Field(description="Whether this session is an internal system run hidden from normal console lists"),
+    ] = False
 
     @model_validator(mode="before")
     @classmethod
@@ -980,12 +995,14 @@ class SessionListRequestDict(TypedDict, total=False):
     only_active: bool
     page_size: int
     page: int
+    include_system: bool
 
 
 class SessionListRequest(SdkRequest):
     only_active: bool = True
     page_size: int = DEFAULT_LIMIT_LIST_ITEMS
     page: int = 1
+    include_system: bool = True
 
 
 class SessionResponse(SdkResponse):
@@ -1047,6 +1064,7 @@ class SessionResponse(SdkResponse):
     cdp_url: Annotated[str | None, Field(description="The URL to connect to the CDP server.")] = None
     viewer_url: Annotated[str | None, Field(description="The remote session viewer URL.")] = None
     web_bot_auth: Annotated[bool, Field(description="Whether to use web bot authentication.")] = False
+    system_hidden: Annotated[bool, Field(description="Whether this session is an internal system run.")] = False
 
     @field_validator("closed_at", mode="before")
     @classmethod

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -2,6 +2,7 @@ import datetime as dt
 import json
 import os
 import re
+import uuid
 import warnings
 from enum import StrEnum
 from pathlib import Path
@@ -851,7 +852,7 @@ class SessionStartRequest(SdkRequest):
 
     vault_id: Annotated[str | None, Field(description="The vault to use for the session")] = None
     auth_ids: Annotated[
-        list[str],
+        list[uuid.UUID],
         Field(description="Managed Auth connection IDs to authenticate inside this session", max_length=10),
     ] = Field(default_factory=list)
     wait_for_authentication: Annotated[

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -418,6 +418,15 @@ def test_solve_captchas_defaults_to_enabled_but_can_be_disabled() -> None:
     assert SessionStartRequest(solve_captchas=False).solve_captchas is False
 
 
+def test_managed_auth_system_session_parameters() -> None:
+    auth_id = "55555555-5555-5555-5555-555555555555"
+    request = SessionStartRequest(auth_ids=[auth_id], system_hidden=True)
+
+    assert request.auth_ids == [auth_id]
+    assert request.wait_for_authentication is True
+    assert request.system_hidden is True
+
+
 def test_new_timeout_parameters_explicit() -> None:
     """Test new explicit timeout parameters."""
     request = SessionStartRequest(max_duration_minutes=10, idle_timeout_minutes=5)

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -418,13 +418,28 @@ def test_solve_captchas_defaults_to_enabled_but_can_be_disabled() -> None:
     assert SessionStartRequest(solve_captchas=False).solve_captchas is False
 
 
-def test_managed_auth_system_session_parameters() -> None:
+@patch("requests.post")
+def test_managed_auth_connection_check(mock_post: MagicMock, client: NotteClient, headers: dict[str, str]) -> None:
     auth_id = "55555555-5555-5555-5555-555555555555"
-    request = SessionStartRequest(auth_ids=[auth_id], system_hidden=True)
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {
+        "connection_id": auth_id,
+        "status": "authenticated",
+        "message": "Authentication check completed",
+    }
 
-    assert request.auth_ids == [auth_id]
-    assert request.wait_for_authentication is True
-    assert request.system_hidden is True
+    result = client.managed_auth.check_connection(auth_id)
+
+    assert result.status == "authenticated"
+    mock_post.assert_called_once_with(
+        url=f"{client.managed_auth.server_url}/managed-auth/connections/{auth_id}/check",
+        headers=headers,
+        data="{}",
+        params=None,
+        timeout=client.managed_auth.DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        files=None,
+        json=None,
+    )
 
 
 def test_new_timeout_parameters_explicit() -> None:


### PR DESCRIPTION
## Summary

- add Managed Auth session parameters to the SDK session request
- expose the system visibility marker on session responses
- allow list callers to include or exclude system sessions

## Testing

- `PYTHONPATH=packages/notte-sdk/src pytest tests/sdk/test_client.py -q` (22 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788424256&installation_model_id=8247&pr_number=879&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F879&signature=9869fcd1a48b6aea1e124624968ea60f07c5f5afefe8a6e916bbd97d502a7842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->