### PR TITLE
[NOT-752] Support hidden system sessions with string Managed Auth IDs

### DIFF
--- a/docs/src/sdk-reference/manual/session.mdx
+++ b/docs/src/sdk-reference/manual/session.mdx
@@ -136,5 +136,6 @@ You can use the default parameters to create your session, or customize them:
   Up to 10 unique Managed Auth connection IDs to authenticate before the session is returned.
 </ParamField>
 
-<ParamField path="wait_for_authentication" type="bool">
+<ParamField path="wait_for_authentication" type="bool" default="True">
+  Defaults to True. Wait for Managed Auth before returning the session; authentication failure or timeout fails session creation. When False, return after the browser is ready while authentication continues in the background.
 </ParamField>

--- a/docs/src/sdk-reference/manual/session.mdx
+++ b/docs/src/sdk-reference/manual/session.mdx
@@ -135,3 +135,6 @@ You can use the default parameters to create your session, or customize them:
 <ParamField path="auth_ids" type="list">
   Up to 10 unique Managed Auth connection IDs to authenticate before the session is returned.
 </ParamField>
+
+<ParamField path="wait_for_authentication" type="bool">
+</ParamField>

--- a/docs/src/sdk-reference/misc/sessionresponse.mdx
+++ b/docs/src/sdk-reference/misc/sessionresponse.mdx
@@ -103,7 +103,7 @@ description: ""
 </ParamField>
 
 <ParamField path="system_hidden" type="bool" default="False">
-  Whether this session is an internal system run.
+  Whether this session is an internal system run. Internal system runs are omitted from session.list() unless include_system=True is requested.
 </ParamField>
 
 

--- a/docs/src/sdk-reference/misc/sessionresponse.mdx
+++ b/docs/src/sdk-reference/misc/sessionresponse.mdx
@@ -102,6 +102,10 @@ description: ""
   Managed Auth connection IDs attached to this session.
 </ParamField>
 
+<ParamField path="system_hidden" type="bool" default="False">
+  Whether this session is an internal system run.
+</ParamField>
+
 
 ## Module
 

--- a/docs/src/sdk-reference/remotesession/__init__.mdx
+++ b/docs/src/sdk-reference/remotesession/__init__.mdx
@@ -105,6 +105,9 @@ RemoteSession instance configured with the specified parameters.
   Up to 10 unique Managed Auth connection IDs to authenticate before the session is returned.
 </ParamField>
 
+<ParamField path="wait_for_authentication" type="bool">
+</ParamField>
+
 ## Returns
 
 `None`: A new RemoteSession instance configured with the specified parameters.

--- a/docs/src/sdk-reference/remotesession/__init__.mdx
+++ b/docs/src/sdk-reference/remotesession/__init__.mdx
@@ -106,6 +106,7 @@ RemoteSession instance configured with the specified parameters.
 </ParamField>
 
 <ParamField path="wait_for_authentication" type="bool">
+  Defaults to True. Wait for Managed Auth before returning the session; authentication failure or timeout fails session creation. When False, return after the browser is ready while authentication continues in the background.
 </ParamField>
 
 ## Returns

--- a/packages/notte-sdk/src/notte_sdk/client.py
+++ b/packages/notte-sdk/src/notte_sdk/client.py
@@ -14,6 +14,7 @@ from notte_sdk.agent_fallback import RemoteAgentFallback
 from notte_sdk.endpoints.agents import AgentsClient, RemoteAgent
 from notte_sdk.endpoints.files import FileStorageClient, RemoteFileStorage
 from notte_sdk.endpoints.functions import NotteFunction
+from notte_sdk.endpoints.managed_auth import ManagedAuthClient
 from notte_sdk.endpoints.personas import NottePersona, PersonasClient
 from notte_sdk.endpoints.profiles import ProfilesClient
 from notte_sdk.endpoints.sessions import RemoteSession, SessionsClient, SessionViewerType
@@ -62,6 +63,9 @@ class NotteClient:
             root_client=self, api_key=api_key, server_url=server_url, verbose=verbose
         )
         self.profiles: ProfilesClient = ProfilesClient(
+            root_client=self, api_key=api_key, server_url=server_url, verbose=verbose
+        )
+        self.managed_auth: ManagedAuthClient = ManagedAuthClient(
             root_client=self, api_key=api_key, server_url=server_url, verbose=verbose
         )
         self.files: FileStorageClient = FileStorageClient(

--- a/packages/notte-sdk/src/notte_sdk/endpoints/managed_auth.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/managed_auth.py
@@ -1,0 +1,38 @@
+from typing import TYPE_CHECKING, final
+
+from notte_sdk.endpoints.base import BaseClient, NotteEndpoint
+from notte_sdk.types import ManagedAuthRunResponse, SdkRequest
+
+if TYPE_CHECKING:
+    from notte_sdk.client import NotteClient
+
+
+class _EmptyRequest(SdkRequest):
+    """Empty JSON body required by the SDK's POST transport."""
+
+
+@final
+class ManagedAuthClient(BaseClient):
+    def __init__(
+        self,
+        root_client: "NotteClient",
+        api_key: str | None = None,
+        server_url: str | None = None,
+        verbose: bool = False,
+    ) -> None:
+        super().__init__(
+            root_client=root_client,
+            base_endpoint_path="managed-auth",
+            api_key=api_key,
+            server_url=server_url,
+            verbose=verbose,
+        )
+
+    def check_connection(self, connection_id: str) -> ManagedAuthRunResponse:
+        endpoint = NotteEndpoint(
+            path=f"connections/{connection_id}/check",
+            response=ManagedAuthRunResponse,
+            request=_EmptyRequest(),
+            method="POST",
+        )
+        return self.request(endpoint)

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -623,6 +623,9 @@ class RemoteSession(SyncResource):
             storage: File Storage to attach to the session
             open_viewer: Whether to open the live viewer when the session starts (default: False).
                 Browsers are always headless; this controls only the viewer popup.
+            wait_for_authentication: Defaults to True. Wait for Managed Auth before returning the
+                session; authentication failure or timeout fails session creation. When False,
+                return after the browser is ready while authentication continues in the background.
             **data: Keyword arguments for the session creation request.
 
         Returns:

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1013,6 +1013,12 @@ class SessionListRequest(SdkRequest):
     include_system: bool = True
 
 
+class ManagedAuthRunResponse(SdkResponse):
+    connection_id: str
+    status: str
+    message: str
+
+
 class SessionResponse(SdkResponse):
     session_id: Annotated[
         str,

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -776,7 +776,7 @@ class SessionStartRequestDict(TypedDict, total=False):
     web_bot_auth: bool
     extra_http_headers: dict[str, str] | None
     vault_id: str | None
-    auth_ids: list[str] | None
+    auth_ids: list[str]
     wait_for_authentication: bool
 
 
@@ -852,7 +852,7 @@ class SessionStartRequest(SdkRequest):
 
     vault_id: Annotated[str | None, Field(description="The vault to use for the session")] = None
     auth_ids: Annotated[
-        list[str] | None,
+        list[str],
         Field(
             max_length=10,
             description=(
@@ -860,7 +860,7 @@ class SessionStartRequest(SdkRequest):
                 "inside this session before it is returned."
             ),
         ),
-    ] = None
+    ] = Field(default_factory=list)
     wait_for_authentication: Annotated[
         bool,
         Field(description="Whether to wait for Managed Auth authentication before returning the session"),
@@ -876,7 +876,7 @@ class SessionStartRequest(SdkRequest):
 
     @model_validator(mode="after")
     def validate_unique_auth_ids(self) -> "SessionStartRequest":
-        if self.auth_ids is not None and len(self.auth_ids) != len(set(self.auth_ids)):
+        if len(self.auth_ids) != len(set(self.auth_ids)):
             raise ValueError("auth_ids must not contain duplicates")
         return self
 

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -754,6 +754,9 @@ class SessionStartRequestDict(TypedDict, total=False):
         screenshot_type: The type of screenshot to use for the session.
         profile: Browser profile configuration for state persistence.
         auth_ids: Up to 10 unique Managed Auth connection IDs to authenticate before the session is returned.
+        wait_for_authentication: Defaults to True. Wait for Managed Auth before returning the session;
+            authentication failure or timeout fails session creation. When False, return after the browser is
+            ready while authentication continues in the background.
     """
 
     headless: bool
@@ -863,7 +866,13 @@ class SessionStartRequest(SdkRequest):
     ] = Field(default_factory=list)
     wait_for_authentication: Annotated[
         bool,
-        Field(description="Whether to wait for Managed Auth authentication before returning the session"),
+        Field(
+            description=(
+                "Whether to wait for Managed Auth before returning the session. Defaults to true. "
+                "When true, authentication failure or timeout fails session creation; when false, "
+                "authentication continues in the background after the browser is ready."
+            )
+        ),
     ] = True
 
     @model_validator(mode="before")
@@ -1012,11 +1021,20 @@ class ListRequest(SdkRequest):
 
 
 class SessionListRequestDict(ListRequestDict, total=False):
+    """Session list filters.
+
+    Args:
+        include_system: Include internal sessions whose response has ``system_hidden=True``.
+    """
+
     include_system: bool | None
 
 
 class SessionListRequest(ListRequest):
-    include_system: bool | None = None
+    include_system: Annotated[
+        bool | None,
+        Field(description="Include internal sessions whose response has system_hidden=True."),
+    ] = None
 
 
 class ManagedAuthRunResponse(SdkResponse):
@@ -1088,7 +1106,15 @@ class SessionResponse(SdkResponse):
         list[str],
         Field(description="Managed Auth connection IDs attached to this session."),
     ] = []
-    system_hidden: Annotated[bool, Field(description="Whether this session is an internal system run.")] = False
+    system_hidden: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether this session is an internal system run. Internal system runs are omitted "
+                "from session.list() unless include_system=True is requested."
+            )
+        ),
+    ] = False
 
     @field_validator("closed_at", mode="before")
     @classmethod

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -777,6 +777,7 @@ class SessionStartRequestDict(TypedDict, total=False):
     extra_http_headers: dict[str, str] | None
     vault_id: str | None
     auth_ids: list[str] | None
+    wait_for_authentication: bool
 
 
 class SessionStartRequest(SdkRequest):
@@ -860,6 +861,10 @@ class SessionStartRequest(SdkRequest):
             ),
         ),
     ] = None
+    wait_for_authentication: Annotated[
+        bool,
+        Field(description="Whether to wait for Managed Auth authentication before returning the session"),
+    ] = True
 
     @model_validator(mode="before")
     @classmethod
@@ -998,12 +1003,14 @@ class SessionListRequestDict(TypedDict, total=False):
     only_active: bool
     page_size: int
     page: int
+    include_system: bool
 
 
 class SessionListRequest(SdkRequest):
     only_active: bool = True
     page_size: int = DEFAULT_LIMIT_LIST_ITEMS
     page: int = 1
+    include_system: bool = True
 
 
 class SessionResponse(SdkResponse):
@@ -1069,6 +1076,7 @@ class SessionResponse(SdkResponse):
         list[str],
         Field(description="Managed Auth connection IDs attached to this session."),
     ] = []
+    system_hidden: Annotated[bool, Field(description="Whether this session is an internal system run.")] = False
 
     @field_validator("closed_at", mode="before")
     @classmethod

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -999,18 +999,24 @@ class SessionStartRequest(SdkRequest):
         raise ValueError(f"Unsupported proxy type: {base_proxy.type}")  # pyright: ignore[reportUnreachable]
 
 
-class SessionListRequestDict(TypedDict, total=False):
+class ListRequestDict(TypedDict, total=False):
     only_active: bool
     page_size: int
     page: int
-    include_system: bool
 
 
-class SessionListRequest(SdkRequest):
+class ListRequest(SdkRequest):
     only_active: bool = True
     page_size: int = DEFAULT_LIMIT_LIST_ITEMS
     page: int = 1
-    include_system: bool = True
+
+
+class SessionListRequestDict(ListRequestDict, total=False):
+    include_system: bool | None
+
+
+class SessionListRequest(ListRequest):
+    include_system: bool | None = None
 
 
 class ManagedAuthRunResponse(SdkResponse):
@@ -1197,13 +1203,13 @@ class ListCredentialsResponse(SdkResponse):
     credentials: Annotated[list[Credential], Field(description="URLs for which we hold credentials")]
 
 
-class VaultListRequestDict(SessionListRequestDict, total=False):
+class VaultListRequestDict(ListRequestDict, total=False):
     """Request dictionary for listing vaults."""
 
     pass
 
 
-class VaultListRequest(SessionListRequest):
+class VaultListRequest(ListRequest):
     pass
 
 
@@ -1531,13 +1537,13 @@ class DeletePhoneNumberResponse(SdkResponse):
     message: Annotated[str, Field(description="Message of the deletion")] = "Phone number deleted successfully"
 
 
-class PersonaListRequestDict(SessionListRequestDict, total=False):
+class PersonaListRequestDict(ListRequestDict, total=False):
     """Request dictionary for listing personas."""
 
     pass
 
 
-class PersonaListRequest(SessionListRequest):
+class PersonaListRequest(ListRequest):
     pass
 
 
@@ -1990,7 +1996,7 @@ class AgentStatusRequest(AgentSessionRequest):
     pass
 
 
-class AgentListRequestDict(SessionListRequestDict, total=False):
+class AgentListRequestDict(ListRequestDict, total=False):
     """Request dictionary for listing agents.
 
     Args:
@@ -2003,7 +2009,7 @@ class AgentListRequestDict(SessionListRequestDict, total=False):
     only_saved: bool
 
 
-class AgentListRequest(SessionListRequest):
+class AgentListRequest(ListRequest):
     only_saved: bool = False
 
 
@@ -2101,7 +2107,7 @@ class GetFunctionRequestDict(TypedDict, total=False):
     version: str | None
 
 
-class ListFunctionsRequestDict(SessionListRequestDict, total=False):
+class ListFunctionsRequestDict(ListRequestDict, total=False):
     """Request dictionary for listing workflows.
 
     Args:
@@ -2213,7 +2219,7 @@ class DeleteFunctionResponse(SdkResponse):
     message: Annotated[str, Field(description="The message of the deletion")]
 
 
-class ListFunctionsRequest(SessionListRequest):
+class ListFunctionsRequest(ListRequest):
     pass
 
 
@@ -2407,11 +2413,11 @@ class UpdateFunctionRunResponse(SdkResponse):
         return self.function_run_id
 
 
-class ListFunctionRunsRequestDict(SessionListRequestDict, total=False):
+class ListFunctionRunsRequestDict(ListRequestDict, total=False):
     pass
 
 
-class ListFunctionRunsRequest(SessionListRequest):
+class ListFunctionRunsRequest(ListRequest):
     pass
 
 

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -14,12 +14,15 @@ from notte_sdk.errors import AuthenticationError
 from notte_sdk.types import (
     DEFAULT_SESSION_IDLE_TIMEOUT_IN_MINUTES,
     DEFAULT_SESSION_MAX_DURATION_IN_MINUTES,
+    AgentListRequest,
     ExecutionRequest,
     ExecutionRequestDict,
     ObserveResponse,
+    SessionListRequest,
     SessionResponse,
     SessionStartRequest,
     SessionStartRequestDict,
+    VaultListRequest,
 )
 
 
@@ -464,6 +467,13 @@ def test_managed_auth_connection_check(mock_post: MagicMock, client: NotteClient
         files=None,
         json=None,
     )
+
+
+def test_system_session_filter_is_session_specific_and_only_sent_explicitly() -> None:
+    assert "include_system" not in SessionListRequest().model_dump(exclude_none=True)
+    assert SessionListRequest(include_system=False).model_dump(exclude_none=True)["include_system"] is False
+    assert "include_system" not in AgentListRequest().model_dump()
+    assert "include_system" not in VaultListRequest().model_dump()
 
 
 def test_new_timeout_parameters_explicit() -> None:

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -421,22 +421,22 @@ def test_solve_captchas_defaults_to_enabled_but_can_be_disabled() -> None:
 def test_managed_auth_ids_are_serialized_and_must_be_unique() -> None:
     from pydantic import ValidationError
 
-    assert "auth_ids" not in SessionStartRequest().model_dump(mode="json", exclude_none=True)
+    assert SessionStartRequest().auth_ids == []
 
     auth_ids = [
-        "55555555-5555-5555-5555-555555555555",
-        "66666666-6666-6666-6666-666666666666",
+        "managed-auth-connection-primary",
+        "managed-auth-connection-secondary",
     ]
     request = SessionStartRequest(auth_ids=auth_ids)
 
     assert request.auth_ids == auth_ids
     assert request.model_dump(mode="json")["auth_ids"] == auth_ids
 
-    ten_auth_ids = [f"{index:08d}-0000-0000-0000-000000000000" for index in range(10)]
+    ten_auth_ids = [f"managed-auth-connection-{index}" for index in range(10)]
     assert SessionStartRequest(auth_ids=ten_auth_ids).auth_ids == ten_auth_ids
 
     with pytest.raises(ValidationError):
-        SessionStartRequest(auth_ids=[*ten_auth_ids, "00000010-0000-0000-0000-000000000000"])
+        SessionStartRequest(auth_ids=[*ten_auth_ids, "managed-auth-connection-10"])
 
     with pytest.raises(ValidationError, match="auth_ids must not contain duplicates"):
         SessionStartRequest(auth_ids=[auth_ids[0], auth_ids[0]])

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -442,6 +442,30 @@ def test_managed_auth_ids_are_serialized_and_must_be_unique() -> None:
         SessionStartRequest(auth_ids=[auth_ids[0], auth_ids[0]])
 
 
+@patch("requests.post")
+def test_managed_auth_connection_check(mock_post: MagicMock, client: NotteClient, headers: dict[str, str]) -> None:
+    auth_id = "55555555-5555-5555-5555-555555555555"
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {
+        "connection_id": auth_id,
+        "status": "authenticated",
+        "message": "Authentication check completed",
+    }
+
+    result = client.managed_auth.check_connection(auth_id)
+
+    assert result.status == "authenticated"
+    mock_post.assert_called_once_with(
+        url=f"{client.managed_auth.server_url}/managed-auth/connections/{auth_id}/check",
+        headers=headers,
+        data="{}",
+        params=None,
+        timeout=client.managed_auth.DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        files=None,
+        json=None,
+    )
+
+
 def test_new_timeout_parameters_explicit() -> None:
     """Test new explicit timeout parameters."""
     request = SessionStartRequest(max_duration_minutes=10, idle_timeout_minutes=5)

--- a/tests/sdk/test_dict_types.py
+++ b/tests/sdk/test_dict_types.py
@@ -460,7 +460,7 @@ def test_all_request_classes_have_dict_types_and_proper_inheritance():
     # Valid inheritance patterns - build hierarchy aware validation
     def is_valid_inheritance(class_name: str, inheritance_chain: str) -> bool:
         valid_direct_bases = ["SdkRequest", "BaseModel"]
-        valid_request_bases = ["SessionListRequest", "PaginationParams", "ScrapeParams"]
+        valid_request_bases = ["ListRequest", "SessionListRequest", "PaginationParams", "ScrapeParams"]
         valid_composite_bases = [
             "SdkAgentCreateRequest",
             "AgentRunRequest",


### PR DESCRIPTION
## Summary

- add the trusted Managed Auth connection-check SDK client
- expose session authentication waiting and system-session visibility fields
- keep Managed Auth connection IDs as opaque strings throughout the public SDK
- preserve string values without UUID parsing or canonicalization

Supersedes #879 with the changes rebased onto current main.

Companion backend PR: https://github.com/nottelabs/monorepo/pull/2063

## Testing

- `PYTHONPATH=packages/notte-sdk/src uv run pytest tests/sdk/test_client.py -q` (23 passed)
- Ruff check and format check on changed files

Linear: NOT-752 https://linear.app/nottelabsinc/issue/NOT-752/notte-pr-883-support-hidden-system-sessions-with-string-managed-auth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed authentication connection checks through the SDK, including status and message results.
  * Session creation now supports waiting for authentication to complete.
  * Session listings can include system sessions.
  * Session responses indicate when a session is system-hidden.

* **Improvements**
  * Authentication identifiers now default to an empty list and consistently prevent duplicates.
  * Resource listing requests now use consistent pagination options.
  * Updated SDK documentation for authentication waiting and system-hidden sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->