### PR TITLE
fix(url): only strip the leading scheme and www. in clean_url

### DIFF
--- a/packages/notte-core/src/notte_core/utils/url.py
+++ b/packages/notte-core/src/notte_core/utils/url.py
@@ -12,8 +12,15 @@ def clean_url(url: str) -> str:
     base = url.split("?")[0]
     if base.endswith("/"):
         base = base[:-1]
-    base = base.replace("https://", "").replace("http://", "")
-    base = base.replace("www.", "")
+    # Strip only the LEADING scheme and www. prefix. str.replace() would also
+    # mangle a later occurrence, e.g. a subdomain literally named "www"
+    # (api.www.example.com) or a path segment that contains "www.".
+    for scheme in ("https://", "http://"):
+        if base.startswith(scheme):
+            base = base[len(scheme) :]
+            break
+    if base.startswith("www."):
+        base = base[len("www.") :]
     return base
 
 

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -1,4 +1,4 @@
-from notte_core.utils.url import get_root_domain
+from notte_core.utils.url import clean_url, get_root_domain
 
 
 def test_get_root_domain_with_https():
@@ -51,3 +51,20 @@ def test_wrong_urls():
 def test_get_root_domain_with_subdirectory():
     """Test get_root_domain with URL that includes subdirectories."""
     assert get_root_domain("https://app.neo.space/mail/") == "neo.space"
+
+
+def test_clean_url_basic():
+    assert clean_url("https://www.example.com") == "example.com"
+    assert clean_url("http://www.example.com/") == "example.com"
+    assert clean_url("https://example.com/path?query=1") == "example.com/path"
+    assert clean_url("www.example.com") == "example.com"
+    assert clean_url("example.com") == "example.com"
+
+
+def test_clean_url_only_strips_leading_www_and_scheme():
+    # Regression: str.replace() used to strip "www."/"http(s)://" anywhere,
+    # mangling a subdomain literally named "www" or a path containing them.
+    assert clean_url("https://api.www.example.com") == "api.www.example.com"
+    assert clean_url("https://download.www.company.com/x") == "download.www.company.com/x"
+    assert clean_url("https://www.example.com/newwww.html") == "example.com/newwww.html"
+    assert clean_url("http://www.example.com/awww.file") == "example.com/awww.file"


### PR DESCRIPTION
### What
`clean_url` used `str.replace("www.", "")` (and the same for the `http(s)://` prefixes), which strips the substring **anywhere** in the URL, not just the leading prefix. So a subdomain literally named `www` or a path containing `www.` is silently corrupted:

| Input | Old output | Fixed |
|---|---|---|
| `https://api.www.example.com` | `api.example.com` | `api.www.example.com` |
| `https://download.www.company.com/x` | `download.company.com/x` | (unchanged) |
| `https://www.example.com/newwww.html` | `example.com/newhtml` | `example.com/newwww.html` |

### Why it matters
`clean_url` backs `snapshot.clean_url` / `observation.clean_url`, and `session.py` uses it for navigation-change detection (`self.snapshot.clean_url != last_observation.clean_url`), so two distinct URLs that clean to the same value can make a session mis-detect whether the page navigated. It also affects favicon labels and observation dedup.

### Fix
Anchor the scheme + `www.` strips to the leading prefix only (no `str.replace` mid-string), and add regression tests in `tests/utils/test_url.py`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788432506&installation_model_id=8247&pr_number=882&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F882&signature=e8c7c44fb16fcdd8278809a3766ad9d221225679881088a194293ce85b74bb98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL cleaning to remove leading schemes and `www.` prefixes without altering matching text later in subdomains or paths.
  * Preserved URL paths, query parameters, and embedded `www` text correctly.

* **Tests**
  * Added coverage for schemes, prefixes, bare domains, paths, queries, and embedded text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->