### PR TITLE
feat(browser): recover Akamai soft denies

### DIFF
--- a/packages/notte-browser/src/notte_browser/errors.py
+++ b/packages/notte-browser/src/notte_browser/errors.py
@@ -2,6 +2,7 @@ import traceback
 from collections.abc import Awaitable
 from functools import wraps
 from typing import Any, Callable, TypeVar
+from urllib.parse import urlsplit
 
 from notte_core.actions import ToolAction
 from notte_core.common.config import config
@@ -37,6 +38,24 @@ class PageLoadingError(BrowserError):
             agent_message=(
                 f"Failed to load page from {url}. Hint: check if the URL is valid and reachable and wait a couple"
                 " seconds before retrying. Otherwise, try another URL."
+            ),
+            should_retry_later=True,
+        )
+
+
+class AkamaiSoftDenyExhaustedError(BrowserError):
+    def __init__(self, url: str, reloads: int) -> None:
+        hostname = urlsplit(url).hostname or "the target website"
+        super().__init__(
+            dev_message=(
+                f"Akamai continued to deny navigation to {hostname} after {reloads} internal reloads. "
+                "The browser completed the available soft-deny recovery attempts."
+            ),
+            user_message=(
+                f"The website at {hostname} temporarily denied access after the browser retried its verification."
+            ),
+            agent_message=(
+                f"Akamai is still denying access to {hostname}. Wait before retrying or use another proxy configuration."
             ),
             should_retry_later=True,
         )

--- a/packages/notte-browser/src/notte_browser/navigation_recovery.py
+++ b/packages/notte-browser/src/notte_browser/navigation_recovery.py
@@ -1,0 +1,70 @@
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+def _read_bounded_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {raw_value!r}") from exc
+
+    if not minimum <= value <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}, got {value}")
+    return value
+
+
+def _read_bool(name: str, default: bool) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+
+    normalized_value = raw_value.strip().lower()
+    if normalized_value in {"1", "true", "yes", "on"}:
+        return True
+    if normalized_value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean, got {raw_value!r}")
+
+
+@dataclass(frozen=True)
+class AkamaiSoftDenyRecoveryPolicy:
+    enabled: bool
+    max_reloads: int
+    settle_ms: int
+
+    @classmethod
+    def from_env(cls) -> "AkamaiSoftDenyRecoveryPolicy":
+        return cls(
+            enabled=_read_bool("AKAMAI_SOFT_DENY_RECOVERY_ENABLED", False),
+            max_reloads=_read_bounded_int("AKAMAI_SOFT_DENY_MAX_RELOADS", 3, minimum=0, maximum=5),
+            settle_ms=_read_bounded_int("AKAMAI_SOFT_DENY_SETTLE_MS", 3000, minimum=500, maximum=10000),
+        )
+
+
+AKAMAI_SOFT_DENY_RECOVERY_POLICY = AkamaiSoftDenyRecoveryPolicy.from_env()
+
+
+def is_akamai_soft_deny(*, status: int, headers: Mapping[str, str], body: str) -> bool:
+    if status != 403:
+        return False
+
+    normalized_headers = {name.lower(): value.lower() for name, value in headers.items()}
+    if "text/html" not in normalized_headers.get("content-type", ""):
+        return False
+    if "x-akamai-transformed" not in normalized_headers:
+        return False
+
+    normalized_body = body.lower()
+    return all(
+        marker in normalized_body
+        for marker in (
+            "access denied",
+            "you don't have permission",
+            "errors.edgesuite.net",
+        )
+    )

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Literal, Self
+from urllib.parse import urlsplit
 
 import httpx
 from notte_core.browser.dom_tree import A11yNode, A11yTree, DomNode
@@ -35,6 +36,7 @@ from typing_extensions import override
 
 from notte_browser.dom.parsing import dom_tree_parsers
 from notte_browser.errors import (
+    AkamaiSoftDenyExhaustedError,
     BrowserExpiredError,
     EmptyPageContentError,
     InvalidLocatorRuntimeError,
@@ -46,6 +48,7 @@ from notte_browser.errors import (
     RemoteDebuggingNotAvailableError,
     UnexpectedBrowserError,
 )
+from notte_browser.navigation_recovery import AKAMAI_SOFT_DENY_RECOVERY_POLICY, is_akamai_soft_deny
 from notte_browser.playwright_async_api import CDPSession, Locator, Page, Response
 
 
@@ -589,24 +592,22 @@ class BrowserWindow(BaseModel):
         def is_default_page():
             return self.page.url == "about:blank" and not url == "about:blank"
 
-        def on_response(resp: Response) -> None:
-            """Store the response so its available for exception handling."""
-            self.goto_response = resp
-
         while True:
             self.goto_response = None
-            self.page.once("response", on_response)
             tries -= 1
 
             try:
+                response: Response | None
                 match operation:
                     case None:
                         assert url is not None, "URL is required for goto"
-                        _ = await self.page.goto(url, timeout=config.timeout_goto_ms)
+                        response = await self.page.goto(url, timeout=config.timeout_goto_ms)
                     case "back":
-                        _ = await self.page.go_back(timeout=config.timeout_goto_ms)
+                        response = await self.page.go_back(timeout=config.timeout_goto_ms)
                     case "forward":
-                        _ = await self.page.go_forward(timeout=config.timeout_goto_ms)
+                        response = await self.page.go_forward(timeout=config.timeout_goto_ms)
+                if response is not None:
+                    self.goto_response = response
                 if self.goto_response is not None:
                     logger.info(
                         f"Goto for {url=} succeeded with HTTP {self.goto_response.status}: {self.goto_response.status_text}"
@@ -631,6 +632,9 @@ class BrowserWindow(BaseModel):
             # to make extra element visible
             await self.short_wait()
 
+            if operation is None and url is not None:
+                self.goto_response = await self._recover_akamai_soft_deny(url, self.goto_response)
+
             if not is_default_page() or tries < 0:
                 break
 
@@ -638,8 +642,6 @@ class BrowserWindow(BaseModel):
             raise PageLoadingError(url=url or self.page.url)
 
     async def goto(self, url: str, tries: int = 3) -> None:
-        if url == self.page.url:
-            return
         prefixes = ("http://", "https://")
 
         if not any(url.startswith(prefix) for prefix in prefixes):
@@ -649,7 +651,73 @@ class BrowserWindow(BaseModel):
         if not is_valid_url(url, check_reachability=False):
             raise InvalidURLError(url=url)
 
+        if url == self.page.url and not await self._is_akamai_soft_deny(self.goto_response):
+            return
+
         await self.goto_and_wait(url=url, tries=tries, operation=None)
+
+    async def _is_akamai_soft_deny(self, response: Response | None) -> bool:
+        if not AKAMAI_SOFT_DENY_RECOVERY_POLICY.enabled or response is None:
+            return False
+
+        try:
+            body = await response.text()
+        except Exception:
+            # Detection is intentionally fail-open: an unreadable response must retain
+            # the existing navigation behavior instead of becoming a false soft deny.
+            logger.debug("Unable to read a 403 response body while checking for an Akamai soft deny")
+            return False
+
+        return is_akamai_soft_deny(status=response.status, headers=response.headers, body=body)
+
+    async def _recover_akamai_soft_deny(self, url: str, response: Response | None) -> Response | None:
+        if not await self._is_akamai_soft_deny(response):
+            return response
+
+        hostname = urlsplit(url).hostname or "unknown"
+        started_at = time.monotonic()
+        logger.warning(f"Akamai soft deny detected for host={hostname}; starting transparent recovery")
+
+        for reload_number in range(1, AKAMAI_SOFT_DENY_RECOVERY_POLICY.max_reloads + 1):
+            wait_message = (
+                f"Waiting for Akamai browser telemetry before reload host={hostname} reload={reload_number}/"
+                + f"{AKAMAI_SOFT_DENY_RECOVERY_POLICY.max_reloads}"
+            )
+            logger.info(wait_message)
+            await self.page.wait_for_timeout(AKAMAI_SOFT_DENY_RECOVERY_POLICY.settle_ms)
+
+            try:
+                response = await self.page.reload(timeout=config.timeout_goto_ms)
+            except PlaywrightTimeoutError as exc:
+                raise PageLoadingError(url=url) from exc
+
+            if response is None:
+                raise PageLoadingError(url=url)
+
+            self.goto_response = response
+            if not await self._is_akamai_soft_deny(response):
+                elapsed_ms = round((time.monotonic() - started_at) * 1000)
+                if response.status < HTTPStatus.BAD_REQUEST:
+                    recovered_message = (
+                        f"Akamai soft deny recovered host={hostname} reloads={reload_number} status={response.status} "
+                        + f"elapsed_ms={elapsed_ms}"
+                    )
+                    logger.info(recovered_message)
+                else:
+                    stopped_message = (
+                        f"Akamai soft deny recovery stopped on a different response host={hostname} "
+                        + f"reloads={reload_number} status={response.status} elapsed_ms={elapsed_ms}"
+                    )
+                    logger.warning(stopped_message)
+                return response
+
+        elapsed_ms = round((time.monotonic() - started_at) * 1000)
+        exhausted_message = (
+            f"Akamai soft deny recovery exhausted host={hostname} "
+            + f"reloads={AKAMAI_SOFT_DENY_RECOVERY_POLICY.max_reloads} elapsed_ms={elapsed_ms}"
+        )
+        logger.warning(exhausted_message)
+        raise AkamaiSoftDenyExhaustedError(url=url, reloads=AKAMAI_SOFT_DENY_RECOVERY_POLICY.max_reloads)
 
     async def set_cookies(self, cookies: list[CookieDict] | None = None, cookie_path: str | Path | None = None) -> None:
         if cookies is None and cookie_path is not None:

--- a/tests/browser/test_akamai_soft_deny_recovery.py
+++ b/tests/browser/test_akamai_soft_deny_recovery.py
@@ -1,0 +1,220 @@
+from types import SimpleNamespace
+
+import notte_browser.window as window_module
+import pytest
+from notte_browser.errors import AkamaiSoftDenyExhaustedError
+from notte_browser.navigation_recovery import AkamaiSoftDenyRecoveryPolicy, is_akamai_soft_deny
+from notte_browser.window import BrowserWindow
+
+AKAMAI_DENY_BODY = """
+<html><body>
+<h1>Access Denied</h1>
+You don't have permission to access this page.
+https://errors.edgesuite.net/18.example
+</body></html>
+"""
+AKAMAI_DENY_HEADERS = {
+    "Content-Type": "text/html; charset=utf-8",
+    "X-Akamai-Transformed": "0 - 0 -",
+}
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        status: int,
+        *,
+        body: str = "",
+        headers: dict[str, str] | None = None,
+        url: str = "https://www.opentable.com/",
+    ) -> None:
+        self.status = status
+        self.status_text = "OK" if status == 200 else "Forbidden"
+        self.headers = headers or {"content-type": "text/html"}
+        self.url = url
+        self._body = body
+
+    async def text(self) -> str:
+        return self._body
+
+
+class UnreadableResponse(FakeResponse):
+    async def text(self) -> str:
+        raise RuntimeError("response body unavailable")
+
+
+class FakePage:
+    def __init__(
+        self,
+        *,
+        url: str = "https://www.opentable.com/",
+        goto_response: FakeResponse | None = None,
+        reload_responses: list[FakeResponse | None] | None = None,
+    ) -> None:
+        self.url = url
+        self.goto_response = goto_response
+        self.reload_responses = list(reload_responses or [])
+        self.goto_calls: list[tuple[str, int]] = []
+        self.reload_calls: list[int] = []
+        self.wait_calls: list[int] = []
+        self.default_timeout: int | None = None
+        self.callbacks: dict[str, object] = {}
+
+    def set_default_timeout(self, timeout: int) -> None:
+        self.default_timeout = timeout
+
+    def on(self, event: str, callback: object) -> None:
+        self.callbacks[event] = callback
+
+    def is_closed(self) -> bool:
+        return False
+
+    async def goto(self, url: str, *, timeout: int) -> FakeResponse | None:
+        self.goto_calls.append((url, timeout))
+        self.url = url
+        return self.goto_response
+
+    async def go_back(self, *, timeout: int) -> None:
+        return None
+
+    async def go_forward(self, *, timeout: int) -> None:
+        return None
+
+    async def reload(self, *, timeout: int) -> FakeResponse | None:
+        self.reload_calls.append(timeout)
+        return self.reload_responses.pop(0)
+
+    async def wait_for_timeout(self, timeout: int) -> None:
+        self.wait_calls.append(timeout)
+
+
+def denied_response() -> FakeResponse:
+    return FakeResponse(403, body=AKAMAI_DENY_BODY, headers=AKAMAI_DENY_HEADERS)
+
+
+def make_window(page: FakePage) -> BrowserWindow:
+    resource = SimpleNamespace(page=page)
+    return BrowserWindow.model_construct(resource=resource, page_callbacks={})
+
+
+@pytest.mark.parametrize(
+    ("status", "headers", "body"),
+    [
+        (200, AKAMAI_DENY_HEADERS, AKAMAI_DENY_BODY),
+        (403, {"content-type": "application/json", "x-akamai-transformed": "0 - 0 -"}, AKAMAI_DENY_BODY),
+        (403, {"content-type": "text/html"}, AKAMAI_DENY_BODY),
+        (403, AKAMAI_DENY_HEADERS, "Access Denied"),
+    ],
+)
+def test_akamai_soft_deny_detector_rejects_incomplete_signatures(
+    status: int, headers: dict[str, str], body: str
+) -> None:
+    assert not is_akamai_soft_deny(status=status, headers=headers, body=body)
+
+
+def test_akamai_soft_deny_detector_matches_captured_signature() -> None:
+    assert is_akamai_soft_deny(status=403, headers=AKAMAI_DENY_HEADERS, body=AKAMAI_DENY_BODY)
+
+
+def test_akamai_recovery_policy_validates_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AKAMAI_SOFT_DENY_RECOVERY_ENABLED", "yes")
+    monkeypatch.setenv("AKAMAI_SOFT_DENY_MAX_RELOADS", "5")
+    monkeypatch.setenv("AKAMAI_SOFT_DENY_SETTLE_MS", "500")
+
+    assert AkamaiSoftDenyRecoveryPolicy.from_env() == AkamaiSoftDenyRecoveryPolicy(
+        enabled=True,
+        max_reloads=5,
+        settle_ms=500,
+    )
+
+    monkeypatch.setenv("AKAMAI_SOFT_DENY_MAX_RELOADS", "6")
+    with pytest.raises(ValueError, match="AKAMAI_SOFT_DENY_MAX_RELOADS must be between 0 and 5"):
+        AkamaiSoftDenyRecoveryPolicy.from_env()
+
+
+@pytest.mark.asyncio
+async def test_recovery_reloads_same_page_until_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    policy = AkamaiSoftDenyRecoveryPolicy(enabled=True, max_reloads=3, settle_ms=750)
+    monkeypatch.setattr(window_module, "AKAMAI_SOFT_DENY_RECOVERY_POLICY", policy)
+    successful_response = FakeResponse(200, body="OpenTable")
+    page = FakePage(reload_responses=[denied_response(), successful_response])
+    window = make_window(page)
+
+    result = await window._recover_akamai_soft_deny(page.url, denied_response())  # pyright: ignore[reportPrivateUsage]
+
+    assert result is successful_response
+    assert window.goto_response is successful_response
+    assert page.wait_calls == [750, 750]
+    assert len(page.reload_calls) == 2
+    assert window.page is page
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    policy = AkamaiSoftDenyRecoveryPolicy(enabled=False, max_reloads=3, settle_ms=750)
+    monkeypatch.setattr(window_module, "AKAMAI_SOFT_DENY_RECOVERY_POLICY", policy)
+    initial_response = denied_response()
+    page = FakePage(reload_responses=[FakeResponse(200)])
+    window = make_window(page)
+
+    result = await window._recover_akamai_soft_deny(page.url, initial_response)  # pyright: ignore[reportPrivateUsage]
+
+    assert result is initial_response
+    assert page.wait_calls == []
+    assert page.reload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_fail_open_when_response_body_is_unreadable(monkeypatch: pytest.MonkeyPatch) -> None:
+    policy = AkamaiSoftDenyRecoveryPolicy(enabled=True, max_reloads=3, settle_ms=750)
+    monkeypatch.setattr(window_module, "AKAMAI_SOFT_DENY_RECOVERY_POLICY", policy)
+    initial_response = UnreadableResponse(403, headers=AKAMAI_DENY_HEADERS)
+    page = FakePage(reload_responses=[FakeResponse(200)])
+    window = make_window(page)
+
+    result = await window._recover_akamai_soft_deny(page.url, initial_response)  # pyright: ignore[reportPrivateUsage]
+
+    assert result is initial_response
+    assert page.wait_calls == []
+    assert page.reload_calls == []
+
+
+@pytest.mark.asyncio
+async def test_recovery_raises_retryable_error_when_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    policy = AkamaiSoftDenyRecoveryPolicy(enabled=True, max_reloads=3, settle_ms=500)
+    monkeypatch.setattr(window_module, "AKAMAI_SOFT_DENY_RECOVERY_POLICY", policy)
+    page = FakePage(reload_responses=[denied_response(), denied_response(), denied_response()])
+    window = make_window(page)
+
+    with pytest.raises(AkamaiSoftDenyExhaustedError) as exc_info:
+        await window._recover_akamai_soft_deny(page.url, denied_response())  # pyright: ignore[reportPrivateUsage]
+
+    assert exc_info.value.should_retry_later
+    assert page.wait_calls == [500, 500, 500]
+    assert len(page.reload_calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_goto_retries_same_url_after_soft_deny(monkeypatch: pytest.MonkeyPatch) -> None:
+    policy = AkamaiSoftDenyRecoveryPolicy(enabled=True, max_reloads=3, settle_ms=500)
+    monkeypatch.setattr(window_module, "AKAMAI_SOFT_DENY_RECOVERY_POLICY", policy)
+    page = FakePage(goto_response=FakeResponse(200, body="OpenTable"))
+    window = make_window(page)
+    window.goto_response = denied_response()  # pyright: ignore[reportAttributeAccessIssue]
+
+    await window.goto(page.url)
+
+    assert len(page.goto_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_goto_keeps_same_url_noop_for_normal_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    policy = AkamaiSoftDenyRecoveryPolicy(enabled=True, max_reloads=3, settle_ms=500)
+    monkeypatch.setattr(window_module, "AKAMAI_SOFT_DENY_RECOVERY_POLICY", policy)
+    page = FakePage(goto_response=FakeResponse(200, body="OpenTable"))
+    window = make_window(page)
+    window.goto_response = FakeResponse(200, body="OpenTable")  # pyright: ignore[reportAttributeAccessIssue]
+
+    await window.goto(page.url)
+
+    assert page.goto_calls == []


### PR DESCRIPTION
## Summary

- detect the specific Akamai Access Denied response signature observed on initial navigation
- optionally wait and reload the same page a bounded number of times
- raise a retryable typed error when recovery is exhausted
- keep the behavior disabled by default and configurable through environment variables

## Configuration

- `AKAMAI_SOFT_DENY_RECOVERY_ENABLED` (default: `false`)
- `AKAMAI_SOFT_DENY_MAX_RELOADS` (default: `3`, maximum: `5`)
- `AKAMAI_SOFT_DENY_SETTLE_MS` (default: `3000`)

## Testing

- `uv run pytest tests/browser/test_akamai_soft_deny_recovery.py`
- `uv run ruff check packages/notte-browser/src/notte_browser/navigation_recovery.py packages/notte-browser/src/notte_browser/window.py packages/notte-browser/src/notte_browser/errors.py tests/browser/test_akamai_soft_deny_recovery.py`
- full browser suite: 66 passed, 3 skipped, with one unrelated existing Google selector failure in `test_screenshot_types.py`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789135008&installation_model_id=8247&pr_number=894&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F894&signature=b93880e352ecae2705860072b70817aef6e86c893d7de0b77039e09b00a495ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->