### PR TITLE
feat(sdk): expose session close reason

### DIFF
--- a/docs/src/sdk-reference/misc/remotesession.mdx
+++ b/docs/src/sdk-reference/misc/remotesession.mdx
@@ -244,7 +244,7 @@ The current status information of the session.
 ### stop
 
 ```python
-stop()
+stop(close_reason: typing.Literal['manual', 'error'] = manual)
 ```
 
 Stop the session and clean up resources

--- a/docs/src/sdk-reference/misc/sessionresponse.mdx
+++ b/docs/src/sdk-reference/misc/sessionresponse.mdx
@@ -39,6 +39,10 @@ description: ""
   Session status
 </ParamField>
 
+<ParamField path="close_reason" type="Literal['manual', 'idle_timeout', 'max_duration', 'error', 'unknown'] | None">
+  Reason the session closed, if it is no longer active
+</ParamField>
+
 <ParamField path="steps" type="list[Dict[str, Any]]" required>
   Steps of the session
 </ParamField>

--- a/docs/src/sdk-reference/remotesession/stop.mdx
+++ b/docs/src/sdk-reference/remotesession/stop.mdx
@@ -33,6 +33,11 @@ with client.Session() as session:
 
 
 
+## Parameters
+
+<ParamField path="close_reason" type="Literal['manual', 'error']" default="manual">
+</ParamField>
+
 ## Returns
 
 `None`

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -69,6 +69,7 @@ from notte_sdk.types import (
     SessionResponse,
     SessionStartRequest,
     SessionStartRequestDict,
+    SessionStopRequest,
     SetCookiesRequest,
     SetCookiesResponse,
     TabSessionDebugRequest,
@@ -183,7 +184,9 @@ class SessionsClient(BaseClient):
         return NotteEndpoint(path=SessionsClient.SESSION_START, response=SessionResponse, method="POST")
 
     @staticmethod
-    def _session_stop_endpoint(session_id: str | None = None) -> NotteEndpoint[SessionResponse]:
+    def _session_stop_endpoint(
+        session_id: str | None = None, params: SessionStopRequest | None = None
+    ) -> NotteEndpoint[SessionResponse]:
         """
         Constructs a DELETE endpoint for closing a session.
 
@@ -199,7 +202,7 @@ class SessionsClient(BaseClient):
         path = SessionsClient.SESSION_STOP
         if session_id is not None:
             path = path.format(session_id=session_id)
-        return NotteEndpoint(path=path, response=SessionResponse, method="DELETE")
+        return NotteEndpoint(path=path, response=SessionResponse, method="DELETE", params=params)
 
     @staticmethod
     def _session_status_endpoint(session_id: str | None = None) -> NotteEndpoint[SessionResponse]:
@@ -328,7 +331,7 @@ class SessionsClient(BaseClient):
         return response
 
     @track_usage("cloud.session.stop")
-    def stop(self, session_id: str) -> SessionResponse:
+    def stop(self, session_id: str, close_reason: Literal["manual", "error"] = "manual") -> SessionResponse:
         """
         Stops an active session.
 
@@ -345,7 +348,10 @@ class SessionsClient(BaseClient):
             SessionResponse: The validated response from the session stop request.
         """
         logger.info(f"[Session] {session_id} is stopping")
-        endpoint = SessionsClient._session_stop_endpoint(session_id=session_id)
+        endpoint = SessionsClient._session_stop_endpoint(
+            session_id=session_id,
+            params=SessionStopRequest(close_reason=close_reason),
+        )
         response = self.request(endpoint)
         if response.status != "closed":
             raise RuntimeError(f"[Session] {session_id} failed to stop")
@@ -692,7 +698,12 @@ class RemoteSession(SyncResource):
             self._playwright_context = None
         self._playwright_page = None
 
-        self.stop()
+        try:
+            self.stop(close_reason="error" if exc_val is not None else "manual")
+        except Exception as stop_error:
+            if exc_val is None:
+                raise
+            logger.error(f"Failed to stop session after context manager exception: {stop_error}")
 
         if isinstance(exc_val, KeyboardInterrupt):
             raise KeyboardInterrupt() from None
@@ -725,7 +736,12 @@ class RemoteSession(SyncResource):
             self._async_playwright_context = None
         self._async_playwright_page = None
 
-        self.stop()
+        try:
+            self.stop(close_reason="error" if exc_val is not None else "manual")
+        except Exception as stop_error:
+            if exc_val is None:
+                raise
+            logger.error(f"Failed to stop session after async context manager exception: {stop_error}")
 
         if isinstance(exc_val, KeyboardInterrupt):
             raise KeyboardInterrupt() from None
@@ -812,7 +828,7 @@ class RemoteSession(SyncResource):
                 logger.warning(f"🍪 Cookie file {self._cookie_file} not found, skipping cookie loading")
 
     @override
-    def stop(self) -> None:
+    def stop(self, close_reason: Literal["manual", "error"] = "manual") -> None:
         """
         Stop the session and clean up resources.
 
@@ -852,7 +868,7 @@ class RemoteSession(SyncResource):
             except Exception as e:
                 logger.error(f"🍪 Error saving cookies to {self._cookie_file}: {e}")
         try:
-            self.response = self.client.stop(session_id=self.session_id)
+            self.response = self.client.stop(session_id=self.session_id, close_reason=close_reason)
         except Exception as e:
             if "already stopped" in str(e).lower() or "already closed" in str(e).lower():
                 logger.warning(f"Session {self.session_id} was already stopped")

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1160,6 +1160,13 @@ class SessionResponse(SdkResponse):
         return self.idle_timeout_minutes
 
 
+class SessionStopRequest(BaseModel):
+    close_reason: Annotated[
+        Literal["manual", "error"],
+        Field(description="Reason supplied by the client when stopping the session"),
+    ] = "manual"
+
+
 class ListFilesResponse(SdkResponse):
     files: Annotated[list[FileInfo], Field(description="List of files with metadata")]
 

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1091,6 +1091,10 @@ class SessionResponse(SdkResponse):
         Literal["active", "closed", "error", "timed_out"],
         Field(description="Session status"),
     ]
+    close_reason: Annotated[
+        Literal["manual", "idle_timeout", "max_duration", "error", "unknown"] | None,
+        Field(description="Reason the session closed, if it is no longer active"),
+    ] = None
     steps: Annotated[list[dict[str, Any]], Field(description="Steps of the session", repr=False)] = Field(
         default_factory=lambda: []
     )

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1160,6 +1160,10 @@ class SessionResponse(SdkResponse):
         return self.idle_timeout_minutes
 
 
+class SessionStopRequestDict(TypedDict, total=False):
+    close_reason: Literal["manual", "error"]
+
+
 class SessionStopRequest(BaseModel):
     close_reason: Annotated[
         Literal["manual", "error"],

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -201,7 +201,7 @@ def test_close_session(mock_delete: MagicMock, client: NotteClient, session_id: 
     mock_delete.assert_called_once_with(
         url=f"{client.sessions.server_url}/sessions/{session_id}/stop",
         headers=headers_copy,
-        params=None,
+        params={"close_reason": "manual"},
         timeout=client.sessions.DEFAULT_REQUEST_TIMEOUT_SECONDS,
     )
 

--- a/tests/sdk/test_session_context_close_reason.py
+++ b/tests/sdk/test_session_context_close_reason.py
@@ -1,0 +1,47 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from notte_sdk.endpoints.sessions import RemoteSession, SessionsClient
+from notte_sdk.types import SessionStopRequest
+
+
+def _bare_session() -> RemoteSession:
+    session = object.__new__(RemoteSession)
+    session._playwright_browser = None
+    session._playwright_context = None
+    session._playwright_page = None
+    session._async_playwright_browser = None
+    session._async_playwright_context = None
+    session._async_playwright_page = None
+    session.stop = MagicMock()
+    return session
+
+
+def test_stop_endpoint_sends_error_close_reason() -> None:
+    endpoint = SessionsClient._session_stop_endpoint(
+        session_id="session-id",
+        params=SessionStopRequest(close_reason="error"),
+    )
+
+    assert endpoint.params is not None
+    assert endpoint.params.model_dump() == {"close_reason": "error"}
+
+
+def test_sync_context_exception_stops_session_as_error() -> None:
+    session = _bare_session()
+
+    session.__exit__(RuntimeError, RuntimeError("callback failed"), None)
+
+    session.stop.assert_called_once_with(close_reason="error")
+
+
+@pytest.mark.asyncio
+async def test_async_context_exception_stops_session_as_error() -> None:
+    session = _bare_session()
+    browser = AsyncMock()
+    session._async_playwright_browser = browser
+
+    await session.__aexit__(RuntimeError, RuntimeError("callback failed"), None)
+
+    session.stop.assert_called_once_with(close_reason="error")
+    browser.close.assert_awaited_once()

--- a/tests/sdk/test_types.py
+++ b/tests/sdk/test_types.py
@@ -266,3 +266,12 @@ def test_session_duration_keeps_sub_second_precision():
     # `format` assertion is dropped rather than the precision.
     assert RFC_3339_DURATION.match(serialized) is None
     assert SessionResponse.model_validate_json(response.model_dump_json()).duration == response.duration
+
+
+def test_session_response_serializes_error_close_reason():
+    response = _session_response(dt.timedelta(seconds=1)).model_copy(
+        update={"status": "closed", "close_reason": "error"}
+    )
+
+    assert response.model_dump(mode="json")["close_reason"] == "error"
+    assert SessionResponse.model_validate_json(response.model_dump_json()).close_reason == "error"


### PR DESCRIPTION
## Summary

- add an optional close_reason field to SessionResponse
- expose manual, idle timeout, max duration, error, and unknown closure reasons
- verify JSON serialization and round-tripping

## Why

The session stop and status responses need to distinguish an ordinary close from an error-driven close, even when the top-level status is closed.

## Validation

- 18 SDK type tests passed
- Ruff lint and format checks passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789738727&installation_model_id=8247&pr_number=902&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F902&signature=73c3002e489ebfa7e2ce77827414d81136d1ea8fcfa9bb8229406a8d5ee6cf36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session stop operations now support specifying whether closure was manual or caused by an error.
  * Session responses report closure reasons, including timeouts, errors, and unknown causes.
  * Context-managed sessions automatically report errors when they close due to exceptions.

* **Documentation**
  * Updated SDK reference documentation with the new closure reason options and behavior.

* **Tests**
  * Added coverage for closure reason handling, serialization, and synchronous/asynchronous cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->