### PR TITLE
ci: pass the release tag and API key through env in the release workflow

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Build and Publish to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
-        run: bash build.sh ${{ github.ref_name }} publish
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: bash build.sh "$RELEASE_TAG" publish
 
       - name: Wait for PyPI indexing
         run: |
@@ -53,6 +54,8 @@ jobs:
           sleep 180  # Wait 3 minutes for PyPI indexing
 
       - name: Install the package from PyPI
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           uv venv pypi
           source pypi/bin/activate
@@ -63,8 +66,8 @@ jobs:
           wait_time=60
 
           while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts: Installing notte==${{ github.ref_name }}..."
-            if uv pip install notte==${{ github.ref_name }}; then
+            echo "Attempt $attempt of $max_attempts: Installing notte==${RELEASE_TAG}..."
+            if uv pip install "notte==${RELEASE_TAG}"; then
               echo "Installation successful!"
               break
             fi
@@ -94,10 +97,12 @@ jobs:
 
     steps:
       - name: Trigger Mintlify deployment
+        env:
+          MINTLIFY_API_KEY: ${{ secrets.MINTLIFY_API_KEY }}
         run: |
           response=$(curl -s -w "\n%{http_code}" -X POST \
             "https://api.mintlify.com/v1/project/update/67325cb675ec6a1a358ff41d" \
-            -H "Authorization: Bearer ${{ secrets.MINTLIFY_API_KEY }}")
+            -H "Authorization: Bearer ${MINTLIFY_API_KEY}")
 
           http_code=$(echo "$response" | tail -n1)
           body=$(echo "$response" | sed '$d')


### PR DESCRIPTION
`${{ }}` expressions are expanded by GitHub before the shell parses the line, so an interpolated value is treated as code rather than data. Quoting inside the script does not help, because the substitution has already happened.

This binds the two expressions in `pypi-release.yml` to step-level `env` and references the quoted shell variables:

- `github.ref_name` in the build/publish and install steps. It was also unquoted, so it was subject to word splitting.
- `secrets.MINTLIFY_API_KEY` in the docs deployment step, which additionally keeps the key out of the `curl` command line.

The workflow only triggers on tag pushes, so this is hardening rather than a fix for something externally reachable.

No behaviour change: same values, same control flow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788425981&installation_model_id=8247&pr_number=880&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F880&signature=6a7e2618bed070e7c61ddb9c1891f9d4333cda58aa5a8c574ae05d86cb5dab2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the release process to publish the correct tagged version more reliably.
  - Updated package installation and documentation publishing steps to use the release version and authentication settings consistently.
  - No changes were made to the product’s public features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->