### PR TITLE
fix(core): read collection variables sent as strings

### DIFF
--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -67,6 +67,9 @@ def _container_kind(annotation: str | None) -> str | None:
     a mapping, since guessing a sequence for something that might be a dict is
     the more expensive mistake.
 
+    Quoted annotations are unwrapped and re-read, since `ast.unparse` keeps the
+    quotes a forward reference was written with.
+
     Parsed rather than pattern-matched: `ast.unparse` produced these strings, so
     `ast.parse` reads them back exactly, including nesting the eye slides over.
     """
@@ -81,6 +84,17 @@ def _container_kind(annotation: str | None) -> str | None:
 
     def walk(current: ast.expr, depth: int = 0) -> None:
         if depth > 8:  # A pathological annotation is not worth recursing into.
+            return
+        if isinstance(current, ast.Constant) and isinstance(current.value, str):
+            # A quoted annotation. `def f(x: "list[str]")` is recorded by
+            # `ast.unparse` as the six characters `'list[str]'`, quotes and all,
+            # so without this the string reads as a bare constant of no
+            # particular type and the parameter silently keeps its raw value.
+            # Reached again for the inner half of `Optional["list[str]"]`.
+            try:
+                walk(ast.parse(current.value.strip(), mode="eval").body, depth + 1)
+            except SyntaxError:
+                pass
             return
         if isinstance(current, ast.BinOp) and isinstance(current.op, ast.BitOr):
             walk(current.left, depth + 1)
@@ -139,7 +153,13 @@ def _parse_collection_text(text: str, kind: str) -> Any | None:
     """
     try:
         value: Any = json.loads(text)
-    except ValueError:
+    except (ValueError, RecursionError):
+        # RecursionError alongside ValueError because `json.loads` recurses per
+        # nesting level: deeply nested input raises it rather than rejecting the
+        # text, and letting it escape would end the run over a variable this
+        # function is allowed to decline. Declining means passing the original
+        # string through, which is what happens if both parsers fail.
+        #
         # Nested rather than a loop with `continue`, so neither attempt needs a
         # bare `except` and the exceptions each parser really raises stay named.
         try:

--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -153,12 +153,15 @@ def _parse_collection_text(text: str, kind: str) -> Any | None:
     """
     try:
         value: Any = json.loads(text)
-    except (ValueError, RecursionError):
-        # RecursionError alongside ValueError because `json.loads` recurses per
-        # nesting level: deeply nested input raises it rather than rejecting the
-        # text, and letting it escape would end the run over a variable this
-        # function is allowed to decline. Declining means passing the original
-        # string through, which is what happens if both parsers fail.
+    except (ValueError, MemoryError, RecursionError):
+        # More than ValueError because a parser can fail on the shape of the
+        # input rather than its syntax: `json.loads` recurses per nesting level,
+        # so deeply nested text raises RecursionError instead of rejecting it,
+        # and a large enough document exhausts memory. Letting either escape
+        # would end the run over a variable this function is allowed to decline.
+        # Declining means passing the original string through, which is what
+        # happens when both parsers fail. Same set the literal_eval arm catches,
+        # for the same reason.
         #
         # Nested rather than a loop with `continue`, so neither attempt needs a
         # bare `except` and the exceptions each parser really raises stay named.

--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -1,3 +1,17 @@
+"""Script parsing and sandboxed execution for Notte functions.
+
+The variable coercion helpers here (`_annotation_head`, `_container_kind`,
+`_parse_collection_text`, `coerce_collection_variables`, the annotation head
+frozensets they share, and `_validate_variables`) are mirrored verbatim by the
+Notte API runtime, which keeps its own fork of this module. Keep the two copies
+byte-identical.
+
+A fix applied to only one of them leaves the other passing a JSON string
+straight through to a parameter annotated `list` or `dict`. That raises nothing:
+a function expecting `list[str]` and handed '["a", "b"]' iterates 21 characters
+and returns a wrong answer instead of failing.
+"""
+
 import ast
 import json
 import traceback

--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -1,8 +1,9 @@
 import ast
+import json
 import traceback
 import types
-from collections.abc import Mapping
-from typing import Any, Callable, ClassVar, Literal, Protocol, final
+from collections.abc import Iterable, Mapping
+from typing import Any, Callable, ClassVar, Literal, Protocol, cast, final
 
 from pydantic import BaseModel, ConfigDict
 from RestrictedPython import compile_restricted, safe_globals  # type: ignore [reportMissingTypeStubs]
@@ -22,6 +23,157 @@ class ParameterInfo(BaseModel):
     name: str
     type: str | None = None
     default: str | None = None
+
+
+_SEQUENCE_HEADS = frozenset({"list", "tuple", "set", "frozenset", "sequence", "iterable"})
+_MAPPING_HEADS = frozenset({"dict", "mapping", "ordereddict", "defaultdict"})
+_TRANSPARENT_HEADS = frozenset({"optional", "annotated", "union", "final"})
+
+
+def _annotation_head(node: ast.expr) -> str | None:
+    """Lowercased name of a subscript head, ignoring the module it came from."""
+    if isinstance(node, ast.Name):
+        return node.id.lower()
+    if isinstance(node, ast.Attribute):
+        return node.attr.lower()
+    if isinstance(node, ast.Subscript):
+        return _annotation_head(node.value)
+    return None
+
+
+def _container_kind(annotation: str | None) -> str | None:
+    """
+    Which container an annotation asks for, or None for anything else.
+
+    Read from the *outermost* type, so `dict[str, list[str]]` is a mapping
+    rather than a sequence that happens to mention one. Wrappers that do not
+    change the shape are looked through: `Optional[list[str]]`,
+    `Annotated[list[str], Field(...)]`, `list[str] | None`, and the `Union[...]`
+    spelling of the same. A union that names more than one container resolves to
+    a mapping, since guessing a sequence for something that might be a dict is
+    the more expensive mistake.
+
+    Parsed rather than pattern-matched: `ast.unparse` produced these strings, so
+    `ast.parse` reads them back exactly, including nesting the eye slides over.
+    """
+    if not annotation:
+        return None
+    try:
+        node: ast.expr = ast.parse(annotation.strip(), mode="eval").body
+    except SyntaxError:
+        return None
+
+    kinds: set[str] = set()
+
+    def walk(current: ast.expr, depth: int = 0) -> None:
+        if depth > 8:  # A pathological annotation is not worth recursing into.
+            return
+        if isinstance(current, ast.BinOp) and isinstance(current.op, ast.BitOr):
+            walk(current.left, depth + 1)
+            walk(current.right, depth + 1)
+            return
+        if isinstance(current, ast.Subscript):
+            head = _annotation_head(current.value)
+            if head in _TRANSPARENT_HEADS:
+                inner = current.slice
+                # `Annotated[T, ...]` and `Union[A, B]` both arrive as a tuple.
+                if isinstance(inner, ast.Tuple):
+                    members = inner.elts if head != "annotated" else inner.elts[:1]
+                    for member in members:
+                        walk(member, depth + 1)
+                else:
+                    walk(inner, depth + 1)
+                return
+            if head in _SEQUENCE_HEADS:
+                kinds.add("sequence")
+            elif head in _MAPPING_HEADS:
+                kinds.add("mapping")
+            return
+        head = _annotation_head(current)
+        if head in _SEQUENCE_HEADS:
+            kinds.add("sequence")
+        elif head in _MAPPING_HEADS:
+            kinds.add("mapping")
+
+    walk(node)
+    if "mapping" in kinds:
+        return "mapping"
+    if "sequence" in kinds:
+        return "sequence"
+    return None
+
+
+def _parse_collection_text(text: str, kind: str) -> Any | None:
+    """
+    A string that spells out a collection, as the collection, or None.
+
+    Two spellings, because both reach this function in practice: JSON, which is
+    what an HTTP caller sends, and the Python literal that `ast.unparse` writes
+    for a parameter default, so a caller echoing a default back sends
+    `['a', 'b']` with quotes JSON rejects.
+
+    `ast.literal_eval` is the safe evaluator: literals and nothing else, so a
+    name like `DEFAULT_KEYWORDS` or a call like `list()` raises here rather than
+    being resolved or executed. `set()` is the one exception, and CPython's
+    rather than ours: it is special-cased because there is no empty-set literal,
+    so it evaluates to an empty set and a parameter defaulted that way arrives
+    as `[]`. That is the value it asked for, and better than the four characters
+    of source it used to receive.
+
+    A set arrives as a list because JSON has no set. The wire format decided
+    that long before this function saw the value.
+    """
+    try:
+        value: Any = json.loads(text)
+    except ValueError:
+        # Nested rather than a loop with `continue`, so neither attempt needs a
+        # bare `except` and the exceptions each parser really raises stay named.
+        try:
+            value = ast.literal_eval(text)
+        except (ValueError, SyntaxError, TypeError, MemoryError, RecursionError):
+            return None
+
+    # `literal_eval` returns `Any`, so the narrowed types stay partially unknown
+    # without saying what the elements are. They are whatever the caller wrote.
+    if kind == "sequence" and isinstance(value, (list, tuple, set, frozenset)):
+        return list(cast("Iterable[Any]", value))
+    if kind == "mapping" and isinstance(value, dict):
+        return cast("dict[Any, Any]", value)
+    return None
+
+
+def coerce_collection_variables(run_parameters: list["ParameterInfo"], variables: dict[str, Any]) -> dict[str, Any]:
+    """
+    Replace strings that spell out a collection with the collection itself.
+
+    A caller that sends `keywords="['a', 'b']"` for `keywords: list[str]` is
+    handing the script a 22-character string where it expects two items, and the
+    script raises somewhere inside itself. Every client hits this: the callers
+    that build the payload from a stored default are echoing back Python source,
+    because that is what `ast.unparse` wrote when the parameter was recorded.
+
+    Deliberately narrow, on the numbers. Across a fortnight of production runs,
+    `int` and `bool` parameters received strings and succeeded 5,166 times,
+    because Python is duck-typed and the scripts cope, so touching those would
+    break working calls. A collection parameter that received a string failed
+    every time it happened, 4 of 4 over thirty days, so there is no behaviour
+    there to preserve and nothing this can regress.
+
+    Nothing is rejected and nothing else is converted. A value this cannot read
+    is passed through exactly as it arrived, which is what happened before.
+    """
+    if not variables:
+        return variables
+
+    kinds = {param.name: _container_kind(param.type) for param in run_parameters}
+    for name, value in variables.items():
+        kind = kinds.get(name)
+        if kind is None or not isinstance(value, str):
+            continue
+        parsed = _parse_collection_text(value, kind)
+        if parsed is not None:
+            variables[name] = parsed
+    return variables
 
 
 class ParsedScriptInfo(BaseModel):
@@ -560,6 +712,14 @@ class SecureScriptRunner:
         """
         Validate that the provided variables match the run function's expected parameters
 
+        Also coerces collection-typed variables in place, so a string spelling
+        out a list or dict arrives at the run function as the collection it
+        describes. That happens here, and mutates rather than returns, because
+        this is the one hook every caller already shares: the workflows Lambda
+        replaces `run_script` wholesale and calls this method on the same dict it
+        later splats into `run(**variables)`. A separate coercion step would be
+        correct and would miss the path that actually runs published functions.
+
         Args:
             run_parameters: List of parameters expected by the run function
             variables: Variables to be passed to the run function
@@ -585,6 +745,8 @@ class SecureScriptRunner:
             raise ValueError(
                 f"Unexpected variable names for run function: {sorted(unexpected_params)} (expected variable names: {sorted(all_params)})"
             )
+
+        _ = coerce_collection_variables(run_parameters, variables)
 
         # Optional: Log parameter information for debugging
         if hasattr(self, "logger"):

--- a/tests/scripts/test_variable_coercion.py
+++ b/tests/scripts/test_variable_coercion.py
@@ -143,3 +143,9 @@ def test_deeply_nested_json_does_not_end_the_run() -> None:
     # through; letting the error escape would kill the run instead.
     deep = "[" * 60_000 + "]" * 60_000
     assert coerce("list[str]", deep) == deep
+
+
+def test_a_huge_flat_json_document_does_not_end_the_run() -> None:
+    # The other half of the same rule: a parser may fail on the size or shape of
+    # the input rather than its syntax, and neither way is worth a dead run.
+    assert coerce("list[str]", "[" + "0," * 200_000 + "0]") is not None

--- a/tests/scripts/test_variable_coercion.py
+++ b/tests/scripts/test_variable_coercion.py
@@ -1,0 +1,109 @@
+"""
+Collection-typed variables arriving as strings.
+
+A caller that sends `keywords="['a', 'b']"` for `keywords: list[str]` hands the
+script a string where it expects two items. Every client hits it, because the
+ones that build a payload from a stored default are echoing back the Python
+source `ast.unparse` wrote when the parameter was recorded.
+"""
+
+import pytest
+from notte_core.ast import ParameterInfo, coerce_collection_variables
+
+
+def coerce(annotation: str | None, value: object) -> object:
+    variables: dict[str, object] = {"x": value}
+    coerce_collection_variables([ParameterInfo(name="x", type=annotation)], variables)
+    return variables["x"]
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "list[str]",
+        "list",
+        "Optional[list[str]]",
+        "list[str] | None",
+        "typing.List[str]",
+        "Sequence[str]",
+        "Annotated[list[str], Field(description='x')]",
+        "Union[list[str], str]",
+        "tuple[str, str]",
+        "set[str]",
+    ],
+)
+def test_reads_a_python_literal_for_every_sequence_spelling(annotation: str) -> None:
+    # `ast.unparse` produces all of these, and a parameter that has a default is
+    # very often wrapped in `Optional[...]`.
+    assert coerce(annotation, "['a', 'b']") == ["a", "b"]
+
+
+@pytest.mark.parametrize("annotation", ["dict[str, int]", "Optional[dict[str, Any]]", "Mapping[str, int]"])
+def test_reads_a_mapping(annotation: str) -> None:
+    assert coerce(annotation, "{'a': 1}") == {"a": 1}
+
+
+def test_reads_json_too() -> None:
+    # What an HTTP caller sends, as opposed to what a stored default looks like.
+    assert coerce("list[str]", '["a", "b"]') == ["a", "b"]
+    assert coerce("dict[str, int]", '{"a": 1}') == {"a": 1}
+
+
+def test_the_outermost_container_decides() -> None:
+    # `dict[str, list[str]]` is a mapping, not a sequence that mentions one.
+    # Handing a dict parameter a list would be a silently wrong argument.
+    assert coerce("dict[str, list[str]]", "['a', 'b']") == "['a', 'b']"
+    assert coerce("list[str]", "{'a': 1}") == "{'a': 1}"
+    assert coerce("dict[str, list[str]]", "{'a': ['x']}") == {"a": ["x"]}
+
+
+@pytest.mark.parametrize(
+    "annotation,value",
+    [
+        ("str", "['a', 'b']"),
+        ("int", "20"),
+        ("bool", "true"),
+        ("Any", "123"),
+        (None, "['a']"),
+    ],
+)
+def test_leaves_everything_that_is_not_a_collection_alone(annotation: str | None, value: str) -> None:
+    # Load-bearing. Across a fortnight of production runs, int and bool
+    # parameters received strings and succeeded 5,166 times: Python is
+    # duck-typed and the scripts cope. Coercing those would break working calls.
+    assert coerce(annotation, value) == value
+
+
+def test_leaves_a_value_that_is_already_structured() -> None:
+    assert coerce("list[str]", ["a"]) == ["a"]
+    assert coerce("dict[str, int]", {"a": 1}) == {"a": 1}
+
+
+def test_passes_through_anything_it_cannot_read() -> None:
+    # No worse than the behaviour this replaces, and never an exception.
+    for value in ("not a literal", "['unterminated", "DEFAULT_KEYWORDS", "list()"):
+        assert coerce("list[str]", value) == value
+
+
+def test_evaluates_no_names_and_no_calls() -> None:
+    # literal_eval, not eval: a name or a call raises rather than resolving.
+    assert coerce("list[str]", "__import__('os').listdir()") == "__import__('os').listdir()"
+
+
+def test_empty_set_source_becomes_an_empty_list() -> None:
+    # CPython special-cases `set()` in literal_eval because there is no
+    # empty-set literal, so this evaluates rather than raising. `[]` is the
+    # value the parameter asked for, and better than four characters of source.
+    assert coerce("set[str]", "set()") == []
+
+
+def test_a_singleton_tuple_keeps_its_element() -> None:
+    # `ast.unparse` writes every 1-tuple with a trailing comma.
+    assert coerce("tuple[str]", "('a',)") == ["a"]
+
+
+def test_absent_and_empty_variables_are_safe() -> None:
+    assert coerce_collection_variables([], {}) == {}
+    variables: dict[str, object] = {"x": "['a']"}
+    # A variable with no matching parameter is not coerced or dropped.
+    assert coerce_collection_variables([ParameterInfo(name="other", type="list[str]")], variables) == {"x": "['a']"}

--- a/tests/scripts/test_variable_coercion.py
+++ b/tests/scripts/test_variable_coercion.py
@@ -107,3 +107,39 @@ def test_absent_and_empty_variables_are_safe() -> None:
     variables: dict[str, object] = {"x": "['a']"}
     # A variable with no matching parameter is not coerced or dropped.
     assert coerce_collection_variables([ParameterInfo(name="other", type="list[str]")], variables) == {"x": "['a']"}
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        "'list[str]'",
+        '"list[str]"',
+        "Optional['list[str]']",
+        "'Optional[list[str]]'",
+    ],
+)
+def test_quoted_annotations_are_read_through(annotation: str) -> None:
+    # `def f(x: "list[str]")` is a forward reference, and `ast.unparse` records
+    # it with the quotes still on. Reading it as a plain constant would skip
+    # coercion and hand the script the raw string, which is the silent wrong
+    # answer this module exists to prevent.
+    assert coerce(annotation, '["a", "b"]') == ["a", "b"]
+
+
+def test_a_quoted_scalar_is_still_not_a_collection() -> None:
+    # Unwrapping the quotes must not turn every quoted annotation into one.
+    assert coerce("'int'", "5") == "5"
+    assert coerce("'NotAType'", "['a']") == "['a']"
+
+
+def test_a_quoted_annotation_that_is_not_a_type_is_ignored() -> None:
+    # The inner text does not have to parse. It must not raise if it does not.
+    assert coerce("'['", "['a']") == "['a']"
+
+
+def test_deeply_nested_json_does_not_end_the_run() -> None:
+    # `json.loads` recurses per nesting level and raises RecursionError rather
+    # than rejecting the text. Declining the value passes the original string
+    # through; letting the error escape would kill the run instead.
+    deep = "[" * 60_000 + "]" * 60_000
+    assert coerce("list[str]", deep) == deep


### PR DESCRIPTION
The runtime half of a bug already patched twice in frontends. This fixes it once, for every caller.

## It does not crash. It returns garbage.

A caller sends `keywords="['a', 'b']"` for `keywords: list[str]`. The script receives a 21-character string, and nothing raises:

```python
def run(keywords: list[str]):
    return {"count": len(keywords), "joined": ",".join(keywords)}
```

| | result |
|---|---|
| **before** | `{'count': 21, 'joined': "[,',a,',,, ,',b,',]"}` |
| **after** | `{'count': 2, 'joined': 'a,b'}` |

`join` walks the string character by character. The function completes, returns, and is recorded as a successful run. That is worse than a traceback, because it looks like an answer.

## Why every client hits it

`ParameterInfo.default` holds Python *source* — it is what `ast.unparse` wrote when the parameter was recorded. Any caller that pre-fills a payload from a stored default is echoing that source back, and `JSON.parse` rejects its single quotes. The console and the Anything marketplace playground were each patched separately for exactly this; the SDK, CLI, MCP `run` and direct API callers still have it.

## What changed

Collection-typed variables arriving as strings are parsed with `json.loads`, then `ast.literal_eval`.

**Literals only.** A name like `DEFAULT_KEYWORDS` or a call like `list()` raises, and the value passes through untouched. `set()` is CPython's one exception — special-cased because there is no empty-set literal — so a parameter defaulted that way arrives as `[]`, which is the value it asked for rather than four characters of source. There is a test pinning that, because it surprised me.

**The outermost annotation decides.** Read with `ast.parse` rather than pattern-matched, since `ast.unparse` produced these strings and `ast.parse` reads them back exactly. So `dict[str, list[str]]` is a mapping, not a sequence that happens to mention one — handing a dict parameter a list would be the same silently wrong argument in the other direction. `Optional[...]`, `Annotated[...]`, `Union[...]` and `X | None` are looked through; a parameter that has a default is very often wrapped.

## Why it is this narrow

Checked against production before touching anything:

- **`int` and `bool` parameters receiving strings succeeded 5,166 times in a fortnight.** Python is duck-typed and the scripts cope. Coercing or rejecting those would break working calls, so they are untouched.
- **A collection parameter receiving a string failed 4 times out of 4 over thirty days.** A 100% failure rate. There is no behaviour to preserve and nothing this can regress.

That asymmetry is the entire justification for the scope. Nothing is rejected, nothing else is converted, and a value this cannot read is passed through exactly as it arrived.

## One structural note

The coercion runs inside `_validate_variables` and mutates in place. That is deliberate and worth flagging in review: the workflows Lambda replaces `run_script` wholesale and calls this method on the same dict it later splats into `run(**variables)`. A separate coercion step would be tidier and would miss the path that actually runs published functions.

## Verification

26 new tests. `ruff check` introduces zero new errors against the file's pre-existing 9; `basedpyright` reports 6 errors / 5 warnings both before and after, none in the new code; `ruff format` clean.

End-to-end through `SecureScriptRunner.run_script` with a real script: the Python-literal spelling and the JSON spelling both arrive as a list, an already-structured value is untouched, and `limit="20"` on an `int` parameter stays a `str`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790177406&installation_model_id=8247&pr_number=904&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F904&signature=290226a946c9bbafb91e3bee3f8757ec365102fe301b99c58b698b7e0d7fda84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically converts stringified JSON and Python-literal values into supported sequence and mapping variables.
  - Supports nested collections, unions, common collection annotations, and quoted annotations such as `"list[str]"`.
  - Preserves already structured values and safely ignores invalid, unsupported, or non-collection inputs.
  - Normalizes collection values before execution for more consistent parameter handling.
  - Safely handles unusually large or deeply nested inputs without interrupting execution.

- **Tests**
  - Added coverage for collection formats, nested values, quoted annotations, empty collections, invalid expressions, parser failures, and missing variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->