### PR TITLE
docs: use wss:// in the external CDP connection example

### DIFF
--- a/docs/src/snippets/sessions/cdp/external_basic.mdx
+++ b/docs/src/snippets/sessions/cdp/external_basic.mdx
@@ -5,7 +5,7 @@
   client = NotteClient()
 
   # CDP URL from any external provider
-  cdp_url = "ws://external-provider.com:9222/devtools/browser/abc123"
+  cdp_url = "wss://external-provider.com:9222/devtools/browser/abc123"
 
   # Connect Notte to the external browser
   with client.Session(cdp_url=cdp_url) as session:


### PR DESCRIPTION
The basic external-provider snippet connects to a remote CDP endpoint over plaintext `ws://`. CDP carries full browser control and session cookies, so that is not a good pattern to copy for a connection crossing the public internet.

The other external-provider snippets (`external_cdp_auth`, `external_error_handling`, `external_monitor_costs`) already use `wss://` - this one was the exception, so this just makes it consistent.

Only the example URL changes; no behaviour or API change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788426215&installation_model_id=8247&pr_number=881&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F881&signature=86b9bd6840eded4cf531c75706b44bab70080dce00c7b70812e2473373f28fee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external browser connection documentation to use secure WebSocket protocol, enhancing security for browser automation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->