### PR TITLE
fix(browser): reduce main-content scrape memory

### DIFF
--- a/docs/src/integrations/hermes.mdx
+++ b/docs/src/integrations/hermes.mdx
@@ -2,6 +2,7 @@
 title: Hermes Agent
 description: 'Use Notte cloud browsers with Hermes Agent'
 ---
+import HermesLauncher from '/snippets/integrations/hermes_launcher.mdx';
 import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 <AgentMdNotice />
@@ -22,22 +23,7 @@ pip install notte
 
 Create a small launcher that starts a Notte session and prints its CDP endpoint:
 
-```python
-# notte_hermes.py
-from notte_sdk import NotteClient
-
-client = NotteClient()
-session = client.Session(
-    proxies=True,
-    solve_captchas=True,
-    open_viewer=True,
-)
-session.start()
-
-print(session.cdp_url())
-input("Press Enter when you are finished with Hermes... ")
-session.stop()
-```
+<HermesLauncher />
 
 Run it in one terminal and keep it running for the lifetime of the Hermes task:
 

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -167,6 +167,7 @@ Full Quickstart: https://docs.notte.cc/quickstart.md
 - [OpenAI CUA](https://docs.notte.cc/integrations/openai-cua.md): Integrate OpenAI CUA with Notte Browser Sessions
 - [Stagehand](https://docs.notte.cc/integrations/stagehand.md): Use Notte cloud browsers with Stagehand browser automation
 - [OpenClaw](https://docs.notte.cc/integrations/openclaw.md): Use Notte cloud browsers with OpenClaw
+- [Hermes Agent](https://docs.notte.cc/integrations/hermes.md): Use Notte cloud browsers with Hermes Agent
 - [Cloudflare Web Bot Auth](https://docs.notte.cc/features/sessions/cloudflare-web-bot-auth.md): Access Cloudflare-protected websites by cryptographically signing browser requests
 
 

--- a/docs/src/snippets/integrations/hermes_launcher.mdx
+++ b/docs/src/snippets/integrations/hermes_launcher.mdx
@@ -1,0 +1,18 @@
+{/* Auto-generated mdx file. Do not edit! */}
+{/* @sniptest testers/integrations/hermes_launcher.py */}
+
+```python notte_hermes.py
+from notte_sdk import NotteClient
+
+client = NotteClient()
+session = client.Session(
+    proxies=True,
+    solve_captchas=True,
+    open_viewer=True,
+)
+session.start()
+
+print(session.cdp_url())
+input("Press Enter when you are finished with Hermes... ")
+session.stop()
+```

--- a/docs/src/testers/integrations/hermes_launcher.py
+++ b/docs/src/testers/integrations/hermes_launcher.py
@@ -1,0 +1,15 @@
+# @sniptest filename=notte_hermes.py
+# @sniptest typecheck_only=true
+from notte_sdk import NotteClient
+
+client = NotteClient()
+session = client.Session(
+    proxies=True,
+    solve_captchas=True,
+    open_viewer=True,
+)
+session.start()
+
+print(session.cdp_url())
+input("Press Enter when you are finished with Hermes... ")
+session.stop()

--- a/packages/notte-browser/pyproject.toml
+++ b/packages/notte-browser/pyproject.toml
@@ -15,16 +15,15 @@ requires-python = ">=3.11"
 dependencies = [
     "notte_core==1.4.4.dev",
     "notte_llm==1.4.4.dev",
-    "maincontentextractor",
+    "html2text>=2025.4.15",
+    "lxml>=5.3.1",
     "markdownify>=0.14.1",
     "pillow>=11.2.1",
     "patchright~=1.55",
     "tqdm>=4.66.0",
+    "trafilatura>=2.0.0",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.uv.sources]
-maincontentextractor = { git = "https://github.com/HawkClaws/main_content_extractor", rev = "7c3ed7f6ed7f6c10223a3357d43ab741663bc812" }

--- a/packages/notte-browser/src/notte_browser/scraping/markdown.py
+++ b/packages/notte-browser/src/notte_browser/scraping/markdown.py
@@ -71,9 +71,13 @@ def _strip_configured_tags(elements: list[etree._Element], tags: list[str]) -> N
     normalized_tags = {tag.lower() for tag in tags}
     for root in elements:
         for element in list(root.iterdescendants()):
-            if element.tag.lower() not in normalized_tags:
+            tag = cast(object, element.tag)
+            if not isinstance(tag, str):
                 continue
-            if element.tag.lower() == "img":
+            normalized_tag = tag.lower()
+            if normalized_tag not in normalized_tags:
+                continue
+            if normalized_tag == "img":
                 _remove_subtree(element)
             else:
                 _unwrap_element(element)

--- a/packages/notte-browser/src/notte_browser/scraping/markdown.py
+++ b/packages/notte-browser/src/notte_browser/scraping/markdown.py
@@ -1,7 +1,12 @@
-from typing import Any
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false
 
+from typing import Any, cast
+
+import html2text
+import trafilatura
 from bs4 import BeautifulSoup
-from main_content_extractor import MainContentExtractor  # type: ignore[import]
+from lxml import etree
+from lxml import html as lxml_html
 from markdownify import MarkdownConverter  # pyright: ignore [reportMissingTypeStubs]
 from notte_core.browser.snapshot import BrowserSnapshot
 from notte_core.common.logging import logger
@@ -11,49 +16,190 @@ from typing_extensions import override
 from notte_browser.errors import EmptyPageContentError, PlaywrightError
 from notte_browser.window import BrowserWindow
 
+_MAIN_CONTENT_REMOVED_TAGS = ("script", "style", "aside", "footer", "header", "hgroup", "nav", "search")
+
+
+def _remove_subtree(element: etree._Element) -> None:
+    parent = element.getparent()
+    if parent is None:
+        return
+    if element.tail:
+        previous = element.getprevious()
+        if previous is None:
+            parent.text = (parent.text or "") + element.tail
+        else:
+            previous.tail = (previous.tail or "") + element.tail
+    parent.remove(element)
+
+
+def _unwrap_element(element: etree._Element) -> None:
+    parent = element.getparent()
+    if parent is None:
+        return
+
+    previous = element.getprevious()
+    if element.text:
+        if previous is None:
+            parent.text = (parent.text or "") + element.text
+        else:
+            previous.tail = (previous.tail or "") + element.text
+
+    index = parent.index(element)
+    children = list(element)
+    for child in children:
+        element.remove(child)
+        parent.insert(index, child)
+        index += 1
+
+    if element.tail:
+        tail_target = children[-1] if children else previous
+        if tail_target is None:
+            parent.text = (parent.text or "") + element.tail
+        else:
+            tail_target.tail = (tail_target.tail or "") + element.tail
+    parent.remove(element)
+
+
+def _remove_hidden_elements(root: etree._Element) -> None:
+    for element in list(root.iter()):
+        style = str(element.get("style", "")).replace(" ", "").lower()
+        if "display:none" in style or "visibility:hidden" in style:
+            _remove_subtree(element)
+
+
+def _strip_configured_tags(elements: list[etree._Element], tags: list[str]) -> None:
+    normalized_tags = {tag.lower() for tag in tags}
+    for root in elements:
+        for element in list(root.iterdescendants()):
+            if element.tag.lower() not in normalized_tags:
+                continue
+            if element.tag.lower() == "img":
+                _remove_subtree(element)
+            else:
+                _unwrap_element(element)
+
+
+def _deepest_content_id(root: etree._Element) -> etree._Element | None:
+    matches = [element for element in root.iter() if element.get("id") in {"contents", "main"}]
+    if not matches:
+        return None
+    return max(matches, key=lambda element: sum(1 for _ in element.iterancestors()))
+
+
+def _trafilatura_fallback(html: str) -> list[etree._Element]:
+    extracted = trafilatura.extract(
+        html,
+        output_format="xml",
+        include_tables=True,
+        include_images=True,
+        include_links=True,
+    )
+    if not extracted:
+        return []
+
+    root = etree.fromstring(extracted.encode("utf-8"))
+    for element in root.iter():
+        tag = element.tag
+        if tag == "list":
+            element.tag = element.get("rend", "ul").split("-", 1)[0]
+            if "rend" in element.attrib:
+                _ = element.attrib.pop("rend")
+        elif tag == "item":
+            element.tag = element.get("rend", "li").split("-", 1)[0]
+            if "rend" in element.attrib:
+                _ = element.attrib.pop("rend")
+        elif tag == "head":
+            element.tag = element.get("rend", "h2").split("-", 1)[0]
+            if "rend" in element.attrib:
+                _ = element.attrib.pop("rend")
+        elif tag == "row":
+            element.tag = "tr"
+        elif tag == "cell":
+            element.tag = "th" if element.get("role") == "head" else "td"
+            if "role" in element.attrib:
+                _ = element.attrib.pop("role")
+        elif tag == "graphic":
+            element.tag = "img"
+        elif tag == "ref":
+            element.tag = "a"
+            target = element.get("target")
+            if target is not None:
+                del element.attrib["target"]
+                element.set("href", target)
+        elif tag == "lb":
+            element.tag = "br"
+
+    containers = [element for element in root if element.tag in {"main", "comments"}]
+    content = [child for container in containers for child in container]
+    return content or [root]
+
+
+def _html_to_markdown(element: etree._Element, params: ScrapeParams, *, images_to_alt: bool) -> str:
+    converter = html2text.HTML2Text()
+    converter.ignore_links = not params.scrape_links
+    converter.ignore_images = not params.scrape_images
+    converter.images_to_alt = images_to_alt
+    serialized = cast(str, lxml_html.tostring(element, encoding="unicode", method="html"))
+    return converter.handle(serialized)
+
 
 class MainContentScrapingPipe:
-    """
-    Data scraping pipe that scrapes data from the page
-    """
+    """Extract main content with a single low-memory lxml DOM."""
 
     @staticmethod
-    def forward(
-        snapshot: BrowserSnapshot,
-        scrape_links: bool,
-        output_format: str = "markdown",
-    ) -> str:
-        data = MainContentExtractor.extract(  # type: ignore[attr-defined]
-            html=snapshot.html_content,
-            output_format=output_format,
-            include_links=scrape_links,
+    def forward(snapshot: BrowserSnapshot, params: ScrapeParams, *, images_to_alt: bool = False) -> str:
+        try:
+            root = lxml_html.document_fromstring(snapshot.html_content)
+        except (etree.ParserError, ValueError) as error:
+            raise EmptyPageContentError(url=snapshot.metadata.url, nb_retries=1) from error
+
+        for tag in _MAIN_CONTENT_REMOVED_TAGS:
+            for element in list(root.iter(tag)):
+                _remove_subtree(element)
+        _remove_hidden_elements(root)
+
+        main = next(root.iter("main"), None)
+        if main is not None:
+            articles = list(main.iter("article"))
+            content = articles or [main]
+        else:
+            articles = list(root.iter("article"))
+            content = articles or ([] if (deepest := _deepest_content_id(root)) is None else [deepest])
+
+        if not content:
+            content = _trafilatura_fallback(snapshot.html_content)
+        if not content:
+            raise EmptyPageContentError(url=snapshot.metadata.url, nb_retries=1)
+
+        _strip_configured_tags(content, params.removed_tags())
+        data = "\n\n".join(
+            filter(
+                None, (_html_to_markdown(element, params, images_to_alt=images_to_alt).strip() for element in content)
+            )
         )
-        if data is None or not isinstance(data, str) or len(data) == 0:
+        if not data:
             raise EmptyPageContentError(url=snapshot.metadata.url, nb_retries=1)
         return data
 
 
 class VisibleMarkdownConverter(MarkdownConverter):
-    """Ignore hidden content on the page"""
+    """Ignore hidden content on the page."""
 
     @override
     def convert_soup(self, soup: BeautifulSoup) -> str | Any:
-        # Remove hidden elements before conversion
         for element in soup.find_all(style=True):
             if not hasattr(element, "attrs") or element.attrs is None:  # pyright: ignore [reportUnnecessaryComparison]
                 continue
 
             style = element.get("style", "")
-            if "display:none" in style.replace(" ", "") or "visibility:hidden" in style.replace(" ", ""):  # pyright: ignore [reportUnknownMemberType, reportOptionalMemberAccess, reportAttributeAccessIssue]
+            if "display:none" in style.replace(" ", "") or "visibility:hidden" in style.replace(" ", ""):  # pyright: ignore [reportOptionalMemberAccess, reportAttributeAccessIssue]
                 element.decompose()
 
-        return super().convert_soup(soup)  # pyright: ignore [reportUnknownVariableType, reportUnknownMemberType]
+        return super().convert_soup(soup)  # pyright: ignore [reportUnknownVariableType]
 
 
 class MarkdownifyScrapingPipe:
-    """
-    Data scraping pipe that scrapes data from the page
-    """
+    """Convert page content to Markdown and append readable iframe content."""
 
     @staticmethod
     async def forward(
@@ -62,16 +208,14 @@ class MarkdownifyScrapingPipe:
         params: ScrapeParams,
         include_iframes: bool | None = None,
     ) -> str:
-        if params.only_main_content:
-            html = MainContentScrapingPipe.forward(snapshot, scrape_links=params.scrape_links, output_format="html")
-
-        else:
-            html = snapshot.html_content
         converter = VisibleMarkdownConverter(strip=params.removed_tags())
-        content: str = converter.convert(html)  # type: ignore[attr-defined]
+        if params.only_main_content:
+            content = MainContentScrapingPipe.forward(snapshot, params)
+        else:
+            content = converter.convert(snapshot.html_content)  # type: ignore[attr-defined]
 
-        # manually append iframe text into the content so it's readable by the LLM (includes cross-origin iframes)
-        # don't include iframes by default if a selector is set (scraping specific element)
+        # Manually append iframe text so cross-origin frames remain readable.
+        # Do not include iframes by default when a selector scopes the scrape.
         if include_iframes is None:
             include_iframes = params.selector is None
 
@@ -82,7 +226,7 @@ class MarkdownifyScrapingPipe:
                         iframe_content = await iframe.content()
                         content += f"\n\nIFRAME {iframe.url}:\n"  # type: ignore[attr-defined]
                         content += converter.convert(iframe_content)  # type: ignore[attr-defined]
-                    except PlaywrightError as e:
-                        logger.warning(f"Failed to get iframe content for {iframe.url}: {e}")
+                    except PlaywrightError as error:
+                        logger.warning(f"Failed to get iframe content for {iframe.url}: {error}")
 
         return content  # type: ignore[return-value]

--- a/packages/notte-browser/src/notte_browser/scraping/pipe.py
+++ b/packages/notte-browser/src/notte_browser/scraping/pipe.py
@@ -1,7 +1,6 @@
 import re
 from typing import final
 
-from html2text import config as html2text_config
 from notte_core.browser.snapshot import BrowserSnapshot
 from notte_core.common.config import ScrapingType, config
 from notte_core.common.logging import logger
@@ -95,13 +94,7 @@ class DataScrapingPipe:
                     logger.trace("📀 Scraping page with main content scraping pipe")
                 if not params.only_main_content:
                     raise ValueError("Main content scraping pipe only supports only_main_content=True")
-                # band-aid fix for now: html2text only takes this global config, no args
-                # want to keep image, but can't handle nicer conversion when src is base64
-                tmp_images_to_alt = html2text_config.IMAGES_TO_ALT
-                html2text_config.IMAGES_TO_ALT = True
-                data = MainContentScrapingPipe.forward(snapshot, params.scrape_links)
-                html2text_config.IMAGES_TO_ALT = tmp_images_to_alt
-                return data
+                return MainContentScrapingPipe.forward(snapshot, params, images_to_alt=True)
 
     async def forward(
         self,

--- a/packages/notte-core/pyproject.toml
+++ b/packages/notte-core/pyproject.toml
@@ -49,6 +49,3 @@ observability = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.uv.sources]
-maincontentextractor = { git = "https://github.com/HawkClaws/main_content_extractor", rev = "7c3ed7f6ed7f6c10223a3357d43ab741663bc812" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "halo>=0.0.28",
     "joblib>=1.4.2",
     "jupyter>=1.1.1",
+    "lxml-stubs>=0.5.1",
     "pandas",
     "pandas-stubs>=2.2.3.250308",
     "pebble>=5.1.1",

--- a/tests/pipe/scraping/test_markdown.py
+++ b/tests/pipe/scraping/test_markdown.py
@@ -88,6 +88,15 @@ def test_main_content_handles_malformed_html() -> None:
     assert "Still readable" in result
 
 
+def test_main_content_handles_comments_when_stripping_tags() -> None:
+    result = MainContentScrapingPipe.forward(
+        _snapshot("<main><!-- marker --><p>visible <em>emphasis</em></p></main>"),  # type: ignore[arg-type]
+        ScrapeParams(only_main_content=True, ignored_tags=["em"]),
+    )
+
+    assert "visible emphasis" in result
+
+
 def test_dense_dom_peak_memory_regression() -> None:
     script = """
 import json

--- a/tests/pipe/scraping/test_markdown.py
+++ b/tests/pipe/scraping/test_markdown.py
@@ -1,0 +1,119 @@
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+
+from notte_browser.scraping.markdown import MainContentScrapingPipe
+from notte_sdk.types import ScrapeParams
+
+
+def _snapshot(html: str) -> SimpleNamespace:
+    return SimpleNamespace(html_content=html, metadata=SimpleNamespace(url="https://example.com"))
+
+
+def test_main_content_prefers_articles_inside_main() -> None:
+    result = MainContentScrapingPipe.forward(
+        _snapshot(
+            "<html><body><header>nav</header><main><p>intro</p>"
+            '<article><h1>First</h1><a href="https://example.com/first">Read</a></article>'
+            "<article><h2>Second</h2></article></main><article>outside</article></body></html>"
+        ),  # type: ignore[arg-type]
+        ScrapeParams(only_main_content=True, scrape_links=True),
+    )
+
+    assert "First" in result
+    assert "Second" in result
+    assert "https://example.com/first" in result
+    assert "intro" not in result
+    assert "outside" not in result
+    assert "nav" not in result
+
+
+def test_main_content_uses_deepest_conventional_content_id() -> None:
+    result = MainContentScrapingPipe.forward(
+        _snapshot('<div id="main">outer<div id="contents"><h1>Deep content</h1></div></div>'),  # type: ignore[arg-type]
+        ScrapeParams(only_main_content=True),
+    )
+
+    assert "Deep content" in result
+    assert "outer" not in result
+
+
+def test_main_content_removes_hidden_and_configured_tags_but_keeps_text() -> None:
+    result = MainContentScrapingPipe.forward(
+        _snapshot(
+            '<main><p style="display: none">secret</p><p style="visibility:hidden">also secret</p>'
+            "<p>visible <em>emphasis</em></p>"
+            '<a href="https://example.com">link text</a><img src="image.png" alt="image alt"></main>'
+        ),  # type: ignore[arg-type]
+        ScrapeParams(only_main_content=True, ignored_tags=["em"], scrape_links=False, scrape_images=False),
+    )
+
+    assert "visible emphasis" in result
+    assert "link text" in result
+    assert "secret" not in result
+    assert "https://example.com" not in result
+    assert "image alt" not in result
+
+
+def test_main_content_falls_back_for_document_without_landmarks() -> None:
+    result = MainContentScrapingPipe.forward(
+        _snapshot("<html><body><div><h1>Fallback title</h1><p>Fallback body with enough text.</p></div></body></html>"),  # type: ignore[arg-type]
+        ScrapeParams(only_main_content=True),
+    )
+
+    assert "Fallback title" in result
+    assert "Fallback body" in result
+
+
+def test_main_content_preserves_image_behavior_without_global_config_mutation() -> None:
+    snapshot = _snapshot('<main><img src="https://example.com/image.png" alt="image alt"></main>')
+    params = ScrapeParams(only_main_content=True, scrape_images=True)
+
+    markdown_image = MainContentScrapingPipe.forward(snapshot, params)  # type: ignore[arg-type]
+    alt_only = MainContentScrapingPipe.forward(snapshot, params, images_to_alt=True)  # type: ignore[arg-type]
+
+    assert "https://example.com/image.png" in markdown_image
+    assert "image alt" in alt_only
+    assert "https://example.com/image.png" not in alt_only
+
+
+def test_main_content_handles_malformed_html() -> None:
+    result = MainContentScrapingPipe.forward(
+        _snapshot("<main><h1>Broken<p>Still readable"),  # type: ignore[arg-type]
+        ScrapeParams(only_main_content=True),
+    )
+
+    assert "Broken" in result
+    assert "Still readable" in result
+
+
+def test_dense_dom_peak_memory_regression() -> None:
+    script = """
+import json
+import resource
+import sys
+from types import SimpleNamespace
+from notte_browser.scraping.markdown import MainContentScrapingPipe
+from notte_sdk.types import ScrapeParams
+
+baseline = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+html = "<main>" + "<i>x</i>" * 524_288 + "</main>"
+result = MainContentScrapingPipe.forward(
+    SimpleNamespace(html_content=html, metadata=SimpleNamespace(url="https://example.com")),
+    ScrapeParams(only_main_content=True),
+)
+peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+units_per_mib = 1024 * 1024 if sys.platform == "darwin" else 1024
+print(json.dumps({"delta_mib": (peak - baseline) / units_per_mib, "output_chars": len(result)}))
+"""
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    measurement = json.loads(completed.stdout)
+
+    assert measurement["output_chars"] > 0
+    assert measurement["delta_mib"] < 350

--- a/uv.lock
+++ b/uv.lock
@@ -2391,13 +2391,12 @@ wheels = [
 ]
 
 [[package]]
-name = "maincontentextractor"
-version = "0.0.4"
-source = { git = "https://github.com/HawkClaws/main_content_extractor?rev=7c3ed7f6ed7f6c10223a3357d43ab741663bc812#7c3ed7f6ed7f6c10223a3357d43ab741663bc812" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "html2text" },
-    { name = "trafilatura" },
+name = "lxml-stubs"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/da/1a3a3e5d159b249fc2970d73437496b908de8e4716a089c69591b4ffa6fd/lxml-stubs-0.5.1.tar.gz", hash = "sha256:e0ec2aa1ce92d91278b719091ce4515c12adc1d564359dfaf81efa7d4feab79d", size = 14778, upload-time = "2024-01-10T09:37:46.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/c9/e0f8e4e6e8a69e5959b06499582dca6349db6769cc7fdfb8a02a7c75a9ae/lxml_stubs-0.5.1-py3-none-any.whl", hash = "sha256:1f689e5dbc4b9247cb09ae820c7d34daeb1fdbd1db06123814b856dae7787272", size = 13584, upload-time = "2024-01-10T09:37:44.931Z" },
 ]
 
 [[package]]
@@ -2805,6 +2804,7 @@ dev = [
     { name = "halo" },
     { name = "joblib" },
     { name = "jupyter" },
+    { name = "lxml-stubs" },
     { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "pebble" },
@@ -2849,6 +2849,7 @@ dev = [
     { name = "halo", specifier = ">=0.0.28" },
     { name = "joblib", specifier = ">=1.4.2" },
     { name = "jupyter", specifier = ">=1.1.1" },
+    { name = "lxml-stubs", specifier = ">=0.5.1" },
     { name = "pandas" },
     { name = "pandas-stubs", specifier = ">=2.2.3.250308" },
     { name = "pebble", specifier = ">=5.1.1" },
@@ -2892,24 +2893,28 @@ name = "notte-browser"
 version = "1.4.4.dev0"
 source = { editable = "packages/notte-browser" }
 dependencies = [
-    { name = "maincontentextractor" },
+    { name = "html2text" },
+    { name = "lxml" },
     { name = "markdownify" },
     { name = "notte-core" },
     { name = "notte-llm" },
     { name = "patchright" },
     { name = "pillow" },
     { name = "tqdm" },
+    { name = "trafilatura" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "maincontentextractor", git = "https://github.com/HawkClaws/main_content_extractor?rev=7c3ed7f6ed7f6c10223a3357d43ab741663bc812" },
+    { name = "html2text", specifier = ">=2025.4.15" },
+    { name = "lxml", specifier = ">=5.3.1" },
     { name = "markdownify", specifier = ">=0.14.1" },
     { name = "notte-core", editable = "packages/notte-core" },
     { name = "notte-llm", editable = "packages/notte-llm" },
     { name = "patchright", specifier = "~=1.55" },
     { name = "pillow", specifier = ">=11.2.1" },
     { name = "tqdm", specifier = ">=4.66.0" },
+    { name = "trafilatura", specifier = ">=2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- replace repeated BeautifulSoup/MainContentExtractor parsing with one lxml DOM and direct html2text conversion
- preserve main/article/content-id selection, links, images, hidden content removal, iframe handling, and the Trafilatura fallback
- remove the MainContentExtractor dependency and declare the parsing dependencies directly
- add behavioral and subprocess peak-memory regression coverage

## Production context

A dense 4 MiB HTML document with 524,288 elements amplified to roughly 1.24 GiB RSS in the previous extraction path and contributed to notte-api OOM restarts. The new path measures about 216 MiB over baseline for the same fixture.

## Validation

- 52 tests under tests/pipe/scraping passed
- Ruff passed
- basedpyright passed with zero warnings
- notte-browser source distribution and wheel built successfully
- the 4 MiB dense-DOM regression stays below the 350 MiB RSS-delta threshold

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789565563&installation_model_id=8247&pr_number=899&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F899&signature=a165d69a2965af3c35e6a65fce517a1bebab5f67e89f187bae5aa3685c471012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved webpage-to-Markdown conversion by prioritizing main article content and removing hidden, unwanted, or irrelevant elements.
  * Added fallback extraction for complex or malformed pages.
  * Improved handling of images, links, configured tags, and nested content regions.
  * Empty or unextractable pages now produce a clear error instead of unusable output.

* **Documentation**
  * Added an integration reference for Hermes Agent.

* **Tests**
  * Added coverage for content selection, fallbacks, malformed HTML, image rendering, hidden elements, and memory usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->