### PR TITLE
[NOT-799] Validate raw payloads in StructuredData.get() instead of unwrapping them

### DIFF
--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -1038,11 +1038,11 @@ class NotteSession(AsyncResource, SyncResource):
         **params: Unpack[ScrapeMarkdownParamsDict],
     ) -> StructuredData[TBaseModel]: ...
 
-    # instructions only, raise_on_failure=True (default) -> unwrapped BaseModel
+    # instructions only, raise_on_failure=True (default) -> raw JSON payload, as for sync `scrape`
     @overload
     async def ascrape(
         self, *, instructions: str, raise_on_failure: Literal[True] = ..., **params: Unpack[ScrapeMarkdownParamsDict]
-    ) -> BaseModel: ...
+    ) -> dict[str, Any]: ...
 
     # instructions only, raise_on_failure=False -> wrapped StructuredData[BaseModel]
     @overload
@@ -1058,7 +1058,7 @@ class NotteSession(AsyncResource, SyncResource):
     @track_usage("local.session.scrape")
     async def ascrape(
         self, *, raise_on_failure: bool = True, **params: Unpack[ScrapeParamsDict]
-    ) -> StructuredData[BaseModel] | BaseModel | str | list[ImageData]:
+    ) -> StructuredData[BaseModel] | BaseModel | dict[str, Any] | str | list[ImageData]:
         # Extract and convert response_format for the action (store as JSON schema)
         response_format = params.get("response_format")
         instructions = params.get("instructions")
@@ -1131,7 +1131,11 @@ class NotteSession(AsyncResource, SyncResource):
             if data.structured is None:
                 raise ScrapeFailedError("Failed to extract structured data")
             if raise_on_failure:  # the following line raises ScrapeFailedError if failed
-                return data.structured.get()
+                extracted_data = data.structured.get()
+                if response_format is None:
+                    # instructions only: no schema to validate against, return the raw JSON payload
+                    return extracted_data.model_dump()
+                return extracted_data
             if isinstance(data.structured.data, RootModel):
                 data.structured.data = data.structured.data.root  # type: ignore[attr-defined]
             return data.structured

--- a/packages/notte-core/src/notte_core/data/space.py
+++ b/packages/notte-core/src/notte_core/data/space.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Annotated, Any, Generic, Self, TypeVar
+from typing import Annotated, Any, Generic, Self, TypeVar, cast
 
 import requests
 from pydantic import BaseModel, Field, RootModel, model_serializer, model_validator
@@ -91,13 +91,47 @@ class StructuredData(BaseModel, Generic[TBaseModel]):
             result["data"] = self.data
         return result
 
+    def _schema(self) -> type[BaseModel] | None:
+        """The model `data` should be validated against, when it is known.
+
+        `StructuredData[Profile]` records `Profile` in pydantic's generic metadata, so a
+        raw JSON payload can be validated back into it. Returns None for the
+        unparametrized form and for `StructuredData[BaseModel]`, where no schema was
+        provided and there is therefore nothing to validate against.
+        """
+        args: tuple[Any, ...] = type(self).__pydantic_generic_metadata__["args"]
+        if len(args) != 1:
+            return None
+        schema = args[0]
+        if not isinstance(schema, type) or not issubclass(schema, BaseModel) or schema is BaseModel:
+            return None
+        return schema
+
     def get(self) -> TBaseModel:
-        """Get the extracted data, raising ScrapeFailedError if extraction failed."""
+        """Get the extracted data, raising ScrapeFailedError if extraction failed.
+
+        A payload that came in as raw JSON is stored wrapped in a `DictBaseModel`
+        (`RootModel[Any]`) by `wrap_dict_in_root_model`. It is validated back into the
+        schema this `StructuredData` was parametrized with, so the returned value is
+        always a model. When no schema is known the `RootModel` wrapper is itself the
+        model, and the raw payload stays reachable through `.root` / `model_dump()`.
+
+        Raises:
+            ScrapeFailedError: if the extraction failed or produced no data.
+            ValidationError: if the payload does not match the parametrized schema.
+        """
         if not self.success or self.data is None:
             raise ScrapeFailedError(self.error or "Unknown extraction error")
-        if isinstance(self.data, RootModel):
-            return self.data.root  # type: ignore[attr-defined]
-        return self.data
+        data: TBaseModel | DictBaseModel = self.data
+        if isinstance(data, RootModel):
+            # local alias: keeps the payload typed as `Any` instead of `RootModel[Unknown]`
+            wrapper = cast(DictBaseModel, data)
+            schema = self._schema()
+            if schema is None:
+                # no schema was provided: the RootModel wrapper is itself the model
+                return cast(TBaseModel, wrapper)
+            return cast(TBaseModel, schema.model_validate(wrapper.root))
+        return data
 
 
 class DataSpace(BaseModel):

--- a/packages/notte-sdk/src/notte_sdk/endpoints/page.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/page.py
@@ -202,16 +202,14 @@ class PageClient(BaseClient):
                 if raise_on_failure:
                     raise ScrapeFailedError(error_message)
                 return StructuredData[BaseModel](success=False, error=error_message, data=None)
-            # Use structured.get() which raises ScrapeFailedError if failed, and unwraps RootModel
+            # Use structured.get() which raises ScrapeFailedError if failed
             if raise_on_failure:
                 extracted_data = structured.get()
                 # Validate against response_format if provided
                 if request.response_format is not None:
-                    extracted_data_dict = (
-                        extracted_data.model_dump() if isinstance(extracted_data, BaseModel) else extracted_data  # pyright: ignore[reportUnnecessaryIsInstance]
-                    )
-                    extracted_data = request.response_format.model_validate(extracted_data_dict)
-                return extracted_data
+                    return request.response_format.model_validate(extracted_data.model_dump())
+                # instructions only: no schema to validate against, return the raw JSON payload
+                return extracted_data.model_dump()
             structured_data = cast(Any, structured.data)
             if isinstance(structured_data, RootModel):
                 # unwrap RootModel

--- a/tests/pipe/scraping/test_schema.py
+++ b/tests/pipe/scraping/test_schema.py
@@ -254,8 +254,9 @@ async def test_unmask_placeholders_with_instructions_only() -> None:
     assert result.success is True
     assert result.data is not None
 
-    # Get the actual data
-    data = result.get()
+    # Get the actual data: no response_format was given, so the payload comes back
+    # wrapped in a DictBaseModel and model_dump() yields the raw JSON
+    data = result.get().model_dump()
     assert isinstance(data, dict)
     assert "hotels" in data
     assert len(data["hotels"]) == 2

--- a/tests/test_structured_data.py
+++ b/tests/test_structured_data.py
@@ -1,0 +1,50 @@
+import pytest
+from notte_core.data.space import DataSpace, DictBaseModel, StructuredData
+from notte_core.errors.processing import ScrapeFailedError
+from pydantic import BaseModel, RootModel, ValidationError
+
+
+class Verification(BaseModel):
+    status: str
+    code: str
+
+
+PAYLOAD = {"status": "found", "code": "463092"}
+
+
+def test_get_validates_raw_payload_into_the_parametrized_schema():
+    """A raw JSON payload is wrapped in a RootModel, get() validates it back into the schema."""
+    structured = StructuredData[Verification].model_validate({"success": True, "data": PAYLOAD})
+    assert isinstance(structured.data, RootModel)
+    assert structured.get() == Verification(status="found", code="463092")
+
+
+def test_get_raises_when_the_payload_does_not_match_the_schema():
+    structured = StructuredData[Verification].model_validate({"success": True, "data": {"unrelated": 1}})
+    with pytest.raises(ValidationError):
+        _ = structured.get()
+
+
+def test_get_returns_the_root_model_when_no_schema_is_known():
+    """`StructuredData[BaseModel]` (what `DataSpace.structured` is) carries no schema to validate against."""
+    space = DataSpace.model_validate({"markdown": "content", "structured": {"success": True, "data": PAYLOAD}})
+    assert space.structured is not None
+    data = space.structured.get()
+    assert isinstance(data, BaseModel)
+    assert data.model_dump() == PAYLOAD
+
+
+def test_get_returns_the_root_model_for_dict_base_model():
+    structured = StructuredData[DictBaseModel](success=True, data=DictBaseModel(PAYLOAD))
+    assert structured.get().model_dump() == PAYLOAD
+
+
+def test_get_returns_model_payloads_untouched():
+    verification = Verification(status="found", code="463092")
+    assert DataSpace.from_structured(verification).structured.get() is verification  # pyright: ignore[reportOptionalMemberAccess]
+
+
+def test_get_raises_on_failed_extraction():
+    structured = StructuredData[Verification](success=False, error="nothing to extract", data=None)
+    with pytest.raises(ScrapeFailedError):
+        _ = structured.get()


### PR DESCRIPTION
Supersedes #895, which fixed this the wrong way round — it widened the annotation to `TBaseModel | dict[str, Any]` to match the unwrapping. The annotation was right; the unwrapping is the bug.

## The bug

A payload that arrives as raw JSON is wrapped in a `DictBaseModel` (`RootModel[Any]`) by the `wrap_dict_in_root_model` before-validator, and `get()` returned `self.data.root` — a plain dict, not a model, despite the `-> TBaseModel` annotation. The `# type: ignore[attr-defined]` sat on exactly that line and hid it.

```
StructuredData[Profile].model_validate({"success": True, "data": {...}}).get()
before: dict            # not a BaseModel, no .model_dump()
after:  Profile(...)
```

## The fix

`packages/notte-core/src/notte_core/data/space.py` — validate the root back into the schema the `StructuredData` was parametrized with, recovered from pydantic's generic metadata (`__pydantic_generic_metadata__["args"]`).

When no schema is known there is nothing to validate against, and `BaseModel.model_validate(...)` doesn't merely lose the fields — it raises `PydanticUserError: BaseModel cannot be instantiated directly`. That covers two real cases:

- `StructuredData[BaseModel]`, which is what `DataSpace.structured` is, so every API-deserialized response lands here
- the unparametrized `StructuredData(...)`

In that case `get()` returns the `RootModel` wrapper itself: it *is* a `BaseModel`, so the annotation holds, and the raw payload stays reachable through `.root` / `model_dump()`.

Verified at runtime across all six shapes — parametrized schema, `StructuredData[BaseModel]` from an API-shaped body, `StructuredData[DictBaseModel]` (what `SchemaScrapingPipe` produces), list root, model payload, bare — plus schema mismatch → `ValidationError`. Serialization round-trips unchanged.

## Knock-on changes

Unwrapping moves out of `get()` into the two call sites that promise `dict[str, Any]` for instructions-only scrapes (pinned for all four entry points by `typing_cases/scrape_overloads.py`):

- `packages/notte-sdk/src/notte_sdk/endpoints/page.py` — with `response_format`, validate `extracted_data.model_dump()`; without, return `model_dump()`.

Linear: NOT-799 — https://linear.app/nottelabsinc/issue/NOT-799/notte-pr-896-validate-raw-payloads-in-structureddataget-instead-of

_Auto-linked by Quaso GitHub PR ↔ Linear reconciler._