### PR TITLE
fix: correct context-manager type annotations on `__exit__`/`__aexit__`

### DIFF
--- a/packages/notte-core/src/notte_core/common/resource.py
+++ b/packages/notte-core/src/notte_core/common/resource.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from types import TracebackType
 from typing import Self
 
 
@@ -19,9 +20,9 @@ class AsyncResource(ABC):
 
     async def __aexit__(
         self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: type[BaseException] | None,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         await self.astop()
 
@@ -45,6 +46,6 @@ class SyncResource(ABC):
         return self
 
     def __exit__(
-        self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: type[BaseException] | None
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
         self.stop()

--- a/packages/notte-integrations/src/notte_integrations/sessions/cdp_session.py
+++ b/packages/notte-integrations/src/notte_integrations/sessions/cdp_session.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from types import TracebackType
 
 from notte_browser.playwright import PlaywrightManager
 from notte_browser.playwright_async_api import Browser
@@ -49,7 +50,7 @@ class CDPSessionManager(PlaywrightManager, ABC):
         return self.notte_session.__enter__()
 
     def __exit__(
-        self, exc_type: type[BaseException], exc_value: BaseException, traceback: type[BaseException] | None
+        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None
     ) -> None:
         if self.notte_session is None or self.session is None:
             raise ValueError("Session not created")

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -2,6 +2,7 @@ import time
 from collections.abc import Sequence
 from enum import StrEnum
 from pathlib import Path
+from types import TracebackType
 from typing import TYPE_CHECKING, Any, Literal, Unpack, overload
 from webbrowser import open as open_browser
 
@@ -674,9 +675,9 @@ class RemoteSession(SyncResource):
 
     @override
     def __exit__(  # pyright: ignore [reportMissingSuperCall]
-        self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: type[BaseException] | None
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
-        if exc_val is not None:  # pyright: ignore [reportUnnecessaryComparison]
+        if exc_val is not None:
             logger.warning(f"Session exiting because of exception: {exc_val}")
 
         # Clean up sync playwright resources
@@ -704,12 +705,12 @@ class RemoteSession(SyncResource):
         return self
 
     async def __aexit__(
-        self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: type[BaseException] | None
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
         """
         Async context manager exit point with cleanup of async playwright resources.
         """
-        if exc_val is not None:  # pyright: ignore [reportUnnecessaryComparison]
+        if exc_val is not None:
             logger.warning(f"Session exiting because of exception: {exc_val}")
 
         # Clean up async playwright resources


### PR DESCRIPTION
## Problem

`ty check` rejects the canonical documented usage of the SDK:

```python
with client.Session() as session:
    ...
```

```
error[invalid-context-manager]: Object of type `RemoteSession` cannot be used with `with` because it does not correctly implement `__exit__`
 --> scratch.py:5:6
  |
5 | with client.Session() as session:
  |      ^^^^^^^^^^^^^^^^
info: Objects of type `RemoteSession` can be used as async context managers
info: Consider using `async with` here
```

The cause is the annotation on `RemoteSession.__exit__`:

```python
def __exit__(
    self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: type[BaseException] | None
) -> None:
```

Two things are wrong:

1. **`exc_type` and `exc_val` are not optional.** On a normal, non-exception exit Python calls `__exit__(None, None, None)`. The declared signature cannot accept that, so the class does not satisfy the sync context-manager protocol.
2. **`exc_tb` is typed `type[BaseException] | None`.** A traceback is not an exception class; it should be `types.TracebackType | None`.

`__aexit__` carried the identical mistake, as did the `SyncResource` / `AsyncResource` base classes in `notte-core` that `RemoteSession` overrides, and `CDPSessionManager.__exit__` in `notte-integrations`.

### Isolated repro

The optionality of the parameters is the whole cause — everything else identical:

```python
class Bad:
    def __exit__(self, t: type[BaseException], v: BaseException, tb: object) -> None: ...
class Good:
    def __exit__(self, t: type[BaseException] | None, v: BaseException | None, tb: object) -> None: ...

with Bad():  pass   # error[invalid-context-manager]
with Good(): pass   # clean
```

## Fix

Standard correct signature everywhere:

```python
def __exit__(
    self,
    exc_type: type[BaseException] | None,
    exc_val: BaseException | None,
    exc_tb: TracebackType | None,
) -> None:
```

Files touched:

- `packages/notte-core/src/notte_core/common/resource.py` — `SyncResource.__exit__` and `AsyncResource.__aexit__` (the base classes; had to be fixed too since `RemoteSession.__exit__` is `@override`)
- `packages/notte-sdk/src/notte_sdk/endpoints/sessions.py` — `RemoteSession.__exit__` and `__aexit__`
- `packages/notte-integrations/src/notte_integrations/sessions/cdp_session.py` — `CDPSessionManager.__exit__`

Also removed two now-unnecessary `# pyright: ignore [reportUnnecessaryComparison]` comments (see below).

**Annotations only — no runtime behaviour changed.** The runtime behaviour was already correct: both bodies start with `if exc_val is not None:`, which was *dead code under its own annotation*, and someone had silenced the resulting warning with `# pyright: ignore [reportUnnecessaryComparison]`. With the annotation fixed the comparison is meaningful and those ignores become unnecessary — verified: leaving them in makes basedpyright emit

```
sessions.py:680:53 - warning: Unnecessary "# pyright: ignore" rule: "reportUnnecessaryComparison" (reportUnnecessaryTypeIgnoreComment)
sessions.py:713:53 - warning: Unnecessary "# pyright: ignore" rule: "reportUnnecessaryComparison" (reportUnnecessaryTypeIgnoreComment)
```

so removing them is required, not cosmetic.

### Sites checked and deliberately left alone

- `packages/notte-agent/src/notte_agent/agent_fallback.py` — already correct (`| None` + `TracebackType`)
- `packages/notte-sdk/src/notte_sdk/agent_fallback.py` — already correct
- `packages/notte-sdk/src/notte_sdk/utils.py` (`LogCapture`) — uses `Any`; verified clean under `ty`, no churn

## Verification

**1. Repo's own type checker (basedpyright, via pre-commit) — passes.** The pre-push hook ran on the changed files:

```
basedpyright....................................................................Passed
0 errors, 0 warnings, 0 notes
```

Full-project run diffed against baseline shows **zero new and zero removed diagnostics** (53 errors / 706 warnings both before and after — all pre-existing and unrelated).

**2. Independent confirmation with `ty`** (`uv run --with ty ty check` against the patched source tree):

```
# before
error[invalid-context-manager]: Object of type `RemoteSession` cannot be used with `with` ...
Found 1 diagnostic

# after
All checks passed!
```

The fix also resolves two other context managers that were broken via the shared base class. Before:

```
error[invalid-context-manager]: Object of type `NotteSession` cannot be used with `with` ...
error[invalid-context-manager]: Object of type `SteelSessionsManager` cannot be used with `with` ...
Found 2 diagnostics
```

After: `All checks passed!`. Sync `with`, `async with`, and `LogCapture` all check clean.

**3. Tests** (`uv run pytest -n logical tests/sdk tests/browser tests/test_session.py`):

| | result |
|---|---|
| baseline (`origin/main`) | 6 failed, 244 passed, 4 skipped, 12 errors |
| patched | 7 failed, 243 passed, 4 skipped, 12 errors |

All failures in both runs are `notte_sdk.errors.AuthenticationError` / network-dependent (no API key in this environment). The one differing test, `test_step_should_succeed_after_observation`, failed with a timeout and **passes on re-run in isolation on the patched tree** — flaky, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788611815&installation_model_id=8247&pr_number=888&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F888&signature=e2f4c82ae3b86fb33bb25963ba490380ae284dd5e88a1929f4d29658befbc556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Python context managers by correctly handling cases where no exception occurs during synchronous or asynchronous cleanup.
  * Standardized exception and traceback handling across resources, sessions, and remote sessions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->