### PR TITLE
Fix blob downloads and flaky new-tab observation

### DIFF
--- a/packages/notte-browser/src/notte_browser/controller.py
+++ b/packages/notte-browser/src/notte_browser/controller.py
@@ -59,7 +59,7 @@ from notte_browser.errors import (
     capture_playwright_errors,
 )
 from notte_browser.form_filling import FormFiller
-from notte_browser.playwright_async_api import CDPSession, Locator
+from notte_browser.playwright_async_api import CDPSession, Frame, Locator, evaluate_in_main_world
 from notte_browser.window import BrowserWindow
 
 # Installed once per download action. Wraps URL.createObjectURL so we retain a
@@ -68,10 +68,9 @@ from notte_browser.window import BrowserWindow
 # Revocation only removes the URL->Blob mapping in the browser's registry;
 # our Map keeps the Blob object alive.
 #
-# Both snippets must run in the page's main world: the Blob is created by the
-# page's own script, and `page.evaluate` runs in an isolated world, where the
-# hook would patch a different `URL` and never observe the page's calls. Driving
-# them over CDP puts them in the main world and also sidesteps the page CSP.
+# Both snippets must run in the page's main world, where the Blob is created.
+# Chromium's top frame uses CDP; iframe and Firefox evaluation explicitly uses
+# the owning frame's page world rather than Patchright's default isolated world.
 _BLOB_CAPTURE_HOOK = """
 (() => {
   if (window.__notte_blob_capture) return;
@@ -138,11 +137,29 @@ async def _main_world_evaluate(cdp: CDPSession, expression: str, await_promise: 
     return cast("dict[str, Any]", result).get("value")
 
 
-async def _read_captured_blob(cdp: CDPSession, blob_url: str) -> str | None:
-    """Read a captured Blob's bytes from the page's main world, base64 encoded."""
-    expression = _BLOB_READ_SCRIPT.replace("__NOTTE_BLOB_URL__", json.dumps(blob_url))
-    value = await _main_world_evaluate(cdp, expression, await_promise=True)
-    return value if isinstance(value, str) else None
+async def _resolve_locator_frame(locator: Locator) -> Frame:
+    """Return the frame containing a locator without retaining its element handle."""
+    handle = await locator.element_handle()
+    try:
+        frame = await handle.owner_frame()
+    finally:
+        await handle.dispose()
+    if frame is None:
+        raise FailedToDownloadFileError()
+    return frame
+
+
+async def _evaluate_blob_expression(
+    frame: Frame,
+    expression: str,
+    *,
+    cdp: CDPSession | None = None,
+    await_promise: bool = False,
+) -> Any:
+    """Evaluate Blob capture code in the frame that owns the clicked locator."""
+    if cdp is not None:
+        return await _main_world_evaluate(cdp, expression, await_promise=await_promise)
+    return await evaluate_in_main_world(frame, expression)
 
 
 @final
@@ -474,16 +491,19 @@ class BrowserController:
                     # Install the blob-capture hook before the click so any
                     # URL.createObjectURL call inside the click handler has
                     # its Blob retained in our side map.
-                    cdp = await window.page.context.new_cdp_session(window.page) if window.is_chromium_based else None
+                    blob_frame = await _resolve_locator_frame(locator)
+                    is_main_frame = blob_frame == window.page.main_frame
+                    cdp = (
+                        await window.page.context.new_cdp_session(window.page)
+                        if window.is_chromium_based and is_main_frame
+                        else None
+                    )
                     try:
-                        if cdp is not None:
-                            _ = await _main_world_evaluate(cdp, _BLOB_CAPTURE_HOOK)
-                        else:
-                            # Firefox does not support CDP. Its native
-                            # page.evaluate calls share an execution world, so
-                            # keep downloads working without creating a
-                            # Chromium-only CDP session.
-                            _ = await window.page.evaluate(_BLOB_CAPTURE_HOOK)
+                        # CDP's default Runtime.evaluate context is the main
+                        # frame. For iframe locators (including cross-origin
+                        # frames), Frame.evaluate targets the owning frame's
+                        # main world directly. Firefox also uses this path.
+                        _ = await _evaluate_blob_expression(blob_frame, _BLOB_CAPTURE_HOOK, cdp=cdp)
 
                         async with window.page.expect_download() as dw:
                             await locator.click()
@@ -491,12 +511,14 @@ class BrowserController:
 
                         dl_url = download.url
                         if dl_url.startswith("blob:"):
-                            if cdp is not None:
-                                b64 = await _read_captured_blob(cdp, dl_url)
-                            else:
-                                expression = _BLOB_READ_SCRIPT.replace("__NOTTE_BLOB_URL__", json.dumps(dl_url))
-                                value = await window.page.evaluate(expression)
-                                b64 = value if isinstance(value, str) else None
+                            expression = _BLOB_READ_SCRIPT.replace("__NOTTE_BLOB_URL__", json.dumps(dl_url))
+                            value = await _evaluate_blob_expression(
+                                blob_frame,
+                                expression,
+                                cdp=cdp,
+                                await_promise=True,
+                            )
+                            b64 = value if isinstance(value, str) else None
                             if b64 is None:
                                 raise FailedToDownloadFileError()
                             file_bytes = base64.b64decode(b64)
@@ -508,18 +530,13 @@ class BrowserController:
                                 raise FailedToDownloadFileError()
                             file_bytes = await resp.body()
                     finally:
-                        if cdp is not None:
-                            try:
-                                _ = await _main_world_evaluate(cdp, _BLOB_CAPTURE_DISPOSE)
-                            except Exception as e:
-                                logger.warning(f"Failed to dispose the Blob capture hook: {e}")
-                            finally:
+                        try:
+                            _ = await _evaluate_blob_expression(blob_frame, _BLOB_CAPTURE_DISPOSE, cdp=cdp)
+                        except Exception as e:
+                            logger.warning(f"Failed to dispose the Blob capture hook: {e}")
+                        finally:
+                            if cdp is not None:
                                 await cdp.detach()
-                        else:
-                            try:
-                                _ = await window.page.evaluate(_BLOB_CAPTURE_DISPOSE)
-                            except Exception as e:
-                                logger.warning(f"Failed to dispose the Blob capture hook: {e}")
 
                     if not file_bytes:
                         raise FailedToDownloadFileError()

--- a/packages/notte-browser/src/notte_browser/controller.py
+++ b/packages/notte-browser/src/notte_browser/controller.py
@@ -1,6 +1,8 @@
 import base64
+import json
 import traceback
 from pathlib import Path
+from typing import Any, cast
 
 from notte_core.actions import (
     BaseAction,
@@ -57,7 +59,7 @@ from notte_browser.errors import (
     capture_playwright_errors,
 )
 from notte_browser.form_filling import FormFiller
-from notte_browser.playwright_async_api import Locator
+from notte_browser.playwright_async_api import CDPSession, Locator
 from notte_browser.window import BrowserWindow
 
 # Installed once per download action. Wraps URL.createObjectURL so we retain a
@@ -65,6 +67,11 @@ from notte_browser.window import BrowserWindow
 # bytes even after the page's URL.revokeObjectURL runs (file-saver.js pattern).
 # Revocation only removes the URL->Blob mapping in the browser's registry;
 # our Map keeps the Blob object alive.
+#
+# Both snippets must run in the page's main world: the Blob is created by the
+# page's own script, and `page.evaluate` runs in an isolated world, where the
+# hook would patch a different `URL` and never observe the page's calls. Driving
+# them over CDP puts them in the main world and also sidesteps the page CSP.
 _BLOB_CAPTURE_HOOK = """
 (() => {
   if (window.__notte_blob_capture) return;
@@ -81,7 +88,7 @@ _BLOB_CAPTURE_HOOK = """
 
 # Returns base64 so we can ferry bytes safely across CDP.
 _BLOB_READ_SCRIPT = """
-async (url) => {
+(async (url) => {
   const blob = window.__notte_blob_capture && window.__notte_blob_capture.get(url);
   if (!blob) return null;
   const buf = await blob.arrayBuffer();
@@ -92,8 +99,27 @@ async (url) => {
     binary += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
   }
   return btoa(binary);
-}
+})(__NOTTE_BLOB_URL__)
 """
+
+
+async def _main_world_evaluate(cdp: CDPSession, expression: str, await_promise: bool = False) -> Any:
+    """Evaluate an expression in the page's main world and return its value."""
+    response: dict[str, Any] = await cdp.send(  # pyright: ignore [reportUnknownMemberType]
+        "Runtime.evaluate",
+        {"expression": expression, "awaitPromise": await_promise, "returnByValue": True},
+    )
+    result: Any = response.get("result")
+    if not isinstance(result, dict):
+        return None
+    return cast("dict[str, Any]", result).get("value")
+
+
+async def _read_captured_blob(cdp: CDPSession, blob_url: str) -> str | None:
+    """Read a captured Blob's bytes from the page's main world, base64 encoded."""
+    expression = _BLOB_READ_SCRIPT.replace("__NOTTE_BLOB_URL__", json.dumps(blob_url))
+    value = await _main_world_evaluate(cdp, expression, await_promise=True)
+    return value if isinstance(value, str) else None
 
 
 @final
@@ -425,25 +451,29 @@ class BrowserController:
                     # Install the blob-capture hook before the click so any
                     # URL.createObjectURL call inside the click handler has
                     # its Blob retained in our side map.
-                    _ = await window.page.evaluate(_BLOB_CAPTURE_HOOK)
+                    cdp = await window.page.context.new_cdp_session(window.page)
+                    try:
+                        _ = await _main_world_evaluate(cdp, _BLOB_CAPTURE_HOOK)
 
-                    async with window.page.expect_download() as dw:
-                        await locator.click()
-                    download = await dw.value
+                        async with window.page.expect_download() as dw:
+                            await locator.click()
+                        download = await dw.value
 
-                    dl_url = download.url
-                    if dl_url.startswith("blob:"):
-                        b64 = await window.page.evaluate(_BLOB_READ_SCRIPT, dl_url)
-                        if b64 is None:
-                            raise FailedToDownloadFileError()
-                        file_bytes = base64.b64decode(b64)
-                    else:
-                        # page.request shares cookies/auth with the page, so
-                        # same-origin protected downloads work.
-                        resp = await window.page.request.get(dl_url)
-                        if resp.status >= 400:
-                            raise FailedToDownloadFileError()
-                        file_bytes = await resp.body()
+                        dl_url = download.url
+                        if dl_url.startswith("blob:"):
+                            b64 = await _read_captured_blob(cdp, dl_url)
+                            if b64 is None:
+                                raise FailedToDownloadFileError()
+                            file_bytes = base64.b64decode(b64)
+                        else:
+                            # page.request shares cookies/auth with the page, so
+                            # same-origin protected downloads work.
+                            resp = await window.page.request.get(dl_url)
+                            if resp.status >= 400:
+                                raise FailedToDownloadFileError()
+                            file_bytes = await resp.body()
+                    finally:
+                        await cdp.detach()
 
                     if not file_bytes:
                         raise FailedToDownloadFileError()

--- a/packages/notte-browser/src/notte_browser/controller.py
+++ b/packages/notte-browser/src/notte_browser/controller.py
@@ -75,16 +75,27 @@ from notte_browser.window import BrowserWindow
 _BLOB_CAPTURE_HOOK = """
 (() => {
   if (window.__notte_blob_capture) return;
-  const origCreate = URL.createObjectURL.bind(URL);
+  const origCreate = URL.createObjectURL;
   const blobs = new Map();
-  URL.createObjectURL = function (obj) {
-    const url = origCreate(obj);
+  const createObjectURL = function (obj) {
+    const url = origCreate.call(URL, obj);
     try { blobs.set(url, obj); } catch (e) {}
     return url;
   };
-  window.__notte_blob_capture = { get: (url) => blobs.get(url) || null };
+  URL.createObjectURL = createObjectURL;
+  window.__notte_blob_capture = {
+    get: (url) => blobs.get(url) || null,
+    clear: () => blobs.clear(),
+    dispose: () => {
+      blobs.clear();
+      if (URL.createObjectURL === createObjectURL) URL.createObjectURL = origCreate;
+      delete window.__notte_blob_capture;
+    },
+  };
 })();
 """
+
+_BLOB_CAPTURE_DISPOSE = "window.__notte_blob_capture?.dispose?.()"
 
 # Returns base64 so we can ferry bytes safely across CDP.
 _BLOB_READ_SCRIPT = """
@@ -105,10 +116,22 @@ _BLOB_READ_SCRIPT = """
 
 async def _main_world_evaluate(cdp: CDPSession, expression: str, await_promise: bool = False) -> Any:
     """Evaluate an expression in the page's main world and return its value."""
-    response: dict[str, Any] = await cdp.send(  # pyright: ignore [reportUnknownMemberType]
-        "Runtime.evaluate",
-        {"expression": expression, "awaitPromise": await_promise, "returnByValue": True},
+    raw_response = cast(
+        "object",
+        await cdp.send(  # pyright: ignore [reportUnknownMemberType]
+            "Runtime.evaluate",
+            {"expression": expression, "awaitPromise": await_promise, "returnByValue": True},
+        ),
     )
+    response = cast("dict[str, Any]", raw_response) if isinstance(raw_response, dict) else {}
+    raw_exception_details: Any = response.get("exceptionDetails")
+    if isinstance(raw_exception_details, dict):
+        exception_details = cast("dict[str, Any]", raw_exception_details)
+        raw_exception: Any = exception_details.get("exception")
+        exception = cast("dict[str, Any]", raw_exception) if isinstance(raw_exception, dict) else None
+        description = exception.get("description") if exception is not None else None
+        message = description if isinstance(description, str) else exception_details.get("text", "unknown error")
+        raise RuntimeError(f"CDP Runtime.evaluate failed: {message}")
     result: Any = response.get("result")
     if not isinstance(result, dict):
         return None
@@ -451,9 +474,16 @@ class BrowserController:
                     # Install the blob-capture hook before the click so any
                     # URL.createObjectURL call inside the click handler has
                     # its Blob retained in our side map.
-                    cdp = await window.page.context.new_cdp_session(window.page)
+                    cdp = await window.page.context.new_cdp_session(window.page) if window.is_chromium_based else None
                     try:
-                        _ = await _main_world_evaluate(cdp, _BLOB_CAPTURE_HOOK)
+                        if cdp is not None:
+                            _ = await _main_world_evaluate(cdp, _BLOB_CAPTURE_HOOK)
+                        else:
+                            # Firefox does not support CDP. Its native
+                            # page.evaluate calls share an execution world, so
+                            # keep downloads working without creating a
+                            # Chromium-only CDP session.
+                            _ = await window.page.evaluate(_BLOB_CAPTURE_HOOK)
 
                         async with window.page.expect_download() as dw:
                             await locator.click()
@@ -461,7 +491,12 @@ class BrowserController:
 
                         dl_url = download.url
                         if dl_url.startswith("blob:"):
-                            b64 = await _read_captured_blob(cdp, dl_url)
+                            if cdp is not None:
+                                b64 = await _read_captured_blob(cdp, dl_url)
+                            else:
+                                expression = _BLOB_READ_SCRIPT.replace("__NOTTE_BLOB_URL__", json.dumps(dl_url))
+                                value = await window.page.evaluate(expression)
+                                b64 = value if isinstance(value, str) else None
                             if b64 is None:
                                 raise FailedToDownloadFileError()
                             file_bytes = base64.b64decode(b64)
@@ -473,7 +508,18 @@ class BrowserController:
                                 raise FailedToDownloadFileError()
                             file_bytes = await resp.body()
                     finally:
-                        await cdp.detach()
+                        if cdp is not None:
+                            try:
+                                _ = await _main_world_evaluate(cdp, _BLOB_CAPTURE_DISPOSE)
+                            except Exception as e:
+                                logger.warning(f"Failed to dispose the Blob capture hook: {e}")
+                            finally:
+                                await cdp.detach()
+                        else:
+                            try:
+                                _ = await window.page.evaluate(_BLOB_CAPTURE_DISPOSE)
+                            except Exception as e:
+                                logger.warning(f"Failed to dispose the Blob capture hook: {e}")
 
                     if not file_bytes:
                         raise FailedToDownloadFileError()

--- a/packages/notte-browser/src/notte_browser/playwright_async_api.py
+++ b/packages/notte-browser/src/notte_browser/playwright_async_api.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING, Any, cast
+
 from notte_core.common.config import BrowserBackend, config
+
+if TYPE_CHECKING:
+    from patchright.async_api import Frame as PatchrightFrame
 from notte_core.common.logging import logger
 
 match config.browser_backend:
@@ -9,6 +14,7 @@ match config.browser_backend:
             CDPSession,
             ConsoleMessage,
             Error,
+            Frame,
             FrameLocator,
             Locator,
             Page,
@@ -26,6 +32,7 @@ match config.browser_backend:
             CDPSession,
             ConsoleMessage,
             Error,
+            Frame,
             FrameLocator,
             Locator,
             Page,
@@ -84,6 +91,14 @@ def getPlaywrightOrPatchrightError() -> tuple[type[Exception], type[Exception]] 
         raise RuntimeError("Unexpected number of errors")
 
 
+async def evaluate_in_main_world(frame: Frame, expression: str) -> Any:
+    """Evaluate JavaScript in a frame's page world for either browser backend."""
+    if config.browser_backend == BrowserBackend.PATCHRIGHT:
+        patchright_frame = cast("PatchrightFrame", frame)
+        return await patchright_frame.evaluate(expression, isolated_context=False)
+    return await frame.evaluate(expression)
+
+
 __all__ = [
     "Browser",
     "BrowserContext",
@@ -91,10 +106,12 @@ __all__ = [
     "async_playwright",
     "TimeoutError",
     "Error",
+    "Frame",
     "Locator",
     "Response",
     "Page",
     "CDPSession",
     "FrameLocator",
     "ConsoleMessage",
+    "evaluate_in_main_world",
 ]

--- a/tests/browser/test_controller_download.py
+++ b/tests/browser/test_controller_download.py
@@ -1,0 +1,41 @@
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from notte_browser.controller import _BLOB_CAPTURE_DISPOSE, _BLOB_CAPTURE_HOOK, _main_world_evaluate
+from notte_browser.playwright_async_api import CDPSession
+
+
+@pytest.mark.asyncio
+async def test_main_world_evaluate_returns_runtime_value() -> None:
+    cdp = AsyncMock()
+    cdp.send.return_value = {"result": {"value": "captured"}}
+
+    value = await _main_world_evaluate(cast("CDPSession", cdp), "expression", await_promise=True)
+
+    assert value == "captured"
+    cdp.send.assert_awaited_once_with(
+        "Runtime.evaluate",
+        {"expression": "expression", "awaitPromise": True, "returnByValue": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_main_world_evaluate_surfaces_javascript_errors() -> None:
+    cdp = AsyncMock()
+    cdp.send.return_value = {
+        "result": {"type": "object"},
+        "exceptionDetails": {
+            "text": "Uncaught",
+            "exception": {"description": "Error: blob read failed"},
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="CDP Runtime.evaluate failed: Error: blob read failed"):
+        _ = await _main_world_evaluate(cast("CDPSession", cdp), "expression")
+
+
+def test_blob_capture_hook_can_release_retained_blobs() -> None:
+    assert "clear: () => blobs.clear()" in _BLOB_CAPTURE_HOOK
+    assert "URL.createObjectURL = origCreate" in _BLOB_CAPTURE_HOOK
+    assert _BLOB_CAPTURE_DISPOSE == "window.__notte_blob_capture?.dispose?.()"

--- a/tests/browser/test_controller_download.py
+++ b/tests/browser/test_controller_download.py
@@ -2,8 +2,14 @@ from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
-from notte_browser.controller import _BLOB_CAPTURE_DISPOSE, _BLOB_CAPTURE_HOOK, _main_world_evaluate
-from notte_browser.playwright_async_api import CDPSession
+from notte_browser.controller import (
+    _BLOB_CAPTURE_DISPOSE,
+    _BLOB_CAPTURE_HOOK,
+    _evaluate_blob_expression,
+    _main_world_evaluate,
+    _resolve_locator_frame,
+)
+from notte_browser.playwright_async_api import CDPSession, Frame, Locator
 
 
 @pytest.mark.asyncio
@@ -31,8 +37,27 @@ async def test_main_world_evaluate_surfaces_javascript_errors() -> None:
         },
     }
 
-    with pytest.raises(RuntimeError, match="CDP Runtime.evaluate failed: Error: blob read failed"):
+    with pytest.raises(RuntimeError, match=r"^CDP Runtime\.evaluate failed: Error: blob read failed$"):
         _ = await _main_world_evaluate(cast("CDPSession", cdp), "expression")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("frame_url", ["https://top.example/frame", "https://cross-origin.example/frame"])
+async def test_blob_capture_uses_locator_owner_frame(frame_url: str) -> None:
+    frame = AsyncMock()
+    frame.url = frame_url
+    handle = AsyncMock()
+    handle.owner_frame.return_value = frame
+    locator = AsyncMock()
+    locator.element_handle.return_value = handle
+
+    resolved_frame = await _resolve_locator_frame(cast("Locator", locator))
+    value = await _evaluate_blob_expression(cast("Frame", resolved_frame), "expression")
+
+    assert resolved_frame is frame
+    assert value is frame.evaluate.return_value
+    frame.evaluate.assert_awaited_once_with("expression", isolated_context=False)
+    handle.dispose.assert_awaited_once_with()
 
 
 def test_blob_capture_hook_can_release_retained_blobs() -> None:

--- a/tests/browser/test_controller_download.py
+++ b/tests/browser/test_controller_download.py
@@ -42,10 +42,8 @@ async def test_main_world_evaluate_surfaces_javascript_errors() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("frame_url", ["https://top.example/frame", "https://cross-origin.example/frame"])
-async def test_blob_capture_uses_locator_owner_frame(frame_url: str) -> None:
+async def test_blob_capture_uses_locator_owner_frame() -> None:
     frame = AsyncMock()
-    frame.url = frame_url
     handle = AsyncMock()
     handle.owner_frame.return_value = frame
     locator = AsyncMock()

--- a/tests/integration/test_basic_scripts.py
+++ b/tests/integration/test_basic_scripts.py
@@ -58,8 +58,11 @@ async def test_observe_with_instructions() -> None:
         if len(actions) == 0:
             raise ValueError("No actions available")
         _ = await session.aexecute(actions[0])
-        obs = await session.aobserve()
+        # The console links carry target="_blank", so the click lands in a new
+        # tab. Switch before observing: the controller's own new-tab detection
+        # polls the page count after a short wait and can miss a slow open.
         _ = await session.aexecute(type="switch_tab", tab_index=-1)
+        obs = await session.aobserve()
         assert obs.metadata.url.startswith("https://console.notte.cc"), (
             f"Expected URL to start with https://console.notte.cc, got {obs.metadata.url}"
         )


### PR DESCRIPTION
Two integration failures, two independent causes.

## Blob downloads never worked

`download_file` on a button that builds its payload with `URL.createObjectURL` always failed with `FailedToDownloadFileError`.

The controller installed a capture hook that wraps `URL.createObjectURL`, then read the Blob back by URL after the click. Both ran through `page.evaluate`, which executes in an **isolated world**. The page's own script calls the real `URL.createObjectURL` in the main world, so the hook never saw a single call and the lookup map stayed empty:

```
DEBUG dl_url='blob:https://.../86cbf81a-...'
DEBUG hook_present=True
DEBUG keys=[]          # <- nothing ever captured
DEBUG b64=None         # -> FailedToDownloadFileError
```

Confirmed directly: a global set by the page's inline script is invisible to `page.evaluate`, and vice versa.

Both snippets now run over CDP `Runtime.evaluate`, which targets the main world. That also means they are not subject to the page's CSP, unlike an injected `<script>` tag.

Verified against all five download fixtures, byte-for-byte:

```
anchor_download_attr: OK (23 bytes)
blob_button:          OK (21 bytes)     <- was failing
raw_txt:              OK (23 bytes)
raw_jpg:              OK (1970107 bytes)
raw_pdf:              OK (223121 bytes)
```

## `test_observe_with_instructions` was racing

Every console link on the landing page carries `target="_blank"`, so the click always lands in a new tab. The test's `switch_tab` ran *after* `aobserve()`, so it could not affect the assertion - the observation was taken on whichever tab happened to be current. It passed only when the controller's own new-tab detection (which polls the page count after a short wait) won the race, and failed with `Expected URL to start with https://console.notte.cc, got https://www.notte.cc/` when it lost.

Moved the switch before the observation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788596797&installation_model_id=8247&pr_number=887&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F887&signature=75e795b365f144721303ff2355ed69bc3e54cda2e0bda71041a96fe0bf12f4bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blob-based download handling, including files created and revoked by page scripts.
  * Increased download reliability with improved cleanup after each download.
  * Preserved support for authenticated non-blob downloads across supported browsers.
  * Improved browser compatibility and error handling during download capture.

* **Tests**
  * Updated browser interaction coverage for links that open in new tabs.
  * Added coverage for download evaluation, error handling, cross-origin blobs, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->