### PR TITLE
Raise on evaluate_js failure instead of returning a null DataSpace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,12 @@ repos:
         language: system
         files: ^docs/src/(docs\.json|scripts/check_docs_nav\.py)$
         pass_filenames: false
+      - id: docs-config-defaults
+        name: Check documented session-config defaults against the SDK
+        entry: bash -c "uv run python docs/src/scripts/check_config_docs_defaults.py"
+        language: system
+        files: ^(docs/src/features/sessions/configuration\.mdx|docs/src/scripts/check_config_docs_defaults\.py|packages/notte-sdk/src/notte_sdk/types\.py|packages/notte-core/src/notte_core/config\.toml)$
+        pass_filenames: false
       - id: docs-quickstart-setup-prompt
         name: Inline Quickstart setup prompt
         entry: bash -c "cd docs/src && uv run python scripts/inline_quickstart_setup_prompt.py --check"

--- a/docs/src/features/sessions/configuration.mdx
+++ b/docs/src/features/sessions/configuration.mdx
@@ -38,11 +38,11 @@ Customize your session with these options:
 
 ### Common Parameters
 
-<ParamField path="headless" type="boolean" default={true}>
+<ParamField path="headless" type="boolean" default={false}>
   Whether to run the browser in headless mode. Set to `false` to open a live viewer in your browser.
 </ParamField>
 
-<ParamField path="solve_captchas" type="boolean" default={false}>
+<ParamField path="solve_captchas" type="boolean" default={true}>
   Automatically detect and solve captchas (reCAPTCHA, hCaptcha, etc.)
 </ParamField>
 
@@ -63,7 +63,7 @@ Customize your session with these options:
   Browser viewport height in pixels.
 </ParamField>
 
-<ParamField path="browser_type" type="string" default={"chrome"}>
+<ParamField path="browser_type" type="string" default={"chromium"}>
   Browser engine to use: `"chromium"`, or `"chrome"`.
 </ParamField>
 
@@ -81,7 +81,7 @@ Customize your session with these options:
   Connect to an external browser session via Chrome DevTools Protocol URL (e.g., from Kernel.sh or other providers).
 </ParamField>
 
-<ParamField path="use_file_storage" type="boolean" default={false}>
+<ParamField path="use_file_storage" type="boolean" default={true}>
   Enable file storage for uploading/downloading files during the session.
 </ParamField>
 

--- a/docs/src/features/sessions/configuration.mdx
+++ b/docs/src/features/sessions/configuration.mdx
@@ -97,7 +97,7 @@ Customize your session with these options:
   Default perception type for observations: `"fast"` (simple) or `"deep"` (LLM-powered).
 </ParamField>
 
-<ParamField path="raise_on_failure" type="boolean" default={false}>
+<ParamField path="raise_on_failure" type="boolean" default={true}>
   Raise exceptions when action execution fails instead of returning error results.
 </ParamField>
 

--- a/docs/src/scripts/check_config_docs_defaults.py
+++ b/docs/src/scripts/check_config_docs_defaults.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Check documented session-config defaults against the SDK's actual values.
+
+`docs/src/features/sessions/configuration.mdx` is hand-written, so its
+`<ParamField default={...}>` values can silently drift from the code (the page
+said `raise_on_failure` defaults to false for seven months while the config
+said true). This check compares every documented default against the source of
+truth: `SessionStartRequest` field defaults and `notte_core` config values.
+
+Doc param names do not always match field names one-to-one, so the mapping in
+`code_defaults()` is explicit; a documented default with no mapping entry is an
+error, which forces the mapping to grow with the page.
+
+Run from the repo root (the script needs the workspace venv for notte imports):
+    uv run python docs/src/scripts/check_config_docs_defaults.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIGURATION_MDX = REPO_ROOT / "docs" / "src" / "features" / "sessions" / "configuration.mdx"
+
+PARAM_FIELD_RE = re.compile(r'<ParamField\s+path="([^"]+)"[^>]*?\sdefault=(\{[^}]*\}|"[^"]*")')
+
+
+def code_defaults() -> dict[str, Any]:
+    from notte_core.common.config import config
+    from notte_sdk.types import (
+        DEFAULT_HEADLESS_VIEWPORT_HEIGHT,
+        DEFAULT_HEADLESS_VIEWPORT_WIDTH,
+        SessionStartRequest,
+    )
+
+    fields = SessionStartRequest.model_fields
+
+    def field_default(name: str) -> Any:
+        return fields[name].default
+
+    return {
+        "headless": field_default("headless"),
+        "solve_captchas": field_default("solve_captchas"),
+        "proxies": field_default("proxies"),
+        # the docs param is the SDK's idle timeout
+        "timeout_minutes": field_default("idle_timeout_minutes"),
+        # the request fields default to None ("server decides"); the effective
+        # server defaults are these shared constants
+        "viewport_width": DEFAULT_HEADLESS_VIEWPORT_WIDTH,
+        "viewport_height": DEFAULT_HEADLESS_VIEWPORT_HEIGHT,
+        "browser_type": field_default("browser_type"),
+        "use_file_storage": field_default("use_file_storage"),
+        "perception_type": config.perception_type,
+        "raise_on_failure": config.raise_on_session_execution_failure,
+    }
+
+
+def parse_doc_default(token: str) -> Any:
+    """Turn a ParamField default token (`{true}`, `{3}`, `{"chrome"}`, `"fast"`) into a value."""
+    if token.startswith('"'):
+        return token[1:-1]
+    inner = token[1:-1].strip()
+    if inner == "true":
+        return True
+    if inner == "false":
+        return False
+    if inner.startswith('"') and inner.endswith('"'):
+        return inner[1:-1]
+    try:
+        return int(inner)
+    except ValueError:
+        return inner
+
+
+def normalize(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def main() -> int:
+    text = CONFIGURATION_MDX.read_text()
+    expected = code_defaults()
+    errors: list[str] = []
+    checked = 0
+
+    for match in PARAM_FIELD_RE.finditer(text):
+        name, token = match.group(1), match.group(2)
+        doc_value = parse_doc_default(token)
+        if name not in expected:
+            errors.append(
+                f"{name}: documented default {doc_value!r} has no entry in code_defaults(); "
+                "add a mapping to the code's source of truth"
+            )
+            continue
+        checked += 1
+        code_value = normalize(expected[name])
+        if doc_value != code_value or isinstance(doc_value, bool) is not isinstance(code_value, bool):
+            errors.append(f"{name}: docs say {doc_value!r}, code default is {code_value!r}")
+
+    if checked == 0:
+        errors.append(f"no ParamField defaults found in {CONFIGURATION_MDX}; the regex or the page drifted")
+
+    if errors:
+        print(f"{CONFIGURATION_MDX.relative_to(REPO_ROOT)} disagrees with the SDK defaults:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"checked {checked} documented defaults against the SDK: all match")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -64,7 +64,7 @@ from notte_core.common.resource import AsyncResource, SyncResource
 from notte_core.common.telemetry import track_usage
 from notte_core.credentials.base import BaseVault, LocatorAttributes
 from notte_core.data.space import DataSpace, ImageData, StructuredData, TBaseModel
-from notte_core.errors.actions import InvalidActionError
+from notte_core.errors.actions import ActionExecutionError, InvalidActionError
 from notte_core.errors.base import NotteBaseError
 from notte_core.errors.provider import RateLimitError
 from notte_core.profiling import profiler
@@ -761,9 +761,15 @@ class NotteSession(AsyncResource, SyncResource):
                         except asyncio.TimeoutError:
                             success = False
                             message = f"JavaScript evaluation timed out after {config.timeout_evaluate_js_ms}ms"
+                            exception = ActionExecutionError(
+                                action_id=resolved_action.type, url=self.window.page.url, reason=message
+                            )
                         except PlaywrightError as js_err:
                             success = False
                             message = f"JavaScript evaluation failed: {js_err}"
+                            exception = ActionExecutionError(
+                                action_id=resolved_action.type, url=self.window.page.url, reason=message
+                            )
                         else:
                             # Convert result to string representation for markdown
                             if result is None:

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -761,15 +761,9 @@ class NotteSession(AsyncResource, SyncResource):
                         except asyncio.TimeoutError:
                             success = False
                             message = f"JavaScript evaluation timed out after {config.timeout_evaluate_js_ms}ms"
-                            exception = ActionExecutionError(
-                                action_id=resolved_action.type, url=self.window.page.url, reason=message
-                            )
                         except PlaywrightError as js_err:
                             success = False
                             message = f"JavaScript evaluation failed: {js_err}"
-                            exception = ActionExecutionError(
-                                action_id=resolved_action.type, url=self.window.page.url, reason=message
-                            )
                         else:
                             # Convert result to string representation for markdown
                             if result is None:
@@ -803,6 +797,9 @@ class NotteSession(AsyncResource, SyncResource):
                             )
                         else:
                             success = await self.controller.execute(self.window, resolved_action, self._snapshot)
+                        if not success:
+                            # `message` still holds the success-phrased execution_message.
+                            message = f"Action '{resolved_action.type}' failed during browser execution"
 
             except (NoSnapshotObservedError, NoStorageObjectProvidedError, NoToolProvidedError) as e:
                 # this should be handled by the caller
@@ -860,6 +857,17 @@ class NotteSession(AsyncResource, SyncResource):
             else:
                 resolved_action = step_action
 
+        if not success and exception is None:
+            # Actions that signal failure by returning (a tool returning `success=False`,
+            # a controller action returning `False`) carry no exception. Synthesize one
+            # before the result is built so the returned result, the trajectory and the
+            # raise below all agree on what failed.
+            exception = ActionExecutionError(
+                action_id=resolved_action.type,
+                url=self._window.page.url if self._window is not None else "",
+                reason=message or "unknown",
+            )
+
         execution_result = ExecutionResult(
             action=resolved_action,
             success=success,
@@ -879,16 +887,10 @@ class NotteSession(AsyncResource, SyncResource):
                 logger.warning(f"Failed to capture post-action screenshot: {e}")
 
         _raise_on_failure = raise_on_failure if raise_on_failure is not None else self.default_raise_on_failure
-        if _raise_on_failure and not success:
-            # Gate on "did the action fail", not "did something throw". Actions that signal
-            # failure by returning (a tool returning `success=False`, a controller action
-            # returning `False`) would otherwise be silently swallowed, the way evaluate_js was.
-            if exception is None:
-                exception = ActionExecutionError(
-                    action_id=resolved_action.type,
-                    url=self._window.page.url if self._window is not None else "",
-                    reason=message or "unknown",
-                )
+        # Gate on "did the action fail", not "did something throw": after the synthesis
+        # above, every failure carries an exception, including the return-style ones
+        # that were previously silently swallowed, the way evaluate_js was.
+        if _raise_on_failure and exception is not None:
             raise exception
         return execution_result
 

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -466,6 +466,7 @@ class NotteSession(AsyncResource, SyncResource):
         only_unread: bool | None = None,
         time_window: dt.timedelta | None = None,
         limit: int | None = None,
+        raise_on_failure: bool = False,
     ) -> ExecutionResult:
         if not self._has_any_persona_tool():
             raise ValueError(
@@ -478,7 +479,9 @@ class NotteSession(AsyncResource, SyncResource):
             payload["timedelta"] = time_window
         if limit is not None:
             payload["limit"] = limit
-        return await self.aexecute(**payload)
+        # reads are queries: a tool reporting "nothing yet" is data, not an error,
+        # so polling `while not session.read_emails().success` keeps working
+        return await self.aexecute(raise_on_failure=raise_on_failure, **payload)
 
     def read_emails(
         self,
@@ -486,8 +489,13 @@ class NotteSession(AsyncResource, SyncResource):
         only_unread: bool | None = None,
         time_window: dt.timedelta | None = None,
         limit: int | None = None,
+        raise_on_failure: bool = False,
     ) -> ExecutionResult:
-        return asyncio.run(self.aread_emails(only_unread=only_unread, time_window=time_window, limit=limit))
+        return asyncio.run(
+            self.aread_emails(
+                only_unread=only_unread, time_window=time_window, limit=limit, raise_on_failure=raise_on_failure
+            )
+        )
 
     async def aread_sms(
         self,
@@ -495,6 +503,7 @@ class NotteSession(AsyncResource, SyncResource):
         only_unread: bool | None = None,
         time_window: dt.timedelta | None = None,
         limit: int | None = None,
+        raise_on_failure: bool = False,
     ) -> ExecutionResult:
         if not self._has_any_persona_tool():
             raise ValueError(
@@ -507,7 +516,7 @@ class NotteSession(AsyncResource, SyncResource):
             payload["timedelta"] = time_window
         if limit is not None:
             payload["limit"] = limit
-        return await self.aexecute(**payload)
+        return await self.aexecute(raise_on_failure=raise_on_failure, **payload)
 
     def read_sms(
         self,
@@ -515,8 +524,13 @@ class NotteSession(AsyncResource, SyncResource):
         only_unread: bool | None = None,
         time_window: dt.timedelta | None = None,
         limit: int | None = None,
+        raise_on_failure: bool = False,
     ) -> ExecutionResult:
-        return asyncio.run(self.aread_sms(only_unread=only_unread, time_window=time_window, limit=limit))
+        return asyncio.run(
+            self.aread_sms(
+                only_unread=only_unread, time_window=time_window, limit=limit, raise_on_failure=raise_on_failure
+            )
+        )
 
     async def locate(self, action: BaseAction) -> Locator | None:
         action_with_selector = await NodeResolutionPipe.forward(action, self._snapshot)
@@ -898,8 +912,11 @@ class NotteSession(AsyncResource, SyncResource):
         with open(actions_file, "r") as f:
             action_list = ActionList.model_validate_json(f.read())
         for i, action in enumerate(action_list.actions):
-            logger.info(f"💡 Step {i + 1}/{len(action_list.actions)}: executing action '{action.type}' {action.id}")
-            res = self.execute(action)
+            # browser-level actions (wait, goto, ...) have no `id` attribute
+            action_id = getattr(action, "id", "")
+            logger.info(f"💡 Step {i + 1}/{len(action_list.actions)}: executing action '{action.type}' {action_id}")
+            # replay stops gracefully on the first failed step instead of raising
+            res = self.execute(action, raise_on_failure=False)
             logger.info(f"{'✅' if res.success else '❌'} - {res.message}")
             if not res.success:
                 logger.error("🚨 Stopping execution of saved actions since last action failed...")

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -879,7 +879,16 @@ class NotteSession(AsyncResource, SyncResource):
                 logger.warning(f"Failed to capture post-action screenshot: {e}")
 
         _raise_on_failure = raise_on_failure if raise_on_failure is not None else self.default_raise_on_failure
-        if _raise_on_failure and exception is not None:
+        if _raise_on_failure and not success:
+            # Gate on "did the action fail", not "did something throw". Actions that signal
+            # failure by returning (a tool returning `success=False`, a controller action
+            # returning `False`) would otherwise be silently swallowed, the way evaluate_js was.
+            if exception is None:
+                exception = ActionExecutionError(
+                    action_id=resolved_action.type,
+                    url=self._window.page.url if self._window is not None else "",
+                    reason=message or "unknown",
+                )
             raise exception
         return execution_result
 

--- a/packages/notte-sdk/src/notte_sdk/client.py
+++ b/packages/notte-sdk/src/notte_sdk/client.py
@@ -227,7 +227,9 @@ class NotteClient:
             For image scraping: returns list[ImageData].
         """
         with self.Session(open_viewer=False, perception_type="fast") as session:
-            result = session.execute(GotoAction(url=url))
+            # best-effort navigation: scrape whatever loaded unless the goto
+            # actually threw server side
+            result = session.execute(GotoAction(url=url), raise_on_failure=False)
             if not result.success and result.exception is not None:
                 raise result.exception
             return session.scrape(raise_on_failure=raise_on_failure, **data)

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -88,6 +88,17 @@ _GENERIC_UNEXPECTED_MESSAGES: frozenset[str] = frozenset(
     }
 )
 
+# `ActionExecutionError.user_message`. The API serialises exceptions with the user-facing
+# message, which drops the action-specific reason, so it has to be detected by prefix
+# (the base class appends "our team has been notified" / "try again later" suffixes).
+_ACTION_EXECUTION_USER_MESSAGE: str = "Sorry, this action cannot be executed at the moment."
+
+
+def _is_generic_error_message(message: str) -> bool:
+    """Whether a serialised exception message lost the action-specific reason."""
+    return message in _GENERIC_UNEXPECTED_MESSAGES or message.startswith(_ACTION_EXECUTION_USER_MESSAGE)
+
+
 # Retry configuration constants
 CLUSTER_OVERLOAD_RETRY_DELAY = 30  # seconds to wait before retrying on 529 errors
 CONSOLE_VIEWER_URL = (
@@ -1593,7 +1604,7 @@ class RemoteSession(SyncResource):
             if isinstance(exception_to_raise, NotteBaseError):
                 result_message = str(result.message).strip()
                 raised_message = str(exception_to_raise).strip()
-                if result_message and raised_message in _GENERIC_UNEXPECTED_MESSAGES:
+                if result_message and _is_generic_error_message(raised_message):
                     # Prefer the action-specific server message when the serialized exception
                     # was reduced to a generic user-safe string.
                     exception_to_raise = NotteBaseError(

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -1598,19 +1598,31 @@ class RemoteSession(SyncResource):
         result = self.client.page.execute(session_id=self.session_id, action=action_obj)
         # raise exception if needed
         _raise_on_failure = raise_on_failure if raise_on_failure is not None else self.default_raise_on_failure
-        if _raise_on_failure and result.exception is not None:
+        # Gate on "did the action fail", not "did something throw", to mirror the local session.
+        # The server may also report a failure without an exception (e.g. an API version that
+        # predates the eval-js fix), in which case the message is all the caller has to go on.
+        if _raise_on_failure and (result.exception is not None or not result.success):
             logger.error(f"🚨 Execution failed with message: '{result.message}'")
-            exception_to_raise: Exception = result.exception
-            if isinstance(exception_to_raise, NotteBaseError):
-                result_message = str(result.message).strip()
-                raised_message = str(exception_to_raise).strip()
-                if result_message and _is_generic_error_message(raised_message):
-                    # Prefer the action-specific server message when the serialized exception
-                    # was reduced to a generic user-safe string.
-                    exception_to_raise = NotteBaseError(
-                        dev_message=result_message,
-                        user_message=result_message,
-                        agent_message=result_message,
-                    )
+            result_message = str(result.message).strip()
+            exception_to_raise: Exception
+            if result.exception is None:
+                fallback_message = result_message or f"Failed to execute action: {action_obj.type}"
+                exception_to_raise = NotteBaseError(
+                    dev_message=fallback_message,
+                    user_message=fallback_message,
+                    agent_message=fallback_message,
+                )
+            else:
+                exception_to_raise = result.exception
+                if isinstance(exception_to_raise, NotteBaseError):
+                    raised_message = str(exception_to_raise).strip()
+                    if result_message and _is_generic_error_message(raised_message):
+                        # Prefer the action-specific server message when the serialized exception
+                        # was reduced to a generic user-safe string.
+                        exception_to_raise = NotteBaseError(
+                            dev_message=result_message,
+                            user_message=result_message,
+                            agent_message=result_message,
+                        )
             raise exception_to_raise from result.exception
         return result

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -81,24 +81,6 @@ from notte_sdk.websockets.jupyter import display_image_in_notebook
 if TYPE_CHECKING:
     from notte_sdk.client import NotteClient
 
-_GENERIC_UNEXPECTED_MESSAGES: frozenset[str] = frozenset(
-    {
-        "An unexpected error occurred. Our team has been notified.",
-        "An unexpected error occurred.",
-    }
-)
-
-# `ActionExecutionError.user_message`. The API serialises exceptions with the user-facing
-# message, which drops the action-specific reason, so it has to be detected by prefix
-# (the base class appends "our team has been notified" / "try again later" suffixes).
-_ACTION_EXECUTION_USER_MESSAGE: str = "Sorry, this action cannot be executed at the moment."
-
-
-def _is_generic_error_message(message: str) -> bool:
-    """Whether a serialised exception message lost the action-specific reason."""
-    return message in _GENERIC_UNEXPECTED_MESSAGES or message.startswith(_ACTION_EXECUTION_USER_MESSAGE)
-
-
 # Retry configuration constants
 CLUSTER_OVERLOAD_RETRY_DELAY = 30  # seconds to wait before retrying on 529 errors
 CONSOLE_VIEWER_URL = (
@@ -1599,30 +1581,18 @@ class RemoteSession(SyncResource):
         # raise exception if needed
         _raise_on_failure = raise_on_failure if raise_on_failure is not None else self.default_raise_on_failure
         # Gate on "did the action fail", not "did something throw", to mirror the local session.
-        # The server may also report a failure without an exception (e.g. an API version that
-        # predates the eval-js fix), in which case the message is all the caller has to go on.
-        if _raise_on_failure and (result.exception is not None or not result.success):
+        if _raise_on_failure and not result.success:
             logger.error(f"🚨 Execution failed with message: '{result.message}'")
-            result_message = str(result.message).strip()
-            exception_to_raise: Exception
-            if result.exception is None:
-                fallback_message = result_message or f"Failed to execute action: {action_obj.type}"
-                exception_to_raise = NotteBaseError(
-                    dev_message=fallback_message,
-                    user_message=fallback_message,
-                    agent_message=fallback_message,
-                )
-            else:
-                exception_to_raise = result.exception
-                if isinstance(exception_to_raise, NotteBaseError):
-                    raised_message = str(exception_to_raise).strip()
-                    if result_message and _is_generic_error_message(raised_message):
-                        # Prefer the action-specific server message when the serialized exception
-                        # was reduced to a generic user-safe string.
-                        exception_to_raise = NotteBaseError(
-                            dev_message=result_message,
-                            user_message=result_message,
-                            agent_message=result_message,
-                        )
-            raise exception_to_raise from result.exception
+            if result.exception is not None:
+                # `ExecutionResult` validation rehydrated the concrete error type, messages
+                # and flags from the structured `exception_detail` wire payload.
+                raise result.exception
+            # An API build that predates `exception_detail` may report a failure without
+            # an exception; the message is all the caller has to go on.
+            fallback_message = str(result.message).strip() or f"Failed to execute action: {action_obj.type}"
+            raise NotteBaseError(
+                dev_message=fallback_message,
+                user_message=fallback_message,
+                agent_message=fallback_message,
+            )
         return result

--- a/packages/notte-sdk/src/notte_sdk/utils.py
+++ b/packages/notte-sdk/src/notte_sdk/utils.py
@@ -147,14 +147,15 @@ def generate_cookies(session: RemoteSession, url: str, output_path: str) -> None
 
     form_fill_action = FormFillAction(value=dict(email=email, current_password=password))  # type: ignore
 
-    res = session.execute(form_fill_action)
+    # this helper has its own failure contract (ValueError / logged return)
+    res = session.execute(form_fill_action, raise_on_failure=False)
     if not res.success:
         logger.error(f"Failed to fill email & password: {res.message}")
         raise ValueError("Failed to fill email & password")
     logger.info("✅ Successfully filled email & password")
 
     actions = session.observe(instructions="Click on the 'Sign in' button", perception_type="deep")
-    res = session.execute(actions[0])
+    res = session.execute(actions[0], raise_on_failure=False)
     if not res.success:
         logger.error(f"Failed to click on the 'Sign in' button: {res.message}")
         return

--- a/tests/integration/sdk/test_error_serialization.py
+++ b/tests/integration/sdk/test_error_serialization.py
@@ -1,0 +1,40 @@
+"""End-to-end checks of the structured exception wire (`ExecutionResult.exception_detail`).
+
+The API serialises failures with `SerializedError` so the client rehydrates the
+concrete `NotteBaseError` subclass, its per-audience messages and retry/notify
+flags, instead of a bare `NotteBaseError` built from a user-safe string.
+"""
+
+import pytest
+from notte_core.errors.actions import InvalidActionError
+from notte_core.errors.base import NotteBaseError
+from notte_sdk.client import NotteClient
+
+
+def test_failed_action_rehydrates_concrete_exception_over_the_wire():
+    client = NotteClient()
+    with client.Session(open_viewer=False) as page:
+        _ = page.execute(type="goto", value="https://www.example.com")
+        _ = page.observe(perception_type="fast")
+
+        # non-raising path: the structured detail crosses the wire and the
+        # exception on the result is the concrete class, not the base one
+        result = page.execute(type="click", id="B999", raise_on_failure=False)
+        assert not result.success
+        assert result.exception_detail is not None
+        assert result.exception_detail.error_type == "InvalidActionError"
+        assert type(result.exception) is InvalidActionError
+        assert "B999" in result.exception.dev_message
+
+        # raising path: remote callers catch the same class as local ones,
+        # with the action-specific reason intact
+        with pytest.raises(InvalidActionError, match="B999"):
+            _ = page.execute(type="click", id="B999")
+
+        # evaluate_js failure: the JS reason must reach the caller. Before the
+        # eval-js fix is deployed the server reports it without an exception
+        # (SDK message fallback); after, as a typed ActionExecutionError. Both
+        # are NotteBaseError and both carry the reason.
+        with pytest.raises(NotteBaseError, match="JavaScript evaluation failed") as exc_info:
+            _ = page.execute(type="evaluate_js", code="notAFunction()")
+        assert "notAFunction is not defined" in str(exc_info.value)

--- a/tests/integration/test_generated_function_patterns.py
+++ b/tests/integration/test_generated_function_patterns.py
@@ -1,0 +1,116 @@
+"""The read that killed five deployed marketplace Functions.
+
+Not a hypothetical. `session.execute(type="evaluate_js", ...)` followed by
+`result.data.markdown` is what the anything-api builder generated, and these are
+the Functions that died on it in production:
+
+    tapology.com          `extraction.data.markdown`
+    pokerdb.thehendonmob  `extraction_result.data.markdown`
+    carrefour.be          `str(result.data.markdown or "")`
+    retailmenot.com       same read
+    solebox.com           same read
+
+Their only failure message was `'NoneType' object has no attribute 'markdown'` -
+a Python attribute, telling a caller nothing about the site. `.data` is
+`DataSpace | None` and is None exactly when the evaluation failed, and the
+reason was already sitting unread in `.message`.
+
+The scripts are reduced to the shape that matters, and the page to the markup
+that triggers it: a script that assumes the elements it wants are there, and a
+page where they are not. That is not a contrived failure - it is what a block
+page, an interstitial or a redesign looks like from inside `evaluate_js`, and it
+is how at least three of the five actually failed.
+"""
+
+import json
+
+import pytest
+from notte_browser.session import NotteSession
+from notte_core.errors.actions import ActionExecutionError
+
+# Reduced from the real Tapology bout-search script. It reads a property off an
+# element it expects to find, which is what every generated extraction script
+# does - and what a page that changed, or a block page served in its place, will
+# not have. Against such a page this throws inside the browser, which arrives as
+# a Playwright error, which used to arrive as a silent `data=None`.
+BOUT_SEARCH_SCRIPT: str = """
+(() => {
+  const heading = document.querySelector("h2.fightCard");
+  return JSON.stringify({event: heading.textContent.trim()});
+})()
+"""
+
+# Stands in for the page the script was not written against. example.com is what
+# the other integration tests here load, and it certainly has no `h2.fightCard`.
+PAGE_THE_SCRIPT_WAS_NOT_WRITTEN_FOR: str = "https://example.com/"
+
+
+def tapology_shaped_run(session: NotteSession) -> dict:
+    """The generated code, verbatim in shape, down to how it reports failure."""
+    try:
+        extraction = session.execute(type="evaluate_js", code=BOUT_SEARCH_SCRIPT)
+        raw_payload = extraction.data.markdown  # pyright: ignore[reportOptionalMemberAccess]
+    except Exception as exc:
+        raise RuntimeError(f"Tapology bout search request failed: {exc}") from exc
+    return json.loads(raw_payload)
+
+
+def carrefour_shaped_run(session: NotteSession) -> dict:
+    """The `or ""` variant, which reported the wrong cause entirely.
+
+    `str(None or "")` is `""`, so the failure arrived as a JSON parse error and
+    sent whoever read it hunting for a malformed response that never existed.
+    """
+    result = session.execute(type="evaluate_js", code=BOUT_SEARCH_SCRIPT)
+    markup = str(result.data.markdown or "")  # pyright: ignore[reportOptionalMemberAccess]
+    return json.loads(markup)
+
+
+def test_a_failed_extraction_names_the_failure_not_the_attribute() -> None:
+    """What the caller is told is now about the page, not about Python."""
+    with NotteSession(headless=True) as session:
+        session.execute(type="goto", url=PAGE_THE_SCRIPT_WAS_NOT_WRITTEN_FOR)
+
+        with pytest.raises(RuntimeError) as raised:
+            _ = tapology_shaped_run(session)
+
+    message = str(raised.value)
+    assert "JavaScript evaluation failed" in message, message
+    # The whole point: this is what the five Functions used to say instead.
+    assert "NoneType" not in message, message
+    assert "markdown" not in message, message
+
+
+def test_the_or_empty_string_variant_no_longer_reports_bad_json() -> None:
+    """A page that never loaded is not a JSON problem, and no longer says it is.
+
+    The guard has to raise *before* the `or ""` can turn the failure into
+    `json.loads("")`, or the caller is told the site returned malformed data.
+    """
+    with NotteSession(headless=True) as session:
+        session.execute(type="goto", url=PAGE_THE_SCRIPT_WAS_NOT_WRITTEN_FOR)
+
+        with pytest.raises(ActionExecutionError) as raised:
+            _ = carrefour_shaped_run(session)
+
+    assert not isinstance(raised.value, json.JSONDecodeError)
+    assert "JavaScript evaluation failed" in str(raised.value)
+
+
+def test_opting_out_still_hands_back_the_reason() -> None:
+    """`raise_on_failure=False` is the deliberate path, and it has to be usable.
+
+    This is what the builder prompt now teaches: check `.success`, and report
+    `.message` - which carries the reason that used to be discarded.
+    """
+    with NotteSession(headless=True) as session:
+        session.execute(type="goto", url=PAGE_THE_SCRIPT_WAS_NOT_WRITTEN_FOR)
+
+        result = session.execute(type="evaluate_js", code=BOUT_SEARCH_SCRIPT, raise_on_failure=False)
+
+    assert result.success is False
+    # None here is what `.markdown` was read off. It is the failure, not an
+    # empty answer: a successful evaluation always sets `data`, and even a JS
+    # `null` arrives as the string "null".
+    assert result.data is None
+    assert result.message.startswith("JavaScript evaluation failed:")

--- a/tests/sdk/test_execute_raise_on_failure.py
+++ b/tests/sdk/test_execute_raise_on_failure.py
@@ -65,7 +65,9 @@ def test_remote_evaluate_js_failure_raises_with_the_actual_reason(server_error_m
         exception = ActionExecutionError(action_id=ACTION.type, url="https://example.com", reason=TIMEOUT_MESSAGE)
     session = remote_session(over_the_wire(server_side_result(exception=exception)))
 
-    with pytest.raises(NotteBaseError) as exc_info:
+    # the structured wire payload rehydrates the concrete type, so remote callers
+    # can catch the same exception class as local ones
+    with pytest.raises(ActionExecutionError) as exc_info:
         _ = session.execute(ACTION)
 
     assert TIMEOUT_MESSAGE in str(exc_info.value)

--- a/tests/sdk/test_execute_raise_on_failure.py
+++ b/tests/sdk/test_execute_raise_on_failure.py
@@ -1,0 +1,84 @@
+"""Remote (SDK) counterpart of the local `raise_on_failure` gate in `NotteSession.execute`.
+
+These tests exercise the *serialised* path: the action runs server side, the resulting
+`ExecutionResult` is dumped to JSON and rebuilt by the client, and only then is the
+raise gate evaluated.
+"""
+
+import datetime as dt
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from notte_core.actions import EvaluateJsAction
+from notte_core.browser.observation import ExecutionResult
+from notte_core.errors.actions import ActionExecutionError
+from notte_core.errors.base import ErrorConfig, ErrorMode, NotteBaseError
+from notte_sdk.client import NotteClient
+from notte_sdk.endpoints.sessions import RemoteSession
+from notte_sdk.types import SessionResponse
+
+TIMEOUT_MESSAGE: str = "JavaScript evaluation timed out after 45000ms"
+ACTION: EvaluateJsAction = EvaluateJsAction(code="new Promise(() => {})")
+
+
+def server_side_result(*, exception: Exception | None) -> ExecutionResult:
+    """The `ExecutionResult` the API builds after a failed `evaluate_js` action."""
+    now = dt.datetime.now(dt.timezone.utc)
+    return ExecutionResult(
+        action=ACTION,
+        success=False,
+        message=TIMEOUT_MESSAGE,
+        data=None,
+        exception=exception,
+        started_at=now,
+        ended_at=now,
+    )
+
+
+def over_the_wire(result: ExecutionResult) -> ExecutionResult:
+    """Serialise server side and rebuild client side, like the real API round trip."""
+    return ExecutionResult.model_validate_json(result.model_dump_json())
+
+
+def remote_session(result: ExecutionResult, *, raise_on_failure: bool = True) -> RemoteSession:
+    client = NotteClient(api_key="test-api-key")
+    session = RemoteSession(_client=client.sessions, raise_on_failure=raise_on_failure)
+    now = dt.datetime.now(dt.timezone.utc)
+    session.response = SessionResponse(
+        session_id="test-session-id",
+        idle_timeout_minutes=1,
+        created_at=now,
+        last_accessed_at=now,
+        status="active",
+    )
+    page_client: Any = MagicMock()
+    page_client.execute = MagicMock(return_value=result)
+    session.client.page = page_client
+    return session
+
+
+@pytest.mark.parametrize("server_error_mode", ["developer", "user"])
+def test_remote_evaluate_js_failure_raises_with_the_actual_reason(server_error_mode: ErrorMode) -> None:
+    """Whatever error mode the API serialises with, the caller sees the real reason."""
+    with ErrorConfig.message_mode(server_error_mode):
+        exception = ActionExecutionError(action_id=ACTION.type, url="https://example.com", reason=TIMEOUT_MESSAGE)
+    session = remote_session(over_the_wire(server_side_result(exception=exception)))
+
+    with pytest.raises(NotteBaseError) as exc_info:
+        _ = session.execute(ACTION)
+
+    assert TIMEOUT_MESSAGE in str(exc_info.value)
+
+
+def test_remote_evaluate_js_failure_does_not_raise_when_disabled() -> None:
+    """`raise_on_failure=False` still returns a result that says it failed."""
+    with ErrorConfig.message_mode("developer"):
+        exception = ActionExecutionError(action_id=ACTION.type, url="https://example.com", reason=TIMEOUT_MESSAGE)
+    session = remote_session(over_the_wire(server_side_result(exception=exception)))
+
+    result = session.execute(ACTION, raise_on_failure=False)
+
+    assert result.success is False
+    assert result.data is None
+    assert result.message == TIMEOUT_MESSAGE

--- a/tests/sdk/test_execute_raise_on_failure.py
+++ b/tests/sdk/test_execute_raise_on_failure.py
@@ -82,3 +82,23 @@ def test_remote_evaluate_js_failure_does_not_raise_when_disabled() -> None:
     assert result.success is False
     assert result.data is None
     assert result.message == TIMEOUT_MESSAGE
+
+
+def test_remote_failure_without_exception_still_raises() -> None:
+    """The API may report a failure without attaching an exception: still raise the reason."""
+    session = remote_session(over_the_wire(server_side_result(exception=None)))
+
+    with pytest.raises(NotteBaseError) as exc_info:
+        _ = session.execute(ACTION)
+
+    assert TIMEOUT_MESSAGE in str(exc_info.value)
+
+
+def test_remote_failure_without_exception_is_quiet_when_disabled() -> None:
+    session = remote_session(over_the_wire(server_side_result(exception=None)), raise_on_failure=False)
+
+    result = session.execute(ACTION)
+
+    assert result.success is False
+    assert result.exception is None
+    assert result.message == TIMEOUT_MESSAGE

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 
 import notte_core
 import pytest
@@ -463,3 +464,33 @@ async def test_evaluate_js_success_path_is_unchanged(code: str, expected_markdow
         assert result.exception is None
         assert result.data is not None
         assert result.data.markdown == expected_markdown
+
+
+# ============================================
+# actions that fail by returning (no exception)
+# ============================================
+
+
+async def _controller_execute_returning_false(*_args: Any, **_kwargs: Any) -> bool:
+    return False
+
+
+@pytest.mark.asyncio
+async def test_action_failing_by_returning_false_raises_by_default() -> None:
+    """The raise gate asks 'did the action fail', not 'did something throw'."""
+    async with NotteSession(headless=True) as session:
+        session.controller.execute = _controller_execute_returning_false  # pyright: ignore[reportAttributeAccessIssue, reportMethodAssign]
+
+        with pytest.raises(ActionExecutionError):
+            _ = await session.aexecute(type="wait", time_ms=1)
+
+
+@pytest.mark.asyncio
+async def test_action_failing_by_returning_false_is_quiet_when_not_raising() -> None:
+    async with NotteSession(headless=True) as session:
+        session.controller.execute = _controller_execute_returning_false  # pyright: ignore[reportAttributeAccessIssue, reportMethodAssign]
+
+        result = await session.aexecute(type="wait", time_ms=1, raise_on_failure=False)
+
+        assert result.success is False
+        assert result.exception is None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -481,7 +481,9 @@ async def test_action_failing_by_returning_false_raises_by_default() -> None:
     async with NotteSession(headless=True) as session:
         session.controller.execute = _controller_execute_returning_false  # pyright: ignore[reportAttributeAccessIssue, reportMethodAssign]
 
-        with pytest.raises(ActionExecutionError):
+        # the raised error must describe a failure, not echo the success-phrased
+        # execution message of the action that did not actually run
+        with pytest.raises(ActionExecutionError, match="Action 'wait' failed during browser execution"):
             _ = await session.aexecute(type="wait", time_ms=1)
 
 
@@ -493,4 +495,8 @@ async def test_action_failing_by_returning_false_is_quiet_when_not_raising() -> 
         result = await session.aexecute(type="wait", time_ms=1, raise_on_failure=False)
 
         assert result.success is False
-        assert result.exception is None
+        assert result.message == "Action 'wait' failed during browser execution"
+        # return-style failures carry the same synthesized exception the raising
+        # path would have thrown, so the result and the trajectory agree
+        assert isinstance(result.exception, ActionExecutionError)
+        assert result.message in str(result.exception)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 from typing import Any
 
 import notte_core
@@ -7,6 +8,7 @@ from notte_browser.captcha import CaptchaHandler
 from notte_browser.errors import CaptchaSolverNotAvailableError, NoSnapshotObservedError, ScrollActionFailedError
 from notte_browser.session import NotteSession
 from notte_core.actions import (
+    ActionList,
     ClickAction,
     GotoAction,
     GotoNewTabAction,
@@ -500,3 +502,23 @@ async def test_action_failing_by_returning_false_is_quiet_when_not_raising() -> 
         # path would have thrown, so the result and the trajectory agree
         assert isinstance(result.exception, ActionExecutionError)
         assert result.message in str(result.exception)
+
+
+@pytest.mark.asyncio
+async def test_help_action_raises_by_default() -> None:
+    """The controller reports HelpAction as `success=False`; under the widened
+    gate that raises like any other failure (deliberate: see PR #905 review)."""
+    async with NotteSession(headless=True) as session:
+        with pytest.raises(ActionExecutionError, match="help"):
+            _ = await session.aexecute(type="help", reason="the page layout is unclear")
+
+
+def test_execute_saved_actions_stops_gracefully_on_failed_step(tmp_path: Path) -> None:
+    """Replay logs the failed step and returns instead of raising."""
+    actions_file = tmp_path / "actions.json"
+    actions_file.write_text(ActionList(actions=[WaitAction(time_ms=1)]).model_dump_json())
+
+    with NotteSession(headless=True) as session:
+        session.controller.execute = _controller_execute_returning_false  # pyright: ignore[reportAttributeAccessIssue, reportMethodAssign]
+
+        session.execute_saved_actions(str(actions_file))  # must not raise

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -16,7 +16,7 @@ from notte_core.actions import (
 )
 from notte_core.actions.actions import ScrapeAction
 from notte_core.browser.snapshot import BrowserSnapshot
-from notte_core.errors.actions import InvalidActionError
+from notte_core.errors.actions import ActionExecutionError, InvalidActionError
 from notte_llm.service import LLMService
 
 from tests.mock.mock_browser import MockBrowserDriver
@@ -362,3 +362,104 @@ async def test_interaction_execution_timeout_returns_failed_result() -> None:
 
         assert result.success is False
         assert result.message == "Action timed out after 1ms"
+
+
+# ============================================
+# evaluate_js failure tests
+# ============================================
+
+# a promise that never settles: forces `asyncio.wait_for` to time out
+HANGING_JS: str = "new Promise(() => {})"
+# a synchronous JS exception: surfaces as a playwright error
+THROWING_JS: str = '(() => { throw new Error("boom"); })()'
+EVALUATE_JS_TIMEOUT_MS: int = 500
+
+
+@pytest.fixture
+def short_evaluate_js_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shorten the evaluate_js timeout (45s by default) so timeout tests stay fast."""
+    from notte_browser import session as session_module
+    from notte_core.common.config import config
+
+    monkeypatch.setattr(
+        session_module,
+        "config",
+        config.model_copy(update={"timeout_evaluate_js_ms": EVALUATE_JS_TIMEOUT_MS}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_js_timeout_raises_by_default(short_evaluate_js_timeout: None) -> None:
+    """A JS evaluation timeout must raise under the default raise_on_failure."""
+    async with NotteSession(headless=True) as session:
+        await session.window.page.set_content("<p>hello</p>")
+
+        with pytest.raises(
+            ActionExecutionError, match=f"JavaScript evaluation timed out after {EVALUATE_JS_TIMEOUT_MS}ms"
+        ):
+            _ = await session.aexecute(type="evaluate_js", code=HANGING_JS)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_js_timeout_returns_failed_result_without_raise(short_evaluate_js_timeout: None) -> None:
+    """With raise_on_failure=False the caller still gets a result that says it failed."""
+    async with NotteSession(headless=True) as session:
+        await session.window.page.set_content("<p>hello</p>")
+
+        result = await session.aexecute(type="evaluate_js", code=HANGING_JS, raise_on_failure=False)
+
+        assert result is not None
+        assert result.success is False
+        assert result.data is None
+        assert result.message == f"JavaScript evaluation timed out after {EVALUATE_JS_TIMEOUT_MS}ms"
+        assert isinstance(result.exception, ActionExecutionError)
+        assert result.message in str(result.exception)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_js_playwright_error_raises_by_default() -> None:
+    """A playwright error during JS evaluation must raise under the default raise_on_failure."""
+    async with NotteSession(headless=True) as session:
+        await session.window.page.set_content("<p>hello</p>")
+
+        with pytest.raises(ActionExecutionError, match="JavaScript evaluation failed"):
+            _ = await session.aexecute(type="evaluate_js", code=THROWING_JS)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_js_playwright_error_returns_failed_result_without_raise() -> None:
+    async with NotteSession(headless=True) as session:
+        await session.window.page.set_content("<p>hello</p>")
+
+        result = await session.aexecute(type="evaluate_js", code=THROWING_JS, raise_on_failure=False)
+
+        assert result is not None
+        assert result.success is False
+        assert result.data is None
+        assert result.message.startswith("JavaScript evaluation failed:")
+        assert isinstance(result.exception, ActionExecutionError)
+        assert "boom" in str(result.exception)
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_markdown"),
+    [
+        ("document.title", "Sample title"),
+        ("1 + 1", "2"),
+        # a JS `null` is a *successful* evaluation, and must stay one
+        ("null", "null"),
+        ("(() => { return null; })()", "null"),
+        ("[1, 2]", "[\n  1,\n  2\n]"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_evaluate_js_success_path_is_unchanged(code: str, expected_markdown: str) -> None:
+    async with NotteSession(headless=True) as session:
+        await session.window.page.set_content("<title>Sample title</title><p>hello</p>")
+
+        result = await session.aexecute(type="evaluate_js", code=code)
+
+        assert result.success is True
+        assert result.exception is None
+        assert result.data is not None
+        assert result.data.markdown == expected_markdown


### PR DESCRIPTION
## Summary

`execute(type="evaluate_js")` failed silently, while `scrape()` — the same contract, in the same file — got it right.

Both eval-js failure branches in `NotteSession._aexecute_impl` set `success = False` and a descriptive `message`, but left `exception = None`. Both raise gates key off `exception`, not `success`:

- `notte-browser/src/notte_browser/session.py`: `if _raise_on_failure and exception is not None`
- `notte-sdk/src/notte_sdk/endpoints/sessions.py`: `if _raise_on_failure and result.exception is not None`

`raise_on_session_execution_failure = true` is the shipped default, so it never fired. The caller got `success=False, data=None, exception=None` and crashed two lines later on `result.data.markdown` with `'NoneType' object has no attribute 'markdown'`, with the real reason (`"JavaScript evaluation timed out after 45000ms"`) sitting unread in `.message`. Five deployed marketplace Functions failed this way; one turned "the page never loaded" into a reported JSON parse error.

`scrape()` already does the right thing: it records the failure to the trajectory with `exception=e` and re-raises unless `raise_on_failure=False`, in which case it returns a value that *says* it failed rather than `None`. This makes eval-js behave the same way.

## What changed

**1. `Raise on evaluate_js failure instead of returning a null DataSpace`**
- attach an `ActionExecutionError` carrying `message` as its `reason` on both the `asyncio.TimeoutError` and `PlaywrightError` branches, the way `controller.py` already does for "Element is disabled"
- extend the SDK's existing generic-message fallback to recognise `ActionExecutionError`'s user-facing message, so a remote caller is raised the actual reason instead of `"Sorry, this action cannot be executed at the moment."`

The success path is untouched. A JS `null` is still a *successful* evaluation returning `data.markdown == "null"`, which is what makes `result.data is None` after an eval an unambiguous failure signal.

**2. `Gate raise_on_failure on failure, not on an exception having been thrown` — ⚠️ behaviour change, droppable**

Kept as a separate commit so it can be dropped in review without losing the eval-js fix.

Both gates now read `not success` instead of `exception is not None`, synthesising an `ActionExecutionError` from `.message` when no exception is available. **This is a real behaviour change for external callers who today receive a silent `success=False`** — most relevantly anyone with a custom `BaseTool` whose `ExecutionResult` carries `success=False`, which will now raise under the default.

Evidence it is safe in-repo — every consumer that wants quiet failures already opts out explicitly:
- `notte-agent/src/notte_agent/agent.py:251` — `raise_on_failure=False`
- `notte-agent/src/notte_agent/agent_fallback.py:127` — `raise_on_failure=False` (and it *rejects* `raise_on_failure=True` outright at line 104)
- `notte-mcp/src/notte_mcp/server.py:138` — builds its session with `raise_on_failure=False`
- the documented pattern for optional actions is already `raise_on_failure=False` (`docs/src/guides/web_automation_tips.mdx`, `browser-controls/{conditional_actions,error_handling}.mdx`, `guides/handle_optional_popup.mdx`)

And the practical blast radius is narrower than it looks: `controller.execute()` returns a bool, but it *raises* on interaction failures (`ActionExecutionError`, `InvalidActionError`, `FailedToUploadFileError`, …) rather than returning `False` — the only `False` it returns is for `HelpAction`, which is agent-only. So a failed click already raises today. No in-repo tool returns `success=False`. The paths this commit actually newly covers are third-party tools and `HelpAction`.

**3. `Document raise_on_failure's actual default`** — `docs/src/features/sessions/configuration.mdx` claimed `default={false}`; `notte-core/src/notte_core/config.toml` sets it to `true`.

## The remote path

Catalog Functions run against the API, so the action executes server-side and the failure has to survive serialisation. Verified by round-tripping a real `ExecutionResult` through `model_dump_json()` / `model_validate_json()`:

- `ExecutionResult.exception` serialises via `json_encoders` to `str(e)`, and the `field_validator` rebuilds it as a `NotteBaseError`. The concrete type is not preserved, so a remote caller can never receive `ActionExecutionError` itself — only a `NotteBaseError`.
- `str(e)` is the message captured at construction time, i.e. whatever `ErrorConfig` mode the API is in. The existing `_GENERIC_UNEXPECTED_MESSAGES` entries are verbatim `user_message` strings from `notte_browser/errors.py`, which is good evidence the API serialises in **user** mode. In that mode `ActionExecutionError` reduces to `"Sorry, this action cannot be executed at the moment. …"` and the reason is lost — hence the prefix check added in commit 1. `tests/sdk/test_execute_raise_on_failure.py` covers both `developer` and `user` server modes and fails on the `user` case without it.
- Commit 2's SDK-side gate additionally covers version skew: until the API ships this fix it will keep returning `success=False, exception=None`, and the client raises the reason from `.message` anyway.

## Tests

`tests/test_session.py` (local) and `tests/sdk/test_execute_raise_on_failure.py` (remote, new file):
- eval-js timeout raises under the default; Playwright error raises under the default
- `raise_on_failure=False` still returns a result that says it failed — `success=False`, `message` intact, `exception` set — and does not regress to returning `None`
- success path untouched, including a JS `null` → `data.markdown == "null"`, `success=True`, `exception is None`
- an action that fails by returning `False` raises under the default and stays quiet with `raise_on_failure=False`
- remote: raise survives the JSON round trip in both `developer` and `user` server error modes, and when the server attaches no exception at all

Ran:
- `uv run pytest tests/test_session.py -q` — 33 passed, 1 skipped, 1 failed: `test_step_should_return_valid_timed_span`, which calls Gemini and fails with `key=None` in a worktree with no `.env`. It passes in the main checkout, and it fails identically with these commits stashed.
- `uv run pytest tests/sdk/test_execute_raise_on_failure.py -q` — 5 passed
- `uv run pytest tests/browser tests/test_trajectory.py tests/actions tests/mcp tests/code tests/config -q` — 173 passed, 7 skipped. The 2 failures + 2 errors are all missing-credentials or network flakiness (`test_tools.py` needs a real `NOTTE_API_KEY`; `test_screenshot_types.py` depends on google.com's live DOM and fails identically with these commits stashed).
- Each new failure-path test was confirmed to fail against the unpatched source before being confirmed to pass against the patched source.
- `pre-commit` on every commit: `ruff check`, `ruff format`, `basedpyright` (0 errors, 0 warnings), detect-secrets, forbidden/playwright import checks, docs link checks — all pass. The `docs-sdk-generate` hook was skipped: it re-fetches `https://api.notte.cc/openapi.json` and rewrites `docs/src/llms.txt` with unrelated live-API drift (mailboxes, profile-duplicate, …). No public signature or docstring changed, so no reference doc regeneration is warranted.

Not run: integration suites requiring API credentials (`tests/integration/**`), and no marketplace sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790182358&installation_model_id=8247&pr_number=905&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F905&signature=32b3154947ba7e24523fda491dbea453b80ab5b72e0acda04a0931f00c3b0331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session actions now raise clear errors for timeouts, browser failures, JavaScript evaluation failures, and other unsuccessful results by default.
  - Failure messages preserve the original reason, including when no exception is provided.

- **Configuration**
  - `raise_on_failure` now defaults to enabled.
  - Disable this option to receive failed results without raising an error.

- **Bug Fixes**
  - Improved consistency between local and remote session failure handling.
  - Actions returning unsuccessful results are now handled consistently across execution types.
  - JavaScript failures now report the underlying evaluation error instead of misleading secondary errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Added: the generated code, as a test

The unit tests above cover the two failure branches. This covers the thing the branches exist for — the pattern the anything-api builder actually emitted, reduced from the real `tapology.com`, `pokerdb.thehendonmob.com` and `carrefour.be` sources:

```python
extraction = session.execute(type="evaluate_js", code=BOUT_SEARCH_SCRIPT)
raw_payload = extraction.data.markdown          # ← the line five Functions died on
```

`tests/integration/test_generated_function_patterns.py`, which the CI suite already picks up (only `test_webvoyager_resolution` and `test_e2e` are excluded). Runs in ~9s against `example.com`, the page the other integration tests here use.

The failure is provoked the way it happened in production rather than synthetically: a script that reads a property off an element it expects, run against a page that does not have it. That is what a block page, an interstitial or a redesign looks like from inside `evaluate_js`, and it is how at least three of the five actually failed.

**Checked against the code before this branch**, the first test reports:

```
Tapology bout search request failed: 'NoneType' object has no attribute 'markdown'
```

which is verbatim what the catalogue ledger recorded for that Function in production. With the branch, the same call reports `JavaScript evaluation failed: ...` and names the page.

Three cases:

| test | catches the regression? |
|---|---|
| a failed extraction names the failure, not the attribute | yes — red before, green after |
| the `or ""` variant no longer reports bad JSON | yes — red before, green after |
| opting out still hands back the reason | **no** — `raise_on_failure=False` returned `.message` before this branch too |

The third is a characterisation test, not a regression test, and is included because it pins the path the builder prompt now teaches callers to take. Calling that out so nobody reads three green ticks as three guarantees.

**Suite:** 36 passed. One unrelated pre-existing failure, `test_step_should_return_valid_timed_span`, which makes a live LLM call and fails on credentials in a worktree — it fails identically without these commits.
