### PR TITLE
Fix incorrect return annotation on StructuredData.get()

### DIFF
--- a/examples/scrape-logo/agent.py
+++ b/examples/scrape-logo/agent.py
@@ -32,10 +32,11 @@ def scrape_logo_url(url: str) -> str | None:
             # Do not raise on failure, we want to handle the case where no logo is found
             raise_on_failure=False,
         )
-        if data.success:
+        logo = data.get() if data.success else None
+        if isinstance(logo, Logo):
             # Case 1: structured output worked
-            logger.info(f"Logo found for {url}: {data.get().get_url(url)}")
-            return data.get().get_url(url)
+            logger.info(f"Logo found for {url}: {logo.get_url(url)}")
+            return logo.get_url(url)
         images = session.scrape(only_images=True)
         for image in images:
             # Case 2: there is a logo image in data.images

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -1038,11 +1038,11 @@ class NotteSession(AsyncResource, SyncResource):
         **params: Unpack[ScrapeMarkdownParamsDict],
     ) -> StructuredData[TBaseModel]: ...
 
-    # instructions only, raise_on_failure=True (default) -> unwrapped BaseModel
+    # instructions only, raise_on_failure=True (default) -> unwrapped BaseModel as dict
     @overload
     async def ascrape(
         self, *, instructions: str, raise_on_failure: Literal[True] = ..., **params: Unpack[ScrapeMarkdownParamsDict]
-    ) -> BaseModel: ...
+    ) -> dict[str, Any]: ...
 
     # instructions only, raise_on_failure=False -> wrapped StructuredData[BaseModel]
     @overload
@@ -1058,7 +1058,7 @@ class NotteSession(AsyncResource, SyncResource):
     @track_usage("local.session.scrape")
     async def ascrape(
         self, *, raise_on_failure: bool = True, **params: Unpack[ScrapeParamsDict]
-    ) -> StructuredData[BaseModel] | BaseModel | str | list[ImageData]:
+    ) -> StructuredData[BaseModel] | BaseModel | dict[str, Any] | str | list[ImageData]:
         # Extract and convert response_format for the action (store as JSON schema)
         response_format = params.get("response_format")
         instructions = params.get("instructions")

--- a/packages/notte-core/src/notte_core/data/space.py
+++ b/packages/notte-core/src/notte_core/data/space.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Annotated, Any, Generic, Self, TypeVar
+from typing import Annotated, Any, Generic, Self, TypeVar, cast
 
 import requests
 from pydantic import BaseModel, Field, RootModel, model_serializer, model_validator
@@ -91,13 +91,22 @@ class StructuredData(BaseModel, Generic[TBaseModel]):
             result["data"] = self.data
         return result
 
-    def get(self) -> TBaseModel:
-        """Get the extracted data, raising ScrapeFailedError if extraction failed."""
+    def get(self) -> TBaseModel | dict[str, Any]:
+        """Get the extracted data, raising ScrapeFailedError if extraction failed.
+
+        Returns the validated model when the data was extracted against a user-provided
+        schema. When no schema was provided the payload is stored as a `DictBaseModel`
+        (i.e. `RootModel`) wrapper and this returns the unwrapped plain JSON object, which
+        is *not* a `BaseModel`. Callers must handle both shapes, e.g. by guarding with
+        `isinstance(data, BaseModel)` before calling `model_dump()`.
+        """
         if not self.success or self.data is None:
             raise ScrapeFailedError(self.error or "Unknown extraction error")
-        if isinstance(self.data, RootModel):
-            return self.data.root  # type: ignore[attr-defined]
-        return self.data
+        # local alias: keeps the narrowed type checkable instead of `RootModel[Unknown]`
+        data: TBaseModel | DictBaseModel = self.data
+        if isinstance(data, RootModel):
+            return cast(dict[str, Any], data.root)
+        return data
 
 
 class DataSpace(BaseModel):

--- a/packages/notte-sdk/src/notte_sdk/endpoints/page.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/page.py
@@ -208,7 +208,7 @@ class PageClient(BaseClient):
                 # Validate against response_format if provided
                 if request.response_format is not None:
                     extracted_data_dict = (
-                        extracted_data.model_dump() if isinstance(extracted_data, BaseModel) else extracted_data  # pyright: ignore[reportUnnecessaryIsInstance]
+                        extracted_data.model_dump() if isinstance(extracted_data, BaseModel) else extracted_data
                     )
                     extracted_data = request.response_format.model_validate(extracted_data_dict)
                 return extracted_data

--- a/tests/test_structured_data.py
+++ b/tests/test_structured_data.py
@@ -1,0 +1,51 @@
+import pytest
+from notte_core.data.space import DataSpace, StructuredData
+from notte_core.errors.processing import ScrapeFailedError
+from pydantic import BaseModel, RootModel
+
+
+class Verification(BaseModel):
+    status: str
+    code: str | None = None
+
+
+def test_get_returns_plain_dict_for_dict_payload():
+    """A dict payload is wrapped in a RootModel, so `get()` returns the unwrapped dict."""
+    structured = StructuredData(success=True, data={"status": "found", "code": "463092"})
+
+    assert isinstance(structured.data, RootModel)
+    data = structured.get()
+    assert isinstance(data, dict)
+    assert not isinstance(data, BaseModel)
+    assert data == {"status": "found", "code": "463092"}
+
+
+def test_get_returns_model_for_model_payload():
+    """A model payload is returned as-is, so `get()` returns a `BaseModel`."""
+    structured = StructuredData[Verification](success=True, data=Verification(status="found", code="463092"))
+
+    data = structured.get()
+    assert isinstance(data, Verification)
+    assert data.model_dump() == {"status": "found", "code": "463092"}
+
+
+def test_get_returns_plain_dict_for_deserialized_response():
+    """Structured data deserialized from a JSON response also yields a plain dict."""
+    space = DataSpace.model_validate(
+        {
+            "markdown": "# page",
+            "structured": {"success": True, "error": None, "data": {"status": "found", "code": "463092"}},
+        }
+    )
+
+    assert space.structured is not None
+    data = space.structured.get()
+    assert isinstance(data, dict)
+    assert data == {"status": "found", "code": "463092"}
+
+
+def test_get_raises_on_failed_extraction():
+    structured = StructuredData[Verification](success=False, error="boom", data=None)
+
+    with pytest.raises(ScrapeFailedError):
+        _ = structured.get()


### PR DESCRIPTION
## The bug

`StructuredData.get()` was annotated `-> TBaseModel` (bound to `BaseModel`), but when `data` holds a `DictBaseModel` (which is `RootModel[Any]` — what the `wrap_dict_in_root_model` before-validator produces for any dict/list payload) it returns `self.data.root`, i.e. the unwrapped **plain dict**. The `# type: ignore[attr-defined]` sat on exactly that line and hid the mismatch.

Measured against `main`:

```
sd = StructuredData(success=True, data={"status": "found", "code": "463092"})
field type after validation: RootModel[Any]
get() returns             : dict
is it a BaseModel?        : False
has .model_dump?          : False
```

whereas `StructuredData[Verification](success=True, data=Verification(status="found")).get()` correctly returns `Verification`.

Callers that trust the annotation and write `result.data.structured.get().model_dump()` get an `AttributeError` at runtime whenever the payload was raw JSON. And a type checker actively works against the correct code: `packages/notte-sdk/src/notte_sdk/endpoints/page.py` had to carry a `# pyright: ignore[reportUnnecessaryIsInstance]` on its `isinstance(extracted_data, BaseModel)` guard, because basedpyright believed the annotation and called the (necessary) check redundant.

## Is the dict path reachable from real responses?

Yes — verified two ways locally, though **not** against the live API:

- `ScrapeResponse` is `DataSpace`, whose `structured` is a `StructuredData[BaseModel]`. Deserializing an API-shaped body — `{"markdown": ..., "structured": {"success": true, "data": {"status": "found"}}}` — via `ScrapeResponse.model_validate` puts a `RootModel[Any]` in `structured.data`, and `.get()` returns a plain `dict`.
- `SchemaScrapingPipe.forward` (`packages/notte-browser/src/notte_browser/scraping/schema.py`) requests `StructuredData[DictBaseModel]` from the LLM whenever no `response_format` was given, so the local scrape path produces the same shape.

So any `scrape(instructions=...)` without a `response_format` lands on the dict branch. I did not confirm this against a live API call — only against the response models and pipes in this repo.

## Which fix, and why

Two candidates were considered:

1. **Widen the annotation** to `TBaseModel | dict[str, Any]` and drop the `type: ignore`.
2. **Stop unwrapping** the `RootModel`, so `get()` genuinely returns a model.

**Option 1 was chosen**, because option 2 is a runtime behaviour change that breaks existing callers. Call sites checked:

| Call site | Expects |
| --- | --- |
| `packages/notte-sdk/src/notte_sdk/endpoints/page.py:207` (`raise_on_failure=True`) | Returns `structured.get()` straight to the user. The instructions-only overload is declared `-> dict[str, Any]`, and `typing_cases/scrape_overloads.py` + `tests/sdk/test_scrape_overload_typing.py` assert that reveal type. Would break under option 2. |
| `packages/notte-browser/src/notte_browser/session.py:1134` (local `ascrape`) | Same: returns `data.structured.get()` to the user; the sync `scrape` overload declares `dict[str, Any]`. Would break under option 2. |
| `tests/pipe/scraping/test_schema.py:258` | `data = result.get()` then `assert isinstance(data, dict)` and `data["hotels"]`. Would break under option 2. |
| `tests/integration/sdk/test_scraping.py:88` | `assert structured.get() == structured.data` after the SDK already unwrapped `.data`. Would break under option 2. |
| `tests/integration/sdk/test_scraping.py:73,216` and `tests/browser/test_tools.py:48,67,128` | Model payloads (`response_format=...`, and `DataSpace.from_structured(ListEmailResponse(...))` in `notte_browser/tools/base.py`). Unaffected either way. |
| `examples/scrape-logo/agent.py:37-38` | `data.get().get_url(url)` with `response_format=Logo`. Runtime-correct today (the SDK re-validates into `response_format`), but the honest union makes it a type error, so it now guards with `isinstance(logo, Logo)`. |

Runtime behaviour is unchanged by this PR.

## Changes

- `packages/notte-core/src/notte_core/data/space.py` — `get()` now returns `TBaseModel | dict[str, Any]`; the `# type: ignore[attr-defined]` is gone, replaced by an explicit `cast` and a docstring that states both shapes.
- `packages/notte-sdk/src/notte_sdk/endpoints/page.py` — dropped the now-unnecessary `# pyright: ignore[reportUnnecessaryIsInstance]`; the guard is no longer reported as redundant.
- `packages/notte-browser/src/notte_browser/session.py` — the async `ascrape` instructions-only overload said `-> BaseModel` while its sync `scrape` sibling already said `-> dict[str, Any]`; the async one is the same lie about the same value, so it now matches, and the implementation signature is widened accordingly.
- `tests/test_structured_data.py` — new unit tests: dict payload, model payload, payload deserialized from a response body, and the failure path.

## Checks run

- `pre-commit` (ruff check, ruff format, basedpyright, and the repo's local hooks) on the commit: **all passed**, basedpyright reporting `0 errors, 0 warnings` on the touched files.
- A full-repo `basedpyright --project .` before/after diff: **identical** counts (96 errors / 967 warnings, all pre-existing), zero new diagnostics.
- `pytest -n 4 tests/sdk tests/pipe tests/utils tests/config tests/actions tests/test_structured_data.py` → 398 passed, 2 skipped, 4 failed. The 4 failures (`test_list.py::test_simple_listing`, `test_replay_frames.py`, `test_validator.py::test_validator_message_received`) are `AuthenticationError` from a missing `NOTTE_API_KEY` in my environment and fail identically on `main`.
- `tests/sdk/test_scrape_overload_typing.py` (basedpyright + ty reveal-type cases) passes unchanged.
- Not run: the integration/browser suites that need API keys and a live browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789209529&installation_model_id=8247&pr_number=895&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F895&signature=28dce5546fbde52de6600adf3037280da3d567b84f5836915ea7a3c68173d35a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Structured scraping now supports returning either validated models or plain dictionary results.
  * Improved handling of instruction-only scraping responses.

* **Bug Fixes**
  * Safer processing of missing, unexpected, or failed scraping results.
  * Scraped logo results are validated before their URLs are logged or returned.

* **Tests**
  * Added coverage for dictionary payloads, model payloads, deserialized responses, and extraction failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->