### PR TITLE
Drop invalid duration format from SessionResponse schema

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1043,6 +1043,19 @@ class ManagedAuthRunResponse(SdkResponse):
     message: str
 
 
+def _drop_duration_format(schema: dict[str, Any]) -> None:
+    """Strip the `duration` format assertion from a `timedelta` field's JSON schema.
+
+    Pydantic annotates `timedelta` as `{"type": "string", "format": "duration"}`.
+    JSON Schema defines that format as the ABNF in RFC 3339 Appendix A, whose
+    `dur-second = 1*DIGIT "S"` rule allows integer components only. We serialize
+    with sub-second precision (`PT41.286072S`), which is valid ISO 8601 but not
+    valid per that grammar, so validators that assert formats reject an otherwise
+    correct payload. The wire value is unchanged; only the format claim is dropped.
+    """
+    _ = schema.pop("format", None)
+
+
 class SessionResponse(SdkResponse):
     session_id: Annotated[
         str,
@@ -1070,9 +1083,10 @@ class SessionResponse(SdkResponse):
     created_at: Annotated[dt.datetime, Field(description="Session creation time")]
     closed_at: Annotated[dt.datetime | None, Field(description="Session closing time")] = None
     last_accessed_at: Annotated[dt.datetime, Field(description="Last access time")]
-    duration: Annotated[dt.timedelta, Field(description="Session duration")] = Field(
-        default_factory=lambda: dt.timedelta(0)
-    )
+    duration: Annotated[
+        dt.timedelta,
+        Field(description="Session duration", json_schema_extra=_drop_duration_format),
+    ] = Field(default_factory=lambda: dt.timedelta(0))
     status: Annotated[
         Literal["active", "closed", "error", "timed_out"],
         Field(description="Session status"),

--- a/tests/sdk/test_types.py
+++ b/tests/sdk/test_types.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import re
 from typing import Any
 
 import pytest
@@ -12,6 +13,7 @@ from notte_sdk.types import (
     AgentStatusResponse,
     ObserveResponse,
     ReplayResponse,
+    SessionResponse,
     SessionStartRequest,
 )
 from pydantic import BaseModel, ValidationError
@@ -222,3 +224,45 @@ def test_unknown_proxy_type_should_raise_error():
 def test_cdp_url_with_headless_false_should_raise_error():
     with pytest.raises(ValidationError, match=r"headless must be True.*only works with a local browser"):
         _ = SessionStartRequest.model_validate({"cdp_url": "ws://localhost:9222", "headless": False})
+
+
+# ABNF `duration` rule from RFC 3339 Appendix A, which is what JSON Schema's
+# `duration` format is defined against. Integer components only.
+RFC_3339_DURATION = re.compile(r"^P(?!$)((\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?|(\d+W)?)$")
+
+
+def _session_response(duration: dt.timedelta) -> SessionResponse:
+    now = dt.datetime.now(dt.timezone.utc)
+    return SessionResponse(
+        session_id="0d5b2f2f-0f6e-4c1e-9d4b-3a1f1f0b2c3d",
+        idle_timeout_minutes=3,
+        created_at=now,
+        last_accessed_at=now,
+        status="active",
+        duration=duration,
+    )
+
+
+@pytest.mark.parametrize("mode", ["validation", "serialization"])
+def test_session_duration_schema_declares_no_format(mode: Any):
+    """`duration` must not claim a `format` its serialized value cannot satisfy.
+
+    Pydantic annotates timedelta as `format: "duration"`, but we serialize with
+    sub-second precision, which RFC 3339 Appendix A does not allow. Clients that
+    assert formats (e.g. the MCP SDKs via ajv-formats) reject the whole payload.
+    """
+    schema = SessionResponse.model_json_schema(mode=mode)["properties"]["duration"]
+    assert schema["type"] == "string"
+    assert "format" not in schema
+
+
+def test_session_duration_keeps_sub_second_precision():
+    """The wire value is unchanged: a sub-second ISO 8601 duration that round-trips."""
+    response = _session_response(dt.timedelta(seconds=41.286072))
+    serialized = response.model_dump(mode="json")["duration"]
+
+    assert serialized == "PT41.286072S"
+    # The value is deliberately outside the RFC 3339 grammar; that is why the
+    # `format` assertion is dropped rather than the precision.
+    assert RFC_3339_DURATION.match(serialized) is None
+    assert SessionResponse.model_validate_json(response.model_dump_json()).duration == response.duration


### PR DESCRIPTION
`SessionResponse.duration` is a `timedelta`, which Pydantic describes in JSON Schema as `{"type": "string", "format": "duration"}`.

JSON Schema defines the `duration` format as the ABNF in RFC 3339 Appendix A, where `dur-second = 1*DIGIT "S"` permits integer components only. Session durations are wall-clock deltas, so they serialize with sub-second precision:

```
PT41.286072S
```

That is valid ISO 8601 but not valid per the grammar the format points at. Clients that assert formats therefore reject a correct payload. With the MCP TypeScript SDK, which validates structured output against the tool's `outputSchema` using `ajv-formats`, every call carrying a `SessionResponse` fails:

```
MCP error -32602: Structured content does not match the tool's output schema:
  data/items/0/duration must match format "duration"
```

This affects `session_start`, `session_status`, `session_stop`, `list_sessions`, `page_observe` and `page_execute`. On `session_start` the session is created and returned successfully, but a strict client discards the result and never learns the `session_id`, so the session is left running until it times out.

This drops the `format` assertion rather than the precision:

- the field stays a `timedelta` in Python, with full precision
- the serialized value is unchanged (`PT41.286072S`)
- parsing is unchanged, still accepting ISO 8601 strings and bare seconds
- generated TypeScript is unchanged, as `format: duration` had no mapping there

Rounding to whole seconds would keep the format claim accurate, but it changes the wire value for every existing consumer and loses precision, so it seemed the worse trade.

Verified against the exact `ajv` configuration the MCP SDK uses:

```
before   PT41.286072S=false  PT0.141782S=false  PT0S=true
after    PT41.286072S=true   PT0.141782S=true   PT0S=true
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788595347&installation_model_id=8247&pr_number=886&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F886&signature=58d80869ef1519e0ec08830a901922bd3090abb79adda61d28d9bdaef05c284a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation of session duration values by removing an incompatible duration format constraint from the generated schema.
  * Preserved precise sub-second duration serialization and reliable round-trip behavior.

* **Tests**
  * Added coverage for duration schema validation, serialization, precision, and round-trip conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->