### PR TITLE
feat(core): carry structured exception detail on ExecutionResult

### DIFF
--- a/docs/src/sdk-reference/misc/executionresult.mdx
+++ b/docs/src/sdk-reference/misc/executionresult.mdx
@@ -28,6 +28,9 @@ description: ""
 <ParamField path="exception" type="UnionType[NotteBaseError, Exception, None]">
 </ParamField>
 
+<ParamField path="exception_detail" type="UnionType[SerializedError, None]">
+</ParamField>
+
 
 ## Module
 

--- a/docs/src/sdk-reference/misc/serializederror.mdx
+++ b/docs/src/sdk-reference/misc/serializederror.mdx
@@ -1,0 +1,37 @@
+---
+title: "SerializedError"
+description: "Lossless wire representation of an execution result's exception"
+---
+
+
+
+The legacy `exception` field is serialized as `str(e)`, which collapses the error
+to whichever single message the server's `ErrorConfig` mode baked in and drops the
+concrete type and the retry/notify flags. This model carries all of it so clients
+can rehydrate the exception the server actually raised. The field is additive for
+wire compatibility: old servers never send it, old clients ignore it
+
+## Fields
+
+<ParamField path="error_type" type="str" required>
+</ParamField>
+
+<ParamField path="dev_message" type="str" required>
+</ParamField>
+
+<ParamField path="user_message" type="str" required>
+</ParamField>
+
+<ParamField path="agent_message" type="str" required>
+</ParamField>
+
+<ParamField path="should_retry_later" type="bool" default="False">
+</ParamField>
+
+<ParamField path="should_notify_team" type="bool" default="False">
+</ParamField>
+
+
+## Module
+
+`notte_core.browser.observation`

--- a/packages/notte-core/src/notte_core/browser/observation.py
+++ b/packages/notte-core/src/notte_core/browser/observation.py
@@ -316,6 +316,78 @@ class Observation(FilledTimedSpan):
         return _empty_observation_instance
 
 
+class SerializedError(BaseModel):
+    """Lossless wire representation of an `ExecutionResult.exception`.
+
+    The legacy `exception` field is serialized as `str(e)`, which collapses the error
+    to whichever single message the server's `ErrorConfig` mode baked in and drops the
+    concrete type and the retry/notify flags. This model carries all of it so clients
+    can rehydrate the exception the server actually raised. The field is additive for
+    wire compatibility: old servers never send it, old clients ignore it.
+    """
+
+    error_type: str
+    dev_message: str
+    user_message: str
+    agent_message: str
+    should_retry_later: bool = False
+    should_notify_team: bool = False
+
+    @staticmethod
+    def from_exception(e: Exception) -> "SerializedError":
+        if isinstance(e, NotteBaseError):
+            return SerializedError(
+                error_type=type(e).__name__,
+                dev_message=e.dev_message,
+                user_message=e.user_message,
+                agent_message=e.agent_message,
+                should_retry_later=e.should_retry_later,
+                should_notify_team=e.should_notify_team,
+            )
+        message = str(e)
+        return SerializedError(
+            error_type=type(e).__name__,
+            dev_message=message,
+            user_message=message,
+            agent_message=message,
+        )
+
+    def to_exception(self) -> NotteBaseError:
+        error_cls = self._resolve_error_class()
+        error = error_cls.__new__(error_cls)
+        # Subclass __init__ signatures differ (e.g. ActionExecutionError takes
+        # action_id/url/reason), so rebuild through the uniform base initializer.
+        NotteBaseError.__init__(
+            error,
+            dev_message=self.dev_message,
+            user_message=self.user_message,
+            agent_message=self.agent_message,
+            should_retry_later=self.should_retry_later,
+            should_notify_team=self.should_notify_team,
+        )
+        return error
+
+    def _resolve_error_class(self) -> type[NotteBaseError]:
+        # Imported lazily so every notte-core error subclass is registered in
+        # `__subclasses__` before the walk, without import cycles at module load.
+        import notte_core.errors.actions  # noqa: F401  # pyright: ignore[reportUnusedImport]
+        import notte_core.errors.llm  # noqa: F401
+        import notte_core.errors.processing  # noqa: F401
+        import notte_core.errors.provider  # noqa: F401
+        import notte_core.errors.validation  # noqa: F401
+
+        # Errors defined outside notte-core (or not imported in this process)
+        # rehydrate as the base class: the type is best-effort, the messages and
+        # flags are not.
+        candidates: list[type[NotteBaseError]] = [NotteBaseError]
+        while candidates:
+            cls = candidates.pop()
+            if cls.__name__ == self.error_type:
+                return cls
+            candidates.extend(cls.__subclasses__())
+        return NotteBaseError
+
+
 class ExecutionResult(FilledTimedSpan):
     # action: BaseAction
     action: ActionUnion
@@ -323,6 +395,7 @@ class ExecutionResult(FilledTimedSpan):
     message: str
     data: DataSpace | None = None
     exception: NotteBaseError | Exception | None = Field(default=None)
+    exception_detail: SerializedError | None = None
 
     @field_validator("exception", mode="before")
     @classmethod
@@ -330,6 +403,22 @@ class ExecutionResult(FilledTimedSpan):
         if isinstance(v, str):
             return NotteBaseError(dev_message=v, user_message=v, agent_message=v)
         return v
+
+    @model_validator(mode="after")
+    def sync_exception_detail(self) -> "ExecutionResult":
+        if self.success:
+            return self
+        if self.exception is None:
+            if self.exception_detail is not None:
+                # Wire payload from a server that only sets the structured field.
+                self.exception = self.exception_detail.to_exception()
+        elif self.exception_detail is None:
+            self.exception_detail = SerializedError.from_exception(self.exception)
+        elif type(self.exception) is NotteBaseError:
+            # The legacy string field was rehydrated as a bare NotteBaseError by
+            # `validate_exception`; the detail knows the real type, messages and flags.
+            self.exception = self.exception_detail.to_exception()
+        return self
 
     model_config: ConfigDict = ConfigDict(  # pyright: ignore [reportIncompatibleVariableOverride]
         arbitrary_types_allowed=True,

--- a/packages/notte-core/src/notte_core/browser/observation.py
+++ b/packages/notte-core/src/notte_core/browser/observation.py
@@ -317,7 +317,7 @@ class Observation(FilledTimedSpan):
 
 
 class SerializedError(BaseModel):
-    """Lossless wire representation of an `ExecutionResult.exception`.
+    """Lossless wire representation of an execution result's exception.
 
     The legacy `exception` field is serialized as `str(e)`, which collapses the error
     to whichever single message the server's `ErrorConfig` mode baked in and drops the

--- a/packages/notte-core/src/notte_core/browser/observation.py
+++ b/packages/notte-core/src/notte_core/browser/observation.py
@@ -368,17 +368,30 @@ class SerializedError(BaseModel):
         return error
 
     def _resolve_error_class(self) -> type[NotteBaseError]:
-        # Imported lazily so every notte-core error subclass is registered in
+        # Imported lazily so every first-party error subclass is registered in
         # `__subclasses__` before the walk, without import cycles at module load.
-        import notte_core.errors.actions  # noqa: F401  # pyright: ignore[reportUnusedImport]
-        import notte_core.errors.llm  # noqa: F401
-        import notte_core.errors.processing  # noqa: F401
-        import notte_core.errors.provider  # noqa: F401
-        import notte_core.errors.validation  # noqa: F401
+        # Modules outside notte-core are optional: an SDK-only install (or one
+        # without playwright) does not ship them.
+        import importlib
 
-        # Errors defined outside notte-core (or not imported in this process)
-        # rehydrate as the base class: the type is best-effort, the messages and
-        # flags are not.
+        for module in (
+            "notte_core.errors.actions",
+            "notte_core.errors.llm",
+            "notte_core.errors.processing",
+            "notte_core.errors.provider",
+            "notte_core.errors.validation",
+            "notte_browser.errors",
+            "notte_agent.errors",
+            "notte_sdk.errors",
+        ):
+            try:
+                _ = importlib.import_module(module)
+            except ImportError:
+                continue
+
+        # Error types not found in the tree (third-party, or from a module that
+        # is not installed) rehydrate as the base class: the type is
+        # best-effort, the messages and flags are not.
         candidates: list[type[NotteBaseError]] = [NotteBaseError]
         while candidates:
             cls = candidates.pop()

--- a/tests/test_execution_result_serialization.py
+++ b/tests/test_execution_result_serialization.py
@@ -1,0 +1,126 @@
+"""ExecutionResult exception round-trips.
+
+The legacy wire format serialized `exception` as `str(e)`, so the concrete error
+type, the per-audience messages and the retry/notify flags were destroyed in
+transit and every remote failure rehydrated as a bare `NotteBaseError`. The
+additive `exception_detail` field carries the full error; these tests pin the
+round-trip, the fallbacks, and compatibility with payloads from older servers.
+"""
+
+import json
+
+import pytest
+from notte_core.actions import ClickAction
+from notte_core.browser.observation import ExecutionResult, SerializedError, TimedSpan
+from notte_core.errors.actions import ActionExecutionError
+from notte_core.errors.base import NotteBaseError
+
+
+def _failed_result(exception: Exception) -> ExecutionResult:
+    span = TimedSpan.start().close()
+    return ExecutionResult(
+        action=ClickAction(id="B1"),
+        success=False,
+        message="click failed",
+        started_at=span.started_at,
+        ended_at=span.ended_at,
+        exception=exception,
+    )
+
+
+def test_notte_error_round_trips_with_type_messages_and_flags() -> None:
+    original = ActionExecutionError(action_id="click", url="https://example.com", reason="element is disabled")
+    dumped = _failed_result(original).model_dump_json()
+
+    restored = ExecutionResult.model_validate_json(dumped)
+
+    assert isinstance(restored.exception, ActionExecutionError)
+    assert restored.exception.dev_message == original.dev_message
+    assert restored.exception.user_message == original.user_message
+    assert restored.exception.agent_message == original.agent_message
+    assert restored.exception.should_retry_later is True
+    assert restored.exception.should_notify_team is True
+    assert "element is disabled" in restored.exception.dev_message
+
+
+def test_legacy_payload_without_detail_keeps_old_behavior() -> None:
+    original = ActionExecutionError(action_id="click", url="https://example.com", reason="element is disabled")
+    payload = json.loads(_failed_result(original).model_dump_json())
+    # An older server serializes only the stringified exception.
+    del payload["exception_detail"]
+
+    restored = ExecutionResult.model_validate(payload)
+
+    assert type(restored.exception) is NotteBaseError
+    assert restored.exception.dev_message == str(original)
+
+
+def test_unknown_error_type_falls_back_to_base_class() -> None:
+    detail = SerializedError(
+        error_type="ServerOnlyError",
+        dev_message="dev",
+        user_message="user",
+        agent_message="agent",
+        should_retry_later=True,
+    )
+    payload = json.loads(_failed_result(ValueError("boom")).model_dump_json())
+    payload["exception"] = "dev"
+    payload["exception_detail"] = detail.model_dump()
+
+    restored = ExecutionResult.model_validate(payload)
+
+    assert type(restored.exception) is NotteBaseError
+    assert restored.exception.dev_message == "dev"
+    assert restored.exception.user_message == "user"
+    assert restored.exception.should_retry_later is True
+
+
+def test_plain_exception_round_trips_messages() -> None:
+    restored = ExecutionResult.model_validate_json(_failed_result(TimeoutError("boom")).model_dump_json())
+
+    assert isinstance(restored.exception, NotteBaseError)
+    assert restored.exception.dev_message == "boom"
+    assert restored.exception.user_message == "boom"
+
+
+def test_detail_only_payload_rehydrates_exception() -> None:
+    payload = json.loads(
+        _failed_result(ActionExecutionError(action_id="click", url="https://example.com")).model_dump_json()
+    )
+    # A future server may stop sending the lossy legacy field altogether.
+    payload["exception"] = None
+
+    restored = ExecutionResult.model_validate(payload)
+
+    assert isinstance(restored.exception, ActionExecutionError)
+
+
+def test_local_construction_populates_detail() -> None:
+    result = _failed_result(ActionExecutionError(action_id="click", url="https://example.com", reason="nope"))
+
+    assert result.exception_detail is not None
+    assert result.exception_detail.error_type == "ActionExecutionError"
+    assert "nope" in result.exception_detail.dev_message
+
+
+def test_success_keeps_exception_invariant() -> None:
+    span = TimedSpan.start().close()
+    result = ExecutionResult(
+        action=ClickAction(id="B1"),
+        success=True,
+        message="clicked",
+        started_at=span.started_at,
+        ended_at=span.ended_at,
+    )
+    assert result.exception is None
+    assert result.exception_detail is None
+
+    with pytest.raises(ValueError, match="Exception should be None"):
+        ExecutionResult(
+            action=ClickAction(id="B1"),
+            success=True,
+            message="clicked",
+            started_at=span.started_at,
+            ended_at=span.ended_at,
+            exception=ValueError("boom"),
+        )

--- a/tests/test_execution_result_serialization.py
+++ b/tests/test_execution_result_serialization.py
@@ -75,6 +75,32 @@ def test_unknown_error_type_falls_back_to_base_class() -> None:
     assert restored.exception.should_retry_later is True
 
 
+def test_first_party_error_outside_core_rehydrates_concrete_type() -> None:
+    """Errors defined in notte-browser/notte-agent resolve without the caller importing them."""
+    for error_type in ("InvalidLocatorRuntimeError", "MaxStepsReachedError", "PageLoadingError"):
+        detail = SerializedError(
+            error_type=error_type,
+            dev_message="dev",
+            user_message="user",
+            agent_message="agent",
+        )
+
+        error = detail.to_exception()
+
+        assert type(error).__name__ == error_type
+
+    from notte_browser.errors import BrowserError
+
+    # hierarchy matters: `except BrowserError` on the client must catch a
+    # rehydrated PageLoadingError
+    assert isinstance(
+        SerializedError(
+            error_type="PageLoadingError", dev_message="dev", user_message="user", agent_message="agent"
+        ).to_exception(),
+        BrowserError,
+    )
+
+
 def test_plain_exception_round_trips_messages() -> None:
     restored = ExecutionResult.model_validate_json(_failed_result(TimeoutError("boom")).model_dump_json())
 


### PR DESCRIPTION
## Why

`ExecutionResult.exception` crosses the wire as `str(e)`, which collapses the error to whichever single message the server's `ErrorConfig` mode baked in and drops the concrete type and the `should_retry_later`/`should_notify_team` flags. Every remote failure therefore rehydrates client-side as a bare `NotteBaseError` with a possibly generic user-safe string — which is what forced the message-sniffing workaround in #905's SDK changes (`_GENERIC_UNEXPECTED_MESSAGES` / `_is_generic_error_message`), and why `except ActionExecutionError` can never match on a `RemoteSession`.

This came out of the review discussion on #905: the reason-loss is unfixable at the SDK layer by construction, so this fixes it at the serialization layer instead, generally, for every error class.

## What

- New `SerializedError` model: `{error_type, dev_message, user_message, agent_message, should_retry_later, should_notify_team}`.
- Additive `ExecutionResult.exception_detail` field, auto-populated from `exception` on construction (so local results, trajectory entries, and serialized payloads all carry it).
- On validation, when `exception_detail` is present, the concrete `NotteBaseError` subclass is rehydrated from it (registry = the `NotteBaseError` subclass tree; unknown/external types fall back to the base class with messages and flags intact).

## Wire compatibility

Additive in both skew directions:
- **Old server → new client:** no `exception_detail` in the payload → exact current behavior (string → bare `NotteBaseError`), pinned by test.
- **New server → old client:** unknown field is ignored by pydantic.

Note on `dev_message`: sending it to clients is no worse than today — the server's default `ErrorConfig` mode is `DEVELOPER`, so `str(e)` already serializes the dev message.

## Follow-up (after the API deploys this)

The SDK's generic-message matching in `endpoints/sessions.py` (added in #905) can be deleted and the remote raise gate collapses to `raise result.exception`, making local and remote sessions raise the same typed errors.

## Tests

`tests/test_execution_result_serialization.py`: round-trip of type/messages/flags, legacy payload without the field, detail-only payload, unknown-type fallback, plain-exception handling, and the success/exception invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790240935&installation_model_id=8247&pr_number=907&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F907&signature=dc966ff98d7488c5711d17b8b29c4c860dacf8ba8ad05b15ff9c6040d50aa420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured execution error details, including error types, messages, retry guidance, and notification status.
  * Preserved detailed error information when execution results are serialized and restored.
  * Added support for errors from additional product components and older error formats.

* **Bug Fixes**
  * Kept legacy and structured exception fields synchronized.
  * Prevented successful results from containing incorrect exception details.

* **Documentation**
  * Documented the new structured error details available in execution results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->