### PR TITLE
Model lightweight function run list responses

### DIFF
--- a/docs/src/snippets/functions/management/cleanup_old_runs.mdx
+++ b/docs/src/snippets/functions/management/cleanup_old_runs.mdx
@@ -19,12 +19,13 @@ def archive_old_runs(function_id: str, days_old: int = 30):
 
     for run in runs.items:
         if run.created_at < cutoff_date:
+            run_detail = client.functions.get_run(function_id, run.function_run_id)
             archive.append(
                 {
                     "run_id": run.workflow_run_id,
                     "status": run.status,
                     "created_at": run.created_at.isoformat(),
-                    "result": str(run.result)[:100],  # First 100 chars
+                    "result": str(run_detail.result)[:100],  # First 100 chars
                 }
             )
 

--- a/docs/src/snippets/functions/management/high_failure_rate.mdx
+++ b/docs/src/snippets/functions/management/high_failure_rate.mdx
@@ -14,7 +14,8 @@ print(f"Failed runs: {len(failures)}/{len(runs.items)}")
 
 # Analyze failure reasons
 for run in failures[:5]:  # Last 5 failures
+    run_detail = client.functions.get_run("function_abc123", run.function_run_id)
     print(f"Run {run.workflow_run_id}:")
-    print(f"  Error: {run.result}")
+    print(f"  Error: {run_detail.result}")
     print(f"  Time: {run.created_at}")
 ```

--- a/docs/src/testers/functions/management/cleanup_old_runs.py
+++ b/docs/src/testers/functions/management/cleanup_old_runs.py
@@ -16,12 +16,13 @@ def archive_old_runs(function_id: str, days_old: int = 30):
 
     for run in runs.items:
         if run.created_at < cutoff_date:
+            run_detail = client.functions.get_run(function_id, run.function_run_id)
             archive.append(
                 {
                     "run_id": run.workflow_run_id,
                     "status": run.status,
                     "created_at": run.created_at.isoformat(),
-                    "result": str(run.result)[:100],  # First 100 chars
+                    "result": str(run_detail.result)[:100],  # First 100 chars
                 }
             )
 

--- a/docs/src/testers/functions/management/high_failure_rate.py
+++ b/docs/src/testers/functions/management/high_failure_rate.py
@@ -11,6 +11,7 @@ print(f"Failed runs: {len(failures)}/{len(runs.items)}")
 
 # Analyze failure reasons
 for run in failures[:5]:  # Last 5 failures
+    run_detail = client.functions.get_run("function_abc123", run.function_run_id)
     print(f"Run {run.workflow_run_id}:")
-    print(f"  Error: {run.result}")
+    print(f"  Error: {run_detail.result}")
     print(f"  Time: {run.created_at}")

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -2383,6 +2383,38 @@ class GetFunctionRunResponse(SdkResponse):
         return self.function_run_id
 
 
+class FunctionRunListItemResponse(SdkResponse):
+    """Lightweight function run metadata returned by list endpoints."""
+
+    function_id: Annotated[
+        str, Field(description="The ID of the function", validation_alias=AliasChoices("workflow_id", "function_id"))
+    ]
+    function_run_id: Annotated[
+        str,
+        Field(
+            description="The ID of the function run",
+            validation_alias=AliasChoices("workflow_run_id", "function_run_id"),
+        ),
+    ]
+    created_at: dt.datetime
+    updated_at: dt.datetime
+    status: FunctionRunStatus
+    session_id: Annotated[str | None, Field(description="The ID of the session")] = None
+    local: Annotated[bool, Field(description="Whether the function has been run locally or on the cloud")] = False
+
+    @computed_field
+    @property
+    def workflow_id(self) -> str:
+        """Legacy key for serialization"""
+        return self.function_id
+
+    @computed_field
+    @property
+    def workflow_run_id(self) -> str:
+        """Legacy key for serialization"""
+        return self.function_run_id
+
+
 class FunctionRunUpdateRequestDict(TypedDict, total=False):
     session_id: str | None
     logs: list[str]
@@ -2462,7 +2494,7 @@ class ListFunctionRunsRequest(ListRequest):
 
 
 class ListFunctionRunsResponse(SdkResponse):
-    items: Annotated[list[GetFunctionRunResponse], Field(description="The function runs")]
+    items: Annotated[list[FunctionRunListItemResponse], Field(description="The function runs")]
     page: Annotated[int, Field(description="Current page number")]
     page_size: Annotated[int, Field(description="Number of items per page")]
     has_next: Annotated[bool, Field(description="Whether there are more pages")]

--- a/tests/integration/sdk/test_workflow_runs.py
+++ b/tests/integration/sdk/test_workflow_runs.py
@@ -530,11 +530,12 @@ class TestFunctionRunsIntegration:
         run_ids = [run.workflow_run_id for run in list_response.items]
         assert run_id in run_ids
 
-        # 4. Find our specific run and verify its data
-        our_run = next(run for run in list_response.items if run.workflow_run_id == run_id)
-        assert our_run.function_id == test_workflow.function_id
-        assert our_run.session_id == session_id
-        assert our_run.logs == test_logs
+        # 4. Fetch our specific run to verify detail-only data
+        run_summary = next(run for run in list_response.items if run.workflow_run_id == run_id)
+        assert run_summary.function_id == test_workflow.function_id
+        assert run_summary.session_id == session_id
+        run_detail = client.functions.get_run(function_id=test_workflow.function_id, run_id=run_id)
+        assert run_detail.logs == test_logs
 
         # 5. Update the run to closed status
         final_update = client.functions.update_run(
@@ -583,12 +584,13 @@ class TestFunctionRunsIntegration:
         for created_run_id in created_runs:
             assert created_run_id in listed_run_ids, f"Run {created_run_id} not found in list response"
 
-        # Verify each run has the correct data
+        # Verify each run has the correct detail data
         for i, run_id in enumerate(created_runs):
-            run_data = next(run for run in list_response.items if run.workflow_run_id == run_id)
+            run_summary = next(run for run in list_response.items if run.workflow_run_id == run_id)
             # Session ID will be a UUID, so just check it exists
-            assert run_data.session_id is not None
-            assert run_data.logs == [f"Log entry {i}"]
+            assert run_summary.session_id is not None
+            run_detail = client.functions.get_run(function_id=workflow_id, run_id=run_id)
+            assert run_detail.logs == [f"Log entry {i}"]
 
     def test_remote_function_complete_flow(self, client: NotteClient, test_workflow: GetFunctionResponse):
         """Test complete RemoteWorkflow execution flow."""

--- a/tests/integration/sdk/test_workflow_runs.py
+++ b/tests/integration/sdk/test_workflow_runs.py
@@ -11,9 +11,9 @@ from notte_sdk.endpoints.functions import NotteFunction
 from notte_sdk.endpoints.workflows import RemoteWorkflow
 from notte_sdk.types import (
     CreateFunctionRunResponse,
+    FunctionRunListItemResponse,
     FunctionRunResponse,
     GetFunctionResponse,
-    GetFunctionRunResponse,
     ListFunctionRunsResponse,
     UpdateFunctionRunResponse,
 )
@@ -154,11 +154,10 @@ class TestFunctionRunsClient:
 
         # Verify the structure of a workflow run response
         found_run = next(run for run in list_response.items if run.function_run_id == create_response.function_run_id)
-        assert isinstance(found_run, GetFunctionRunResponse)
+        assert isinstance(found_run, FunctionRunListItemResponse)
         assert found_run.function_id == test_workflow.function_id
         assert found_run.function_run_id == create_response.function_run_id
         assert found_run.created_at is not None
-        assert isinstance(found_run.logs, list)
 
     def test_update_workflow_run(self, client: NotteClient, test_workflow: GetFunctionResponse, session_id: str):
         """Test updating a workflow run."""

--- a/tests/sdk/test_function_run_list_types.py
+++ b/tests/sdk/test_function_run_list_types.py
@@ -1,0 +1,34 @@
+import datetime as dt
+
+from notte_sdk.types import FunctionRunListItemResponse, ListFunctionRunsResponse
+
+
+def test_function_run_list_uses_lightweight_items() -> None:
+    response = ListFunctionRunsResponse.model_validate(
+        {
+            "items": [
+                {
+                    "function_id": "function-1",
+                    "function_run_id": "run-1",
+                    "created_at": "2026-08-17T10:00:00Z",
+                    "updated_at": "2026-08-17T10:01:00Z",
+                    "status": "closed",
+                    "session_id": None,
+                    "local": False,
+                }
+            ],
+            "page": 1,
+            "page_size": 10,
+            "has_next": False,
+            "has_previous": False,
+        }
+    )
+
+    item = response.items[0]
+    assert isinstance(item, FunctionRunListItemResponse)
+    assert item.created_at == dt.datetime(2026, 8, 17, 10, tzinfo=dt.UTC)
+    assert item.workflow_id == "function-1"
+    assert item.workflow_run_id == "run-1"
+    assert "logs" not in item.model_dump()
+    assert "variables" not in item.model_dump()
+    assert "result" not in item.model_dump()


### PR DESCRIPTION
## Summary

- add a dedicated `FunctionRunListItemResponse` for metadata-only list results
- keep `GetFunctionRunResponse` for the complete single-run detail response
- update SDK tests and examples to fetch run details before reading logs or results

Follows nottelabs/monorepo#2227.

## Validation

- `uv run pytest tests/sdk/test_function_run_list_types.py -q`
- `uv run ruff check packages/notte-sdk/src/notte_sdk/types.py tests/sdk/test_function_run_list_types.py tests/integration/sdk/test_workflow_runs.py`
- `uv run basedpyright packages/notte-sdk/src/notte_sdk/types.py tests/sdk/test_function_run_list_types.py tests/integration/sdk/test_workflow_runs.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a lightweight response format for listed function runs, including identifiers, timestamps, status, session information, and execution state.
  * Function-run list results no longer include detailed logs, variables, or result data.

* **Bug Fixes**
  * Improved parsing and validation of function-run list responses.
  * Updated run-management workflows to retrieve detailed run information when logs, errors, or results are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->