### PR TITLE
feat(core): bring the script runner up to the runtime version

### DIFF
--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -1,34 +1,218 @@
-"""Script parsing and sandboxed execution for Notte functions.
+"""Parsing and sandboxed execution of user-authored Notte functions.
 
-The variable coercion helpers here (`_annotation_head`, `_container_kind`,
-`_parse_collection_text`, `coerce_collection_variables`, the annotation head
-frozensets they share, and `_validate_variables`) are mirrored verbatim by the
-Notte API runtime, which keeps its own fork of this module. Keep the two copies
-byte-identical.
+`ScriptValidator` decides what a submitted script is allowed to contain and
+pulls the signature of its `run` entry point back out. `SecureScriptRunner`
+executes it, either under RestrictedPython or, by default, in plain Python with
+a builtins allowlist that withholds `eval`, `exec`, `compile`, `open` and
+`__import__`, substituting sandboxed versions of the last two.
 
-A fix applied to only one of them leaves the other passing a JSON string
-straight through to a parameter annotated `list` or `dict`. That raises nothing:
-a function expecting `list[str]` and handed '["a", "b"]' iterates 21 characters
-and returns a wrong answer instead of failing.
+Variables arriving from a caller are coerced to match the entry point's
+annotations before it is invoked, so a JSON or Python-literal string sent for a
+`list` or `dict` parameter becomes the collection it spells out rather than
+being iterated character by character.
 """
 
 import ast
+import builtins
+import copy
 import json
+import re
+import sys
 import traceback
 import types
-from collections.abc import Iterable, Mapping
-from typing import Any, Callable, ClassVar, Literal, Protocol, cast, final
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, ClassVar, Literal, Protocol, cast, final
 
 from pydantic import BaseModel, ConfigDict
-from RestrictedPython import compile_restricted, safe_globals  # type: ignore [reportMissingTypeStubs]
-from RestrictedPython.transformer import RestrictingNodeTransformer  # type: ignore [reportMissingTypeStubs]
+from RestrictedPython import (
+    compile_restricted,  # type: ignore [reportMissingTypeStubs]
+    safe_globals,  # type: ignore [reportMissingTypeStubs]
+)
+from RestrictedPython.transformer import (
+    RestrictingNodeTransformer,
+)
 from typing_extensions import override
+
+from notte_core.common.logging import logger
+
+
+def module_scope_statements(body: list[ast.stmt]) -> list[ast.stmt]:
+    """Statements that execute in module scope, flattened in source order.
+
+    Descends through control flow - ``if`` / ``try`` / ``with`` / loops - because
+    a definition there still binds at module scope. Never descends into a class
+    body or a nested function, whose ``run`` is not reachable as
+    ``globals()["run"]``.
+
+    Lives here rather than beside the schema check so that the upload validator
+    and ``check_run_returns_pydantic_model`` cannot drift on what the entry point
+    is. When they did, a ``run`` defined inside ``if`` was accepted by the
+    validator and then rejected for having no verifiable return model.
+    """
+    out: list[ast.stmt] = []
+    for node in body:
+        out.append(node)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        for field_name in ("body", "orelse", "finalbody"):
+            nested: list[ast.stmt] = getattr(node, field_name, None) or []
+            out.extend(module_scope_statements(nested))
+        handlers: list[ast.ExceptHandler] = getattr(node, "handlers", None) or []
+        for handler in handlers:
+            out.extend(module_scope_statements(handler.body))
+        # `match` is control flow like any other: a case body binds at module
+        # scope, and skipping it hid rebindings entirely.
+        cases: list[ast.match_case] = getattr(node, "cases", None) or []
+        for case in cases:
+            out.extend(module_scope_statements(case.body))
+    return out
+
+
+def _pattern_binds_run(pattern: ast.pattern | None) -> bool:
+    """Whether a match pattern captures into the name ``run``.
+
+    ``case str() as run:`` and ``case [*run]:`` bind the name just as an
+    assignment would, and nest arbitrarily inside or/sequence patterns.
+    """
+    if pattern is None:
+        return False
+    for node in ast.walk(pattern):
+        if isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name == "run":
+            return True
+        if isinstance(node, ast.MatchMapping) and node.rest == "run":
+            return True
+    return False
+
+
+def _target_rebinds_run(target: ast.expr) -> bool:
+    """Whether an assignment target binds ``run``, including through unpacking.
+
+    ``run, other = f, 1`` and ``[run] = [f]`` bind it just as ``run = f`` does,
+    and starred targets nest one level deeper again.
+    """
+    match target:
+        case ast.Name(id="run"):
+            return True
+        case ast.Tuple(elts=elts) | ast.List(elts=elts):
+            return any(_target_rebinds_run(e) for e in elts)
+        case ast.Starred(value=value):
+            return _target_rebinds_run(value)
+        case _:
+            return False
+
+
+def _statement_rebinds_run(node: ast.stmt) -> bool:
+    """Whether a module-scope statement rebinds or removes ``run``.
+
+    Assignment is only the most obvious way to replace the name. Every binding
+    form Python offers has to be covered, because each leaves the validated
+    definition describing something the runtime will not call - or, for ``del``,
+    nothing at all:
+
+    ``run = f`` / ``run, x = f, 1`` / ``run: C = f`` / ``run += 1``
+    ``for run in ...`` / ``async for run in ...``
+    ``import json as run`` / ``from x import y as run``
+    ``with open(p) as run`` / ``except ValueError as run``
+    ``class run: ...``
+    ``del run``
+    """
+    match node:
+        case ast.Assign(targets=targets):
+            return any(_target_rebinds_run(t) for t in targets)
+        case ast.AnnAssign(target=target) | ast.AugAssign(target=target):
+            return _target_rebinds_run(target)
+        case ast.For(target=target) | ast.AsyncFor(target=target):
+            return _target_rebinds_run(target)
+        case ast.Delete(targets=targets):
+            return any(_target_rebinds_run(t) for t in targets)
+        case ast.Import(names=names) | ast.ImportFrom(names=names):
+            # `import json as run`, and plain `import run` which binds the
+            # top-level package name.
+            return any((alias.asname or alias.name.split(".")[0]) == "run" for alias in names)
+        case ast.With(items=items) | ast.AsyncWith(items=items):
+            return any(item.optional_vars is not None and _target_rebinds_run(item.optional_vars) for item in items)
+        case ast.Try(handlers=handlers):
+            # `except ValueError as run` binds, then unbinds at the end of the
+            # handler - either way the name no longer holds the definition.
+            return any(handler.name == "run" for handler in handlers)
+        case ast.ClassDef(name="run"):
+            return True
+        case ast.Match(cases=cases):
+            return any(_pattern_binds_run(case.pattern) for case in cases)
+        case _:
+            return False
+
+
+def _rebinding_after(definition: ast.stmt, tree: ast.Module) -> ast.stmt | None:
+    """The first statement that rebinds ``run`` after ``definition``, if any.
+
+    Order matters. ``run = print`` *before* the definition is harmless - the def
+    executes later and wins - so rejecting it would fail a script Python handles
+    unambiguously. Only a rebinding that runs afterwards leaves the name holding
+    something other than the validated function.
+    """
+    statements = module_scope_statements(tree.body)
+    try:
+        start = statements.index(definition)
+    except ValueError:  # pragma: no cover - definition always comes from this list
+        return None
+    return next((node for node in statements[start + 1 :] if _statement_rebinds_run(node)), None)
+
+
+def resolve_run_entry_point(tree: ast.Module) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """The single top-level ``def run`` the runtime will call, or None.
+
+    None whenever the binding is not knowable from the source: several
+    definitions, one hidden under control flow that may never execute, or a
+    later assignment over the name. ``ScriptValidator`` raises on each of those
+    with a specific message; callers that only need to know whether a contract
+    can be trusted use this and get None.
+    """
+    top_level = [
+        node for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "run"
+    ]
+    if len(top_level) != 1:
+        return None
+
+    nested = [
+        node
+        for node in module_scope_statements(tree.body)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "run"
+    ]
+    if len(nested) != 1:
+        return None
+
+    if _rebinding_after(top_level[0], tree) is not None:
+        return None
+
+    # A decorator binds its own return value to the name, not the function
+    # written below it. That value can take different arguments and return a
+    # different type, so the annotation here describes something the runtime
+    # may never call.
+    if top_level[0].decorator_list:
+        return None
+
+    return top_level[0]
 
 
 class MissingRunFunctionError(Exception):
     """Raised when a script does not contain a required 'run' function"""
 
-    pass
+
+class AmbiguousRunFunctionError(Exception):
+    """Raised when a script binds ``run`` more than once at module scope.
+
+    Which definition executes is then either a source-order accident (two
+    sequential ``def run``, where the second silently discards the first) or not
+    knowable at all (``if`` / ``else`` branches picked at runtime). Everything
+    downstream - the advertised parameters, the verified return model, the
+    schema shown in the marketplace - would describe whichever one this code
+    happened to choose, which may not be the one that runs.
+
+    Rejecting is the honest option: one entry point per function, stated
+    clearly at upload, rather than a contract that is right by luck.
+    """
 
 
 class ParameterInfo(BaseModel):
@@ -228,61 +412,123 @@ class NotteModule(Protocol):
     Session: type
 
 
+_GETATTR_MISSING_DEFAULT = object()
+
+
 class ScriptValidator(RestrictingNodeTransformer):
     """Validates that the AST only contains allowed operations"""
 
-    # Safe modules that can be imported in user scripts
-    # These modules are considered safe because they don't provide:
-    # - File system access (os, pathlib, shutil)
-    # - Process/subprocess control (subprocess, multiprocessing)
-    # - Network access beyond basic parsing (socket, urllib.request, http)
-    # - System introspection (sys, inspect, importlib)
-    # - Code execution (exec, eval, compile - handled separately)
-    ALLOWED_IMPORTS: ClassVar[set[str]] = {
-        # Notte ecosystem - always safe in this context
+    # Modules that can be imported in user scripts.
+    # Most standard-library modules are allowed, but modules that provide direct
+    # process control, filesystem access, raw sockets, dynamic imports, or native
+    # memory access stay blocked.
+    DISALLOWED_STDLIB_IMPORTS: ClassVar[set[str]] = {
+        "_ctypes",
+        "_elementtree",
+        "_imp",
+        "_io",
+        "_multiprocessing",
+        "_pickle",
+        "_posixshmem",
+        "_posixsubprocess",
+        "_signal",
+        "_socket",
+        "_sqlite3",
+        "_thread",
+        "asyncio.subprocess",
+        "builtins",
+        "code",
+        "codeop",
+        "compileall",
+        "configparser",
+        "ctypes",
+        "dbm",
+        "filecmp",
+        "fileinput",
+        "fcntl",
+        "gc",
+        "glob",
+        "grp",
+        "importlib",
+        "inspect",
+        "linecache",
+        "mmap",
+        "modulefinder",
+        "marshal",
+        "multiprocessing",
+        "nt",
+        "os",
+        "pathlib",
+        "pickle",
+        "pickletools",
+        "pkgutil",
+        "posix",
+        "pty",
+        "pwd",
+        "py_compile",
+        "resource",
+        "runpy",
+        "shelve",
+        "shutil",
+        "signal",
+        "socket",
+        "socketserver",
+        "sqlite3",
+        "subprocess",
+        "sys",
+        "sysconfig",
+        "tarfile",
+        "tempfile",
+        "termios",
+        "threading",
+        "tty",
+        "venv",
+        "winreg",
+        "xml",
+        "zipapp",
+        "zipfile",
+        "zipimport",
+    }
+    DISALLOWED_IMPORT_MEMBERS: ClassVar[dict[str, set[str]]] = {
+        "_io": {"FileIO", "open", "open_code"},
+        "asyncio": {"create_subprocess_exec", "create_subprocess_shell", "subprocess", "to_thread"},
+        "codecs": {"open"},
+        "io": {"FileIO", "open", "open_code"},
+    }
+    ALLOWED_IMPORTS: ClassVar[set[str]] = (set(sys.stdlib_module_names) - DISALLOWED_STDLIB_IMPORTS) | {
+        # Notte ecosystem
         "notte",
         "notte_browser",
         "notte_sdk",
         "notte_agent",
         "notte_core",
-        # Safe third-party
+        "notte_llm",
+        "tqdm",
+        # Third-party
         "pydantic",  # Data validation library
         "loguru",  # Logging library
         "requests",
-        "asyncio",
+        # Sync and async HTTP in one library. `requests` alone left async
+        # functions with no client at all, so `asyncio` was only ever usable to
+        # drive a thread pool - the one thing it is worst at. Present in the
+        # runner image already: litellm's module-level clients are httpx.Client
+        # and httpx.AsyncClient, verified against the deployed image rather than
+        # inferred from the dependency tree.
+        "httpx",
+        # requests-compatible client that emulates a browser's TLS/HTTP2
+        # fingerprint. `requests` and `httpx` are both trivially fingerprintable,
+        # so a function scraping a site behind bot detection had no in-sandbox
+        # option that was not a browser session. Ships a bundled shared library
+        # it loads with ctypes from its own package directory - no subprocess and
+        # nothing written at runtime, so it holds under Lambda's read-only image.
+        "httpcloak",
         "playwright",
         "gspread",
         "google",
         "litellm",
-        # Safe standard library modules - data processing and utilities
-        "types",
-        "json",  # JSON parsing
-        "datetime",  # Date/time handling
-        "time",  # Time utilities
-        "math",  # Mathematical functions
-        "random",  # Random number generation
-        "uuid",  # UUID generation
-        "re",  # Regular expressions
-        "urllib.parse",  # URL parsing only (not requests)
-        "base64",  # Base64 encoding/decoding
-        "hashlib",  # Cryptographic hashing
-        "hmac",  # HMAC operations
-        "secrets",  # Secure random generation
-        "string",  # String operations
-        "collections",  # Collection types
-        "itertools",  # Iterator utilities
-        "functools",  # Functional programming utilities
-        "operator",  # Operator functions
-        "copy",  # Object copying
-        "decimal",  # Decimal arithmetic
-        "fractions",  # Fraction arithmetic
-        "statistics",  # Statistical functions
-        "enum",  # Enumeration support
-        "dataclasses",  # Dataclass support
-        "typing",  # Type hints
+        "bs4",
+        "pipedream",
         "typing_extensions",  # Extended type hints
-        "calendar",
-        "tempfile",
     }
 
     FORBIDDEN_NODES: set[type[ast.AST]] = {
@@ -304,10 +550,10 @@ class ScriptValidator(RestrictingNodeTransformer):
         # ast.Await,
         ast.Delete,
         # ast.AugAssign,
+        # ast.AsyncFunctionDef,
     }
 
     FORBIDDEN_CALLS: set[str] = {
-        "open",
         "input",
         # "print",  # print might be OK depending on your needs
         # "hash",
@@ -319,13 +565,59 @@ class ScriptValidator(RestrictingNodeTransformer):
         "locals",
         "vars",
         "dir",
-        "getattr",
         "setattr",
         "delattr",
-        "hasattr",
         "id",
         "memoryview",
+        "_io.FileIO",
+        "_io.open",
+        "_io.open_code",
+        "asyncio.create_subprocess_exec",
+        "asyncio.create_subprocess_shell",
+        "asyncio.to_thread",
+        "codecs.open",
+        "io.FileIO",
+        "io.open",
+        "io.open_code",
     }
+
+    RESTRICTED_INTERNAL_NAMES: ClassVar[set[str]] = {
+        "_apply_",
+        "_getattr_",
+        "_getitem_",
+        "_getiter_",
+        "_inplacevar_",
+        "_iter_unpack_sequence_",
+        "_print",
+        "_print_",
+        "_unpack_sequence_",
+        "_write_",
+    }
+
+    @override
+    def check_name(
+        self,
+        node: ast.AST,
+        name: str | None,
+        allow_magic_methods: bool = False,
+    ) -> None:
+        if name is not None and name.startswith("_") and not name.startswith("__"):
+            if name in self.RESTRICTED_INTERNAL_NAMES or re.fullmatch(r"_tmp[0-9]+", name):
+                super().check_name(node, name, allow_magic_methods)  # pyright: ignore[reportUnknownMemberType]
+            return
+
+        if name == "__name__" and isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            return
+
+        super().check_name(node, name, allow_magic_methods)  # pyright: ignore[reportUnknownMemberType]
+
+    @override
+    def visit_Constant(self, node: ast.Constant) -> ast.AST | None:
+        """Allow Python's Ellipsis literal (`...`) in user scripts."""
+        if node.value is Ellipsis:
+            return node
+
+        return super().visit_Constant(node)
 
     @override
     def visit_Call(self, node: ast.Call) -> ast.AST:
@@ -359,22 +651,96 @@ class ScriptValidator(RestrictingNodeTransformer):
             return f"{base}.{node.attr}" if base else None
         return None
 
+    # Safe dunder methods that are allowed in user scripts
+    ALLOWED_DUNDER_METHODS: ClassVar[set[str]] = {
+        "__init__",
+        "__str__",
+        "__repr__",
+        "__eq__",
+        "__ne__",
+        "__lt__",
+        "__le__",
+        "__gt__",
+        "__ge__",
+        "__hash__",
+        "__bool__",
+        "__len__",
+        "__getitem__",
+        "__setitem__",
+        "__delitem__",
+        "__iter__",
+        "__next__",
+        "__contains__",
+        "__add__",
+        "__sub__",
+        "__mul__",
+        "__truediv__",
+        "__floordiv__",
+        "__mod__",
+        "__pow__",
+        "__and__",
+        "__or__",
+        "__xor__",
+        "__enter__",
+        "__exit__",
+        "__aenter__",
+        "__aexit__",
+        "__call__",
+        "__post_init__",  # For dataclasses
+    }
+
+    # Dangerous dunder attributes that should be blocked
+    DANGEROUS_DUNDER_ATTRS: ClassVar[set[str]] = {
+        "__class__",
+        "__bases__",
+        "__subclasses__",
+        "__mro__",
+        "__globals__",
+        "__code__",
+        "__func__",
+        "__self__",
+        "__dict__",
+        "__getattribute__",
+        "__setattr__",
+        "__delattr__",
+        "__import__",
+        "__builtins__",
+        "__loader__",
+        "__spec__",
+        "__cached__",
+        "__file__",
+        "__path__",
+        "__package__",
+    }
+
     @override
     def visit_Attribute(self, node: ast.Attribute) -> ast.AST:
         """Override to add custom attribute access restrictions"""
-        # Block access to private attributes
-        if hasattr(node, "attr") and node.attr.startswith("_"):
-            raise SyntaxError(f"Access to private attribute forbidden: '{node.attr}'")
-        return super().visit_Attribute(node)
+        if hasattr(node, "attr"):
+            attr_name = node.attr
 
-    @override
-    def check_name(self, node: ast.AST, name: str | None, allow_magic_methods: bool = False) -> None:
-        if name == "__name__" and isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
-            return
-        return super().check_name(node, name, allow_magic_methods)  # pyright: ignore[reportUnknownMemberType]
+            # Block dangerous dunder attributes
+            if attr_name in self.DANGEROUS_DUNDER_ATTRS:
+                raise SyntaxError(f"Access to dangerous attribute forbidden: '{attr_name}'")
+
+            # Allow safe dunder methods (like __init__, __str__, etc.)
+            if attr_name in self.ALLOWED_DUNDER_METHODS:
+                return super().visit_Attribute(node)
+
+            # Block all other private attributes (starting with _)
+            if attr_name.startswith("_"):
+                raise SyntaxError(f"Access to private attribute forbidden: '{attr_name}'")
+
+        return super().visit_Attribute(node)
 
     @staticmethod
     def check_valid_import(name: str, import_type: Literal["import", "import from"] = "import") -> None:
+        blocked = name in ScriptValidator.DISALLOWED_STDLIB_IMPORTS or any(
+            name.startswith(f"{m}.") for m in ScriptValidator.DISALLOWED_STDLIB_IMPORTS
+        )
+        if blocked:
+            raise SyntaxError(f"Import {'of' if import_type == 'import' else 'from'} '{name}' is not allowed")
+
         # Allow exact matches and explicitly whitelisted submodules
         allowed = name in ScriptValidator.ALLOWED_IMPORTS or any(
             name.startswith(f"{m}.") for m in ScriptValidator.ALLOWED_IMPORTS
@@ -403,6 +769,11 @@ class ScriptValidator(RestrictingNodeTransformer):
                 return super().visit_ImportFrom(node)
             raise SyntaxError("Only 'from __future__ import annotations' is allowed")
 
+        blocked_members = ScriptValidator.DISALLOWED_IMPORT_MEMBERS.get(node.module, set())
+        for alias in node.names:
+            if alias.name == "*" or alias.name in blocked_members:
+                raise SyntaxError(f"Import from '{node.module}' of '{alias.name}' is not allowed")
+
         ScriptValidator.check_valid_import(node.module, import_type="import from")
         return super().visit_ImportFrom(node)
 
@@ -427,23 +798,126 @@ class ScriptValidator(RestrictingNodeTransformer):
         return super().visit(node)
 
     @staticmethod
+    def _module_scope_run_defs(tree: ast.Module) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+        """Definitions of ``run`` that end up bound in the module namespace.
+
+        AsyncFunctionDef is a sibling of FunctionDef rather than a subclass, so
+        matching only the latter reported a valid ``async def run()`` as missing
+        and rejected the upload outright.
+
+        The traversal descends through control flow (``if``, ``try``, ``with``,
+        loops) because a definition there still binds at module scope, but never
+        into a class body or another function: a method or closure named ``run``
+        is not reachable as ``globals()["run"]``, so accepting one would pass an
+        upload whose every invocation then fails to find an entry point.
+        """
+        return [
+            node
+            for node in module_scope_statements(tree.body)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "run"
+        ]
+
+    @staticmethod
+    def _check_run_entry_point(tree: ast.Module) -> ast.FunctionDef | ast.AsyncFunctionDef:
+        """The single top-level ``def run``, or raise explaining why there isn't one.
+
+        The runtime calls whatever ``globals()["run"]`` holds after the module
+        finishes executing. Three shapes make that unknowable at upload time, and
+        each one produces a function that looks fine here and fails later:
+
+        * **More than one definition** - only the last executes, so the declared
+          parameters and return model may describe the discarded one.
+        * **Defined under control flow** - ``if cond: def run()`` binds nothing
+          when ``cond`` is false, so the upload succeeds and every invocation
+          then fails with no entry point.
+        * **Rebound afterwards** - ``run = print`` leaves the advertised
+          signature describing a function the runtime never calls.
+
+        Requiring exactly one unconditional top-level definition, never
+        reassigned, is what makes the stored contract true by construction
+        rather than by luck.
+        """
+        top_level = [
+            node
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "run"
+        ]
+        all_defs = ScriptValidator._module_scope_run_defs(tree)
+
+        if len(all_defs) > 1:
+            lines = ", ".join(str(node.lineno) for node in all_defs)
+            detail = "Only the last one executes, so the declared parameters and return model may describe the wrong function."
+            raise AmbiguousRunFunctionError(
+                f"Python script must define 'run' exactly once, found {len(all_defs)} definitions (lines {lines}). {detail}"
+            )
+
+        if not top_level:
+            if all_defs:
+                detail = "Define 'run' at the top level of the module."
+                raise AmbiguousRunFunctionError(
+                    f"'run' is defined inside control flow (line {all_defs[0].lineno}), so it may never be bound. {detail}"
+                )
+            raise MissingRunFunctionError("Python script must contain a 'run' function")
+
+        rebind = _rebinding_after(top_level[0], tree)
+        if rebind is not None:
+            detail = "The runtime calls the reassigned value, which the declared parameters no longer describe."
+            raise AmbiguousRunFunctionError(f"'run' is reassigned at line {rebind.lineno}. {detail}")
+
+        if top_level[0].decorator_list:
+            detail = "A decorator binds its own return value to 'run', which may take different arguments and return a different type."
+            raise AmbiguousRunFunctionError(f"'run' is decorated at line {top_level[0].lineno}. {detail}")
+
+        return top_level[0]
+
+    @staticmethod
     def _check_run_function_exists(tree: ast.Module) -> bool:
-        """Check if the AST contains a function named 'run'"""
-        for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == "run":
-                return True
-        return False
+        """Check if the module binds a function named 'run' at module scope."""
+        return len(ScriptValidator._module_scope_run_defs(tree)) > 0
 
     @staticmethod
     def _extract_run_function_parameters(tree: ast.Module) -> list[ParameterInfo]:
-        """Extract parameter information from the 'run' function"""
-        for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == "run":
-                parameters: list[ParameterInfo] = []
+        """Extract parameter information from the 'run' function.
 
-                # Handle regular arguments
-                defaults_offset = len(node.args.args) - len(node.args.defaults)
-                for i, arg in enumerate(node.args.args):
+        Reversed because the last binding is the one the runtime calls. Reading
+        the first definition would advertise the signature of a callable that
+        was overwritten, so supplied variables would be rejected as unexpected
+        while the ones the real function needs would be reported missing.
+        """
+        for node in reversed(ScriptValidator._module_scope_run_defs(tree)):
+            parameters: list[ParameterInfo] = []
+
+            # Handle regular arguments
+            defaults_offset = len(node.args.args) - len(node.args.defaults)
+            for i, arg in enumerate(node.args.args):
+                param_name = arg.arg
+                type_annotation = None
+                default_value = None
+
+                # Extract type annotation if present
+                if arg.annotation:
+                    try:
+                        # Use ast.unparse for Python 3.9+ or fallback to basic string representation
+                        type_annotation = ast.unparse(arg.annotation)
+                    except AttributeError:
+                        # Fallback for older Python versions (though we're on 3.11)
+                        type_annotation = str(arg.annotation)
+
+                # Extract default value if present
+                if i >= defaults_offset:
+                    default_index = i - defaults_offset
+                    if default_index < len(node.args.defaults):
+                        try:
+                            default_value = ast.unparse(node.args.defaults[default_index])
+                        except AttributeError:
+                            default_value = str(node.args.defaults[default_index])
+
+                parameters.append(ParameterInfo(name=param_name, type=type_annotation, default=default_value))
+
+            # Handle keyword-only arguments
+            if node.args.kwonlyargs:
+                kw_defaults = node.args.kw_defaults or []
+                for i, arg in enumerate(node.args.kwonlyargs):
                     param_name = arg.arg
                     type_annotation = None
                     default_value = None
@@ -451,73 +925,90 @@ class ScriptValidator(RestrictingNodeTransformer):
                     # Extract type annotation if present
                     if arg.annotation:
                         try:
-                            # Use ast.unparse for Python 3.9+ or fallback to basic string representation
                             type_annotation = ast.unparse(arg.annotation)
                         except AttributeError:
-                            # Fallback for older Python versions (though we're on 3.11)
                             type_annotation = str(arg.annotation)
 
                     # Extract default value if present
-                    if i >= defaults_offset:
-                        default_index = i - defaults_offset
-                        if default_index < len(node.args.defaults):
+                    if i < len(kw_defaults) and kw_defaults[i] is not None:
+                        default_node = kw_defaults[i]
+                        if default_node is not None:
                             try:
-                                default_value = ast.unparse(node.args.defaults[default_index])
+                                default_value = ast.unparse(default_node)
                             except AttributeError:
-                                default_value = str(node.args.defaults[default_index])
+                                default_value = str(default_node)
 
                     parameters.append(ParameterInfo(name=param_name, type=type_annotation, default=default_value))
 
-                # Handle keyword-only arguments
-                if node.args.kwonlyargs:
-                    kw_defaults = node.args.kw_defaults or []
-                    for i, arg in enumerate(node.args.kwonlyargs):
-                        param_name = arg.arg
-                        type_annotation = None
-                        default_value = None
-
-                        # Extract type annotation if present
-                        if arg.annotation:
-                            try:
-                                type_annotation = ast.unparse(arg.annotation)
-                            except AttributeError:
-                                type_annotation = str(arg.annotation)
-
-                        # Extract default value if present
-                        if i < len(kw_defaults) and kw_defaults[i] is not None:
-                            default_node = kw_defaults[i]
-                            if default_node is not None:
-                                try:
-                                    default_value = ast.unparse(default_node)
-                                except AttributeError:
-                                    default_value = str(default_node)
-
-                        parameters.append(ParameterInfo(name=param_name, type=type_annotation, default=default_value))
-
-                return parameters
+            return parameters
 
         return []
+
+    @staticmethod
+    def _is_run_invocation(node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "run"
+        )
+
+    @staticmethod
+    def _is_name_main_guard(node: ast.AST) -> bool:
+        if not isinstance(node, ast.If):
+            return False
+        test = node.test
+        if not isinstance(test, ast.Compare) or len(test.ops) != 1 or len(test.comparators) != 1:
+            return False
+        if not isinstance(test.ops[0], ast.Eq):
+            return False
+
+        def is_dunder_name(value: ast.AST) -> bool:
+            return isinstance(value, ast.Name) and value.id == "__name__"
+
+        def is_main_string(value: ast.AST) -> bool:
+            return isinstance(value, ast.Constant) and value.value == "__main__"
+
+        return (is_dunder_name(test.left) and is_main_string(test.comparators[0])) or (
+            is_main_string(test.left) and is_dunder_name(test.comparators[0])
+        )
+
+    @staticmethod
+    def _strip_top_level_entrypoint_invocations(tree: ast.Module) -> ast.Module:
+        """Remove script-style entrypoint calls before the managed runner calls run()."""
+        sanitized = ast.fix_missing_locations(ast.Module(body=[], type_ignores=tree.type_ignores))
+        sanitized.body = [
+            node
+            for node in tree.body
+            if not ScriptValidator._is_run_invocation(node) and not ScriptValidator._is_name_main_guard(node)
+        ]
+        return ast.fix_missing_locations(sanitized)
 
     @staticmethod
     def parse_script(code_string: str, restricted: bool = True) -> ParsedScriptInfo:
         # 1. Parse the AST first to check for run function
         tree = ast.parse(code_string)
 
-        # 2. Check if run function exists
-        if not ScriptValidator._check_run_function_exists(tree):
-            raise MissingRunFunctionError("Python script must contain a 'run' function")
+        # 2. Check if run function exists, and that there is exactly one
+        _ = ScriptValidator._check_run_entry_point(tree)
 
         # 3. Extract run function parameters
         run_parameters = ScriptValidator._extract_run_function_parameters(tree)
+        sanitized_tree = ScriptValidator._strip_top_level_entrypoint_invocations(copy.deepcopy(tree))
 
         if not restricted:
             # For non-strict mode, use regular Python compilation
-            code = compile(code_string, filename="<user_script.py>", mode="exec")
+            code = compile(sanitized_tree, filename="<user_script.py>", mode="exec")
             return ParsedScriptInfo(code=code, variables=run_parameters)
+
+        # Validate the original source before compiling the sanitized runner code.
+        _ = compile_restricted(  # pyright: ignore [reportUnknownVariableType]
+            copy.deepcopy(tree), filename="<user_script.py>", mode="exec", policy=ScriptValidator
+        )
 
         # 4. Compile with RestrictedPython validation (strict mode only)
         code: types.CodeType = compile_restricted(  # pyright: ignore [reportUnknownVariableType]
-            code_string, filename="<user_script.py>", mode="exec", policy=ScriptValidator
+            sanitized_tree, filename="<user_script.py>", mode="exec", policy=ScriptValidator
         )
 
         return ParsedScriptInfo(code=code, variables=run_parameters)  # pyright: ignore [reportUnknownArgumentType]
@@ -527,29 +1018,99 @@ class ScriptValidator(RestrictingNodeTransformer):
 class SecureScriptRunner:
     """Secure runner for notte scripts"""
 
+    UNRESTRICTED_BUILTIN_NAMES: ClassVar[tuple[str, ...]] = (
+        "ArithmeticError",
+        "AssertionError",
+        "AttributeError",
+        "BaseException",
+        "EOFError",
+        "Exception",
+        "ImportError",
+        "IndexError",
+        "KeyError",
+        "LookupError",
+        "NameError",
+        "OSError",
+        "RuntimeError",
+        "StopIteration",
+        "SyntaxError",
+        "TypeError",
+        "ValueError",
+        "ZeroDivisionError",
+        "__build_class__",
+        "abs",
+        "all",
+        "any",
+        "ascii",
+        "bin",
+        "bool",
+        "bytes",
+        "callable",
+        "chr",
+        "classmethod",
+        "dict",
+        "divmod",
+        "enumerate",
+        "filter",
+        "float",
+        "format",
+        "frozenset",
+        "getattr",
+        "hasattr",
+        "hash",
+        "hex",
+        "int",
+        "isinstance",
+        "issubclass",
+        "iter",
+        "len",
+        "list",
+        "map",
+        "max",
+        "min",
+        "next",
+        "object",
+        "oct",
+        "ord",
+        "pow",
+        "print",
+        "property",
+        "range",
+        "repr",
+        "reversed",
+        "round",
+        "set",
+        "slice",
+        "sorted",
+        "staticmethod",
+        "str",
+        "sum",
+        "super",
+        "tuple",
+        "type",
+        "zip",
+    )
+
     def __init__(self, notte_module: NotteModule):
         self.notte_module = notte_module
 
-    def create_restricted_logger(self, level: str = "INFO"):
+    def get_unrestricted_builtins(self) -> dict[str, Any]:
+        allowed_builtins = {name: getattr(builtins, name) for name in self.UNRESTRICTED_BUILTIN_NAMES}
+        allowed_builtins["__import__"] = self.safe_import
+        allowed_builtins["open"] = self.safe_tmp_open
+        return allowed_builtins
+
+    def create_restricted_logger(self, level: str = "INFO"):  # pyright: ignore[reportUnusedParameter]
         """
         Create a restricted logger that's safe for user scripts
         """
-        import sys
-
-        from notte_core.common.logging import logger
 
         # Create a new logger instance to avoid conflicts
         user_logger = logger.bind(user_script=True)
 
-        # Optional: Configure logger to only output to stdout/stderr
-        # and prevent users from logging to files
-        user_logger.remove()  # Remove default handler
-        user_logger.add(  # pyright: ignore [reportUnusedCallResult]
-            sys.stdout,
-            level=level,
-            format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>user_script</cyan> | <level>{message}</level>",
-            colorize=True,
-        )
+        # Note: We don't remove handlers from the global logger to avoid interfering
+        # with the main application logging. The user script logs will go to both
+        # the main app.log file and stdout.
         return user_logger
 
     def _is_safe_attribute(self, attr_value: Any) -> bool:
@@ -598,7 +1159,6 @@ class SecureScriptRunner:
         """
         Alternative approach: Use types.SimpleNamespace for a cleaner solution
         """
-        import types
 
         restricted_notte = types.SimpleNamespace()
 
@@ -665,6 +1225,9 @@ class SecureScriptRunner:
                 "abs": abs,
                 "round": round,
                 "sorted": sorted,
+                "getattr": self.safe_getattr,
+                "hasattr": self.safe_hasattr,
+                "open": self.safe_tmp_open,
                 "enumerate": enumerate,
                 "zip": zip,
                 "range": range,
@@ -673,8 +1236,28 @@ class SecureScriptRunner:
 
         return restricted_globals
 
+    def safe_tmp_open(self, file: Any, mode: str = "r", *args: Any, **kwargs: Any):
+        """
+        Restricted open() replacement that only allows access under /tmp.
+        """
+        if kwargs.get("opener") is not None:
+            raise PermissionError("Custom openers are not allowed")
+
+        tmp_root = Path("/tmp").resolve()
+        requested_path = Path(file)
+        target = requested_path if requested_path.is_absolute() else tmp_root / requested_path
+        resolved_target = target.resolve(strict=False)
+
+        if resolved_target != tmp_root and tmp_root not in resolved_target.parents:
+            raise PermissionError("Only files inside /tmp are allowed")
+
+        return builtins.open(resolved_target, mode, *args, **kwargs)
+
     def safe_getattr(
-        self, obj: Any, name: str, default: Any = None, getattr: Callable[[Any, str], Any] = getattr
+        self,
+        obj: Any,
+        name: str,
+        default: Any = _GETATTR_MISSING_DEFAULT,
     ) -> Any:
         """
         Safe attribute access guard
@@ -698,11 +1281,30 @@ class SecureScriptRunner:
         if name in dangerous_attrs:
             raise AttributeError(f"Access to attribute '{name}' is not allowed")
 
+        if isinstance(obj, types.ModuleType):
+            module_name = obj.__name__
+            if name in ScriptValidator.DISALLOWED_IMPORT_MEMBERS.get(module_name, set()):
+                raise AttributeError(f"Access to attribute '{module_name}.{name}' is not allowed")
+
         # Block access to private attributes
         if name.startswith("_"):
             raise AttributeError(f"Access to private attribute '{name}' is not allowed")
 
-        return getattr(obj, name, default)  # pyright: ignore [reportUnknownVariableType, reportCallIssue]
+        if default is _GETATTR_MISSING_DEFAULT:
+            return getattr(obj, name)
+
+        return getattr(obj, name, default)
+
+    def safe_hasattr(self, obj: Any, name: str) -> bool:
+        """
+        Safe hasattr replacement that applies the same attribute policy as safe_getattr.
+        """
+        missing = object()
+        try:
+            result = self.safe_getattr(obj, name, default=missing)
+        except AttributeError:
+            return False
+        return result is not missing
 
     def safe_getitem(self, obj: Any, key: Any):
         """
@@ -815,10 +1417,13 @@ class SecureScriptRunner:
         if restricted:
             # Use RestrictedPython for strict mode
             execution_globals = self.get_safe_globals()
-            result: Mapping[str, object] = {}
+            result: dict[str, object] = {}
 
             try:
                 exec(parsed_info.code, execution_globals, result)
+                execution_globals.update(
+                    {name: value for name, value in result.items() if name not in execution_globals}
+                )
 
                 # Call the run function if it exists
                 run_ft = result.get("run")
@@ -834,9 +1439,13 @@ class SecureScriptRunner:
         else:
             # Use regular Python execution for non-strict mode
             # Create execution namespace with notte module and logger
-            execution_globals = {
+            execution_globals: dict[str, Any] = {
+                "__name__": "__main__",
+                "__package__": None,
+                "__builtins__": self.get_unrestricted_builtins(),
                 "notte": self.notte_module,
                 "logger": self.create_restricted_logger(),
+                "open": self.safe_tmp_open,
             }
 
             try:
@@ -848,7 +1457,7 @@ class SecureScriptRunner:
                 if run_ft is None or not callable(run_ft):
                     raise MissingRunFunctionError("Python script must contain a 'run' function")
                 if callable(run_ft):
-                    return run_ft(**variables) if variables else run_ft()  # pyright: ignore [reportUnknownVariableType]
+                    return run_ft(**variables) if variables else run_ft()
 
                 return execution_globals
 

--- a/tests/scripts/test_validator.py
+++ b/tests/scripts/test_validator.py
@@ -101,6 +101,13 @@ def test_script_runner(mock_notte: NotteModule, test_script: str):
     runner.run_script(test_script)
 
 
+class _StubNotteModule:
+    """Enough of the NotteModule protocol to execute a script that never calls it."""
+
+    def __getattr__(self, name: str):
+        raise RuntimeError(f"notte.{name} is not available in this test")
+
+
 def test_script_validator(test_script: str):
     validator = ScriptValidator()
     _ = validator.parse_script(test_script)
@@ -427,7 +434,19 @@ def run():
 
 """
     validator = ScriptValidator()
-    with pytest.raises(SyntaxError, match="Forbidden function call: 'open'"):
+    # `open` is no longer rejected at parse time. It resolves to `safe_tmp_open`,
+    # which confines every path to /tmp, so a script may keep scratch files
+    # without reaching the rest of the filesystem. See test_open_is_confined_to_tmp.
+    _ = validator.parse_script(script)
+
+    script = """
+def run():
+    with notte.Session() as session:
+        eval("1 + 1")
+        session.execute(type="goto", value="https://example.com")
+
+"""
+    with pytest.raises(SyntaxError, match="Forbidden function call: 'eval'"):
         _ = validator.parse_script(script)
 
 
@@ -458,7 +477,7 @@ def run():
 
 """
     validator = ScriptValidator()
-    with pytest.raises(SyntaxError, match="Access to private attribute forbidden: '__class__'"):
+    with pytest.raises(SyntaxError, match="Access to dangerous attribute forbidden: '__class__'"):
         _ = validator.parse_script(script)
 
 
@@ -961,3 +980,32 @@ def run(name, age = 25):
     assert age_param.name == "age"
     assert age_param.type is None
     assert age_param.default == "25"
+
+
+def test_open_is_confined_to_tmp():
+    """`open` is permitted, and cannot reach outside /tmp.
+
+    The validator no longer rejects `open` at parse time, so the containment is
+    entirely `safe_tmp_open`'s job: it resolves the path first, which is what
+    stops `../` and symlinks from walking out, and roots relative names at /tmp
+    rather than the working directory.
+    """
+    runner = SecureScriptRunner(_StubNotteModule())
+
+    with pytest.raises(RuntimeError, match="Only files inside /tmp are allowed"):
+        _ = runner.run_script('def run():\n    return open("/etc/passwd").read()\n')
+
+    with pytest.raises(RuntimeError, match="Only files inside /tmp are allowed"):
+        _ = runner.run_script('def run():\n    return open("/tmp/../etc/passwd").read()\n')
+
+    # A scratch file is the point of allowing it at all.
+    assert (
+        runner.run_script(
+            "def run():\n"
+            '    f = open("notte_confinement_probe.txt", "w")\n'
+            '    _ = f.write("scratch")\n'
+            "    f.close()\n"
+            '    return open("notte_confinement_probe.txt").read()\n'
+        )
+        == "scratch"
+    )


### PR DESCRIPTION
`notte_core.ast` and the copy the hosted runtime executes had drifted apart.
This closes the gap in one direction, because the drift is one directional:

| | notte_core (before) | runtime copy |
|---|---|---|
| lines | 856 | 1466 |
| top level symbols | 13 | 21 |

Every symbol `notte_core` had, the runtime copy also had. **Nothing here was
ahead of it**, so there was nothing to merge, only to catch up. Of the 13 shared
symbols, 10 were already identical; the 3 that differed were
`MissingRunFunctionError`, `ScriptValidator` and `SecureScriptRunner`.

### Behaviour that changes

**Builtins are now restricted in the default mode.** `run_script` defaults to
`restricted=False`, and that path previously set no `__builtins__` key at all,
which makes CPython inject the real builtins. Scripts therefore had `eval`,
`exec`, `compile`, `open` and `__import__`. They now get an allowlist of 70
names, with `__import__` and `open` swapped for checked versions.

**`open` is permitted, and confined to /tmp.** It used to be rejected by the
validator at parse time. It now resolves to a wrapper that resolves the path
first, then refuses anything that is not under /tmp, so `..` and symlinks cannot
walk out, and relative names land in /tmp rather than the working directory.

Net: considerably stricter on builtins, deliberately looser on scratch files.
The first is the larger change, and the one worth reading closely if you embed
this to run untrusted code.

**Run entry point resolution** also arrives: several candidate `run` definitions,
a rebinding, or a `__name__ == "__main__"` guard are now diagnosed rather than
resolved by accident.

### Tests

`tests/scripts`: **79 passed**, 5 skipped. The one failure on this branch,
`test_run_script_with_agent`, fails identically on `main` and is an absent
Gemini API key, not this change.

Two existing tests changed:

- `test_private_attribute_forbidden` - still refused, wording moved from
  "private attribute" to "dangerous attribute". `__class__`, `__bases__` and
  `__subclasses__` are all still blocked; verified by hand.
- `test_dangerous_builtins_forbidden` - the `open` half now parses, so it
  asserts on `eval` instead, and the confinement is covered by a new test.

`test_open_is_confined_to_tmp` is new and pins the containment directly,
including the `/tmp/../etc/passwd` walk out.

`ruff` and `basedpyright` are clean (3 pre-existing warnings, unchanged).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790184851&installation_model_id=8247&pr_number=906&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F906&signature=e23dce639a2e369835119c0f394ba8129a6d1655ea304e201c2748133a3948aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering both synchronous and asynchronous `run` entry points.
  * Added collection-type input handling and improved script parsing.
  * Added safe temporary-file access within `/tmp`.

* **Bug Fixes**
  * Prevented ambiguous, conditional, decorated, or overridden `run` definitions from executing unexpectedly.
  * Improved sandbox protection against unsafe imports, attributes, built-ins, and file paths.
  * Preserved existing logger handlers during script execution.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->