### PR TITLE
Allow idle_timeout_minutes up to twice the default max session duration

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -801,7 +801,7 @@ class SessionStartRequest(SdkRequest):
         Field(
             description="Idle timeout in minutes. Session closes after this period of inactivity (resets on each operation).",
             gt=0,
-            le=DEFAULT_SESSION_MAX_DURATION_IN_MINUTES,
+            le=DEFAULT_SESSION_MAX_DURATION_IN_MINUTES * 2,
             validation_alias=AliasChoices(
                 "idle_timeout_minutes", "timeout_minutes"
             ),  # Accept both names for backward compatibility


### PR DESCRIPTION
`SessionStartRequest.idle_timeout_minutes` was capped at the default max session duration (15 minutes), which made it impossible to request a longer idle timeout even when `max_duration_minutes` was raised.

This doubles the upper bound so values up to 30 minutes are accepted. The cross-field validator still requires `idle_timeout_minutes <= max_duration_minutes`, so a longer idle timeout must be paired with a matching `max_duration_minutes`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788594550&installation_model_id=8247&pr_number=884&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F884&signature=b592fa5f52a58a0c41d1497dd73eb4428317aa96de009909688d38f16b85214d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum allowed idle timeout when starting a session, enabling longer timeout configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->