### PR TITLE
docs: document mp4_url on the session replay endpoint

### DIFF
--- a/docs/src/api-reference/using-session-replay.mdx
+++ b/docs/src/api-reference/using-session-replay.mdx
@@ -37,7 +37,7 @@ Example response:
   HLS playlist content with presigned segment URLs, for streaming playback.
 </ResponseField>
 
-<ResponseField name="expires_at" type="string">
+<ResponseField name="expires_at" type="string | null">
   When the presigned URLs expire. Download promptly if you need a durable copy.
 </ResponseField>
 

--- a/docs/src/api-reference/using-session-replay.mdx
+++ b/docs/src/api-reference/using-session-replay.mdx
@@ -1,0 +1,62 @@
+---
+title: Session Replay
+description: Use mp4_url from GET /sessions/{session_id}/replay to download recordings
+---
+import AgentMdNotice from '/partials/agent-md-notice.mdx';
+
+<AgentMdNotice />
+
+`GET /sessions/{session_id}/replay` returns presigned URLs for the session recording after the session has ended.
+
+The field most clients need is **`mp4_url`**: a time-limited presigned URL for the MP4 file. Use it to download or share the recording from any HTTP client (webhooks, CI, non-Python SDKs). Check `expires_at` for when the URL stops working.
+
+```bash
+curl "https://api.notte.cc/sessions/{session_id}/replay" \
+  -H "Authorization: Bearer $NOTTE_API_KEY"
+```
+
+Example response:
+
+```json
+{
+  "mp4_url": "https://storage.example.com/replays/session_abc.mp4?X-Amz-Signature=...",
+  "playlist_content": "#EXTM3U\n...",
+  "expires_at": "2026-08-06T18:00:00+00:00",
+  "video_start_ms": 0,
+  "video_duration_ms": 45200
+}
+```
+
+## Response fields
+
+<ResponseField name="mp4_url" type="string | null">
+  Presigned URL for downloading the session recording as an MP4. Prefer this when you need the video file itself.
+</ResponseField>
+
+<ResponseField name="playlist_content" type="string | null">
+  HLS playlist content with presigned segment URLs, for streaming playback.
+</ResponseField>
+
+<ResponseField name="expires_at" type="string">
+  When the presigned URLs expire. Download promptly if you need a durable copy.
+</ResponseField>
+
+<ResponseField name="video_start_ms" type="integer | null">
+  Video start offset in milliseconds.
+</ResponseField>
+
+<ResponseField name="video_duration_ms" type="integer | null">
+  Video duration in milliseconds.
+</ResponseField>
+
+<Tip>
+  From the Python SDK, the same payload is returned by `session.replay()` as a
+  <Visibility for="humans">[`ReplayResponse`](/sdk-reference/misc/replayresponse)</Visibility><Visibility for="agents">[`ReplayResponse`](/sdk-reference/misc/replayresponse.md)</Visibility>.
+  Use `replay.mp4_url` or `replay.download("session.mp4")`.
+</Tip>
+
+Interactive OpenAPI playground for this endpoint is available under the API tab
+(Sessions → Session Replay), generated from
+[https://api.notte.cc/openapi.json](https://api.notte.cc/openapi.json).
+
+See also [Session recordings](/features/sessions/recordings).

--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -178,7 +178,8 @@
                 "pages": [
                   "api-reference/authentication",
                   "api-reference/errors",
-                  "api-reference/rate-limits"
+                  "api-reference/rate-limits",
+                  "api-reference/using-session-replay"
                 ]
               }
             ],

--- a/docs/src/features/agents/replay.mdx
+++ b/docs/src/features/agents/replay.mdx
@@ -33,7 +33,8 @@ Debug agent executions with MP4 replays that show exactly what the agent saw and
 ## Agent Replay
 
 Get a visual replay of the agent's execution. The `session.replay()` method returns a
-`ReplayResponse` with a presigned URL you can use to download the MP4 file:
+`ReplayResponse` with **`mp4_url`** — a presigned URL for the MP4 — which you can
+pass around or download with `replay.download()`:
 
 <BasicReplay />
 

--- a/docs/src/features/sessions/recordings.mdx
+++ b/docs/src/features/sessions/recordings.mdx
@@ -15,7 +15,7 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 <AgentMdNotice />
 
-Notte automatically records every action in your browser sessions, allowing you to download video replays for debugging and analysis. Calling `session.replay()` returns a `ReplayResponse` containing a presigned URL for the MP4 file, which you can download with `replay.download()`.
+Notte automatically records every action in your browser sessions, allowing you to download video replays for debugging and analysis. Calling `session.replay()` (or `GET /sessions/{session_id}/replay`) returns a `ReplayResponse` with **`mp4_url`** — a presigned URL for the MP4 file. Use that URL directly, or download with `replay.download()`.
 
 ## Quick Start
 
@@ -38,6 +38,37 @@ Session recordings capture:
 ### Download as MP4
 
 <DownloadMp4 />
+
+### Replay response (`mp4_url`)
+
+The replay endpoint returns JSON. The field you usually want is `mp4_url`:
+
+| Field | Description |
+|-------|-------------|
+| `mp4_url` | Presigned URL to download the MP4 recording |
+| `playlist_content` | HLS playlist with presigned segment URLs (for streaming) |
+| `expires_at` | When the presigned URLs expire |
+| `video_start_ms` | Video start offset in milliseconds |
+| `video_duration_ms` | Video duration in milliseconds |
+
+REST example:
+
+```bash
+curl "https://api.notte.cc/sessions/{session_id}/replay" \
+  -H "Authorization: Bearer $NOTTE_API_KEY"
+```
+
+```json
+{
+  "mp4_url": "https://storage.example.com/replays/session_abc.mp4?X-Amz-Signature=...",
+  "playlist_content": "#EXTM3U\n...",
+  "expires_at": "2026-08-06T18:00:00+00:00",
+  "video_start_ms": 0,
+  "video_duration_ms": 45200
+}
+```
+
+Full API reference: <Visibility for="humans">[Session Replay](/api-reference/using-session-replay)</Visibility><Visibility for="agents">[Session Replay](/api-reference/using-session-replay.md)</Visibility>.
 
 ### Replay by Session ID
 
@@ -97,13 +128,13 @@ Remove old recordings to save disk space:
 
 Recordings are:
 - Stored on Notte's servers after the session ends
-- Accessed via presigned URLs (returned by `session.replay()`)
+- Accessed via the `mp4_url` (and optional HLS playlist) returned by `session.replay()` / `GET /sessions/{session_id}/replay`
 - **Retained for 24 hours**
-- Downloadable as MP4 via `replay.download()`
+- Downloadable as MP4 via `replay.download()` or by fetching `mp4_url`
 
 <Warning>
   Recordings are deleted after 24 hours. Download them promptly if needed for later analysis.
-  Presigned URLs also expire — check `replay.expires_at` for the expiration time.
+  Presigned URLs also expire — check `expires_at` (or `replay.expires_at` in the SDK) for the expiration time.
 </Warning>
 
 ## Next Steps

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -177,6 +177,7 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 - [Authentication](https://docs.notte.cc/api-reference/authentication.md): Authenticate with the Notte API
 - [API Error Codes](https://docs.notte.cc/api-reference/errors.md): API error responses and status codes
 - [Rate Limits](https://docs.notte.cc/api-reference/rate-limits.md): API rate limiting and response headers
+- [Session Replay](https://docs.notte.cc/api-reference/using-session-replay.md): Use mp4_url from GET /sessions/{session_id}/replay to download recordings
 
 ## Agents
 

--- a/docs/src/sdk-reference/misc/replayresponse.mdx
+++ b/docs/src/sdk-reference/misc/replayresponse.mdx
@@ -3,21 +3,16 @@ title: "ReplayResponse"
 description: "Response containing presigned URLs for session replay"
 ---
 
-Returned by `session.replay()`, `client.sessions.replay(session_id=...)`, and
-`GET /sessions/{session_id}/replay`.
 
-Use **`mp4_url`** when you need the recording file (download, upload to your own
-storage, or share a link). Prefer `playlist_content` for HLS streaming players.
-Call `download(path)` to fetch `mp4_url` into a local file.
 
 ## Fields
 
-<ParamField path="mp4_url" type="UnionType[str, None]">
-  Presigned URL for MP4 download. Time-limited; see `expires_at`.
-</ParamField>
-
 <ParamField path="playlist_content" type="UnionType[str, None]">
   HLS playlist content with presigned segment URLs
+</ParamField>
+
+<ParamField path="mp4_url" type="UnionType[str, None]">
+  Presigned URL for MP4 download
 </ParamField>
 
 <ParamField path="expires_at" type="UnionType[str, None]">
@@ -31,6 +26,7 @@ Call `download(path)` to fetch `mp4_url` into a local file.
 <ParamField path="video_duration_ms" type="UnionType[int, None]">
   Video duration in milliseconds
 </ParamField>
+
 
 ## Module
 

--- a/docs/src/sdk-reference/misc/replayresponse.mdx
+++ b/docs/src/sdk-reference/misc/replayresponse.mdx
@@ -3,16 +3,21 @@ title: "ReplayResponse"
 description: "Response containing presigned URLs for session replay"
 ---
 
+Returned by `session.replay()`, `client.sessions.replay(session_id=...)`, and
+`GET /sessions/{session_id}/replay`.
 
+Use **`mp4_url`** when you need the recording file (download, upload to your own
+storage, or share a link). Prefer `playlist_content` for HLS streaming players.
+Call `download(path)` to fetch `mp4_url` into a local file.
 
 ## Fields
 
-<ParamField path="playlist_content" type="UnionType[str, None]">
-  HLS playlist content with presigned segment URLs
+<ParamField path="mp4_url" type="UnionType[str, None]">
+  Presigned URL for MP4 download. Time-limited; see `expires_at`.
 </ParamField>
 
-<ParamField path="mp4_url" type="UnionType[str, None]">
-  Presigned URL for MP4 download
+<ParamField path="playlist_content" type="UnionType[str, None]">
+  HLS playlist content with presigned segment URLs
 </ParamField>
 
 <ParamField path="expires_at" type="UnionType[str, None]">
@@ -26,7 +31,6 @@ description: "Response containing presigned URLs for session replay"
 <ParamField path="video_duration_ms" type="UnionType[int, None]">
   Video duration in milliseconds
 </ParamField>
-
 
 ## Module
 

--- a/docs/src/snippets/agents/replay/basic_replay.mdx
+++ b/docs/src/snippets/agents/replay/basic_replay.mdx
@@ -12,6 +12,7 @@ with client.Session() as session:
 
 # Get MP4 replay (returns presigned URL)
 replay = session.replay()
+print(replay.mp4_url)  # Presigned URL for MP4 download
 
 # Download to file
 replay.download("agent_run.mp4")

--- a/docs/src/testers/agents/replay/basic_replay.py
+++ b/docs/src/testers/agents/replay/basic_replay.py
@@ -8,6 +8,7 @@ with client.Session() as session:
 
 # Get MP4 replay (returns presigned URL)
 replay = session.replay()
+print(replay.mp4_url)  # Presigned URL for MP4 download
 
 # Download to file
 replay.download("agent_run.mp4")


### PR DESCRIPTION
## Summary
- Document `mp4_url` (and the rest of the replay response) on the session recordings guide, including a REST curl example
- Add an API Getting Started page for `GET /sessions/{session_id}/replay` that highlights `mp4_url`
- Clarify `ReplayResponse` / agent replay docs and examples so the field is discoverable without inspecting a live response

## Test plan
- [ ] Preview docs and open Session recordings — confirm the new `mp4_url` section renders
- [ ] Open API → Getting Started → Session Replay and verify the curl/response example
- [ ] Confirm links from recordings → Session Replay and ReplayResponse resolve


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788613411&installation_model_id=8247&pr_number=889&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F889&signature=a360cf1b3cd67b85031325bdcf58062b6b9466db58a4ec07835d59d7f48d592b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Session Replay API reference covering MP4 downloads, HLS streaming, response fields, expiration details, timing metadata, cURL usage, Python examples, and the OpenAPI playground.
  - Expanded recording and SDK guidance for using presigned MP4 URLs, HLS content, and replay downloads.
  - Updated navigation and LLM documentation indexes.
  - Enhanced replay examples to display the returned MP4 URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->