### PR TITLE
fix(url): add timeout to is_valid_url reachability HEAD request

### DIFF
--- a/packages/notte-core/src/notte_core/utils/url.py
+++ b/packages/notte-core/src/notte_core/utils/url.py
@@ -55,7 +55,7 @@ def is_valid_url(url: str, check_reachability: bool = True) -> bool:
         if not check_reachability:
             return True
         # Send a HEAD request to the URL
-        response = requests.head(url, allow_redirects=True)
+        response = requests.head(url, allow_redirects=True, timeout=10)
         return response.status_code < 400  # Valid if status code is less than 400
     except requests.RequestException:
         return False


### PR DESCRIPTION
### Problem

`is_valid_url` in `notte_core/utils/url.py` does its reachability check with `requests.head(url, allow_redirects=True)` and no `timeout`. `requests` has no default timeout, so the call can block indefinitely on a slow or unresponsive host.

The one internal caller (`notte-browser/window.py`) passes `check_reachability=False`, so it does not hit this path, but `check_reachability=True` is the function's default, so any caller using the default (including SDK users) is exposed.

### Fix

Add a `timeout=10` to the HEAD request so an unresponsive URL fails the reachability check cleanly instead of hanging the caller.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788761817&installation_model_id=8247&pr_number=892&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F892&signature=7474680c5dbb47b08d07d15ea537ffa7cadec0174fffac99badfac4dcde50d8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URL validation requests now time out after 10 seconds, preventing checks from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->