### PR TITLE
Serialize local function run results as JSON

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -46,7 +46,7 @@ from notte_sdk.types import (
     UpdateFunctionRequestDict,
     UpdateFunctionRunResponse,
 )
-from notte_sdk.utils import LogCapture
+from notte_sdk.utils import LogCapture, serialize_function_run_result
 
 if TYPE_CHECKING:
     from notte_sdk.client import NotteClient
@@ -842,7 +842,7 @@ class RemoteWorkflow:
             _ = self.client.update_run(
                 function_id=self.function_id,
                 run_id=function_run_id,
-                result=str(result),
+                result=serialize_function_run_result(result),
                 variables=variables,
                 status=status,
                 session_id=log_capture.session_id,

--- a/packages/notte-sdk/src/notte_sdk/utils.py
+++ b/packages/notte-sdk/src/notte_sdk/utils.py
@@ -21,11 +21,12 @@ def serialize_function_run_result(result: Any) -> str:
     Pydantic models (and containers that hold them) must be stored as JSON, not
     Python ``str()`` / ``repr()``. Plain strings are kept as-is so error messages
     and already-serialized payloads are unchanged.
+
+    Any serialization failure falls back to ``str(result)`` so local runs still
+    persist a closed status even when a model field is not JSON-encodable.
     """
     if isinstance(result, str):
         return result
-    if isinstance(result, BaseModel):
-        return result.model_dump_json()
 
     def _default(obj: Any) -> Any:
         if isinstance(obj, BaseModel):
@@ -33,6 +34,8 @@ def serialize_function_run_result(result: Any) -> str:
         raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
     try:
+        if isinstance(result, BaseModel):
+            return result.model_dump_json()
         return json.dumps(result, default=_default)
     except (TypeError, ValueError):
         return str(result)

--- a/packages/notte-sdk/src/notte_sdk/utils.py
+++ b/packages/notte-sdk/src/notte_sdk/utils.py
@@ -10,8 +10,32 @@ from typing import Any, final
 
 from notte_core.actions import FormFillAction
 from notte_core.common.logging import logger
+from pydantic import BaseModel
 
 from notte_sdk.endpoints.sessions import RemoteSession
+
+
+def serialize_function_run_result(result: Any) -> str:
+    """Serialize a local function return value for `function_runs.result` (text).
+
+    Pydantic models (and containers that hold them) must be stored as JSON, not
+    Python ``str()`` / ``repr()``. Plain strings are kept as-is so error messages
+    and already-serialized payloads are unchanged.
+    """
+    if isinstance(result, str):
+        return result
+    if isinstance(result, BaseModel):
+        return result.model_dump_json()
+
+    def _default(obj: Any) -> Any:
+        if isinstance(obj, BaseModel):
+            return obj.model_dump(mode="json")
+        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+    try:
+        return json.dumps(result, default=_default)
+    except (TypeError, ValueError):
+        return str(result)
 
 
 @final

--- a/tests/sdk/test_serialize_function_run_result.py
+++ b/tests/sdk/test_serialize_function_run_result.py
@@ -1,0 +1,48 @@
+import json
+
+from notte_sdk.utils import serialize_function_run_result
+from pydantic import BaseModel
+
+
+class _UseCase(BaseModel):
+    id: str
+    slug: str
+
+
+class _Catalog(BaseModel):
+    use_cases: list[_UseCase]
+
+
+def test_serialize_pydantic_model_as_json() -> None:
+    result = _Catalog(use_cases=[_UseCase(id="1", slug="hipcamp")])
+
+    serialized = serialize_function_run_result(result)
+
+    assert json.loads(serialized) == {
+        "use_cases": [{"id": "1", "slug": "hipcamp"}],
+    }
+    assert "UseCase(" not in serialized
+
+
+def test_serialize_list_of_pydantic_models_as_json() -> None:
+    result = [_UseCase(id="1", slug="a"), _UseCase(id="2", slug="b")]
+
+    serialized = serialize_function_run_result(result)
+
+    assert json.loads(serialized) == [
+        {"id": "1", "slug": "a"},
+        {"id": "2", "slug": "b"},
+    ]
+
+
+def test_serialize_plain_dict_and_str_unchanged_shape() -> None:
+    assert json.loads(serialize_function_run_result({"a": 1})) == {"a": 1}
+    assert serialize_function_run_result("already a string") == "already a string"
+
+
+def test_serialize_non_json_object_falls_back_to_str() -> None:
+    class _Opaque:
+        def __str__(self) -> str:
+            return "opaque-value"
+
+    assert serialize_function_run_result(_Opaque()) == "opaque-value"

--- a/tests/sdk/test_serialize_function_run_result.py
+++ b/tests/sdk/test_serialize_function_run_result.py
@@ -46,3 +46,16 @@ def test_serialize_non_json_object_falls_back_to_str() -> None:
             return "opaque-value"
 
     assert serialize_function_run_result(_Opaque()) == "opaque-value"
+
+
+def test_serialize_model_with_unsupported_field_falls_back_to_str() -> None:
+    class _Bad:
+        def __str__(self) -> str:
+            return "bad-field"
+
+    class _Model(BaseModel):
+        model_config = {"arbitrary_types_allowed": True}
+        value: object
+
+    result = _Model(value=_Bad())
+    assert serialize_function_run_result(result) == str(result)


### PR DESCRIPTION
## Summary
- Local function runs that return a Pydantic model (or containers of models) now persist JSON via `model_dump_json` / `json.dumps` instead of Python `str()` / `repr()`.
- Plain strings are unchanged; non-JSON-serializable values still fall back to `str()`.

## Test plan
- [x] `uv run pytest tests/sdk/test_serialize_function_run_result.py`
- [ ] Run a function that returns a Pydantic model and confirm `function_runs.result` is valid JSON in the console

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788621390&installation_model_id=8247&pr_number=890&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F890&signature=fb8192a2c53368dbb8110fd32df0df0a814697f2589115d73906c0ed3c26b9cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow result handling to preserve strings and serialize structured results as JSON.
  * Added support for results containing Pydantic models, nested models, lists, and dictionaries.
  * Added a safe fallback for values that cannot be serialized as JSON.
  * Ensured locally executed workflow results are stored consistently for reliable retrieval and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->