### PR TITLE
Gate remote sessions behind Advanced Stealth

### DIFF
--- a/docs/src/concepts/sessions.mdx
+++ b/docs/src/concepts/sessions.mdx
@@ -8,7 +8,7 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 <AgentMdNotice />
 
-Sessions are isolated browser instances running in the cloud that you can control programmatically. Think of them as headless Chrome browsers, but managed, scalable, and equipped with anti-detection, proxies, and captcha solving out of the box.
+Sessions are isolated browser instances running in the cloud that you can control programmatically. They are managed, scalable, and equipped with anti-detection, proxies, and captcha solving out of the box.
 
 Every operation in Notte—whether you're running an AI agent, scraping data, or automating a workflow—happens within a session.
 

--- a/docs/src/features/sessions/captcha-solving.mdx
+++ b/docs/src/features/sessions/captcha-solving.mdx
@@ -88,7 +88,7 @@ Check if captcha solving failed:
 
 <MonitorFailures />
 
-### 3. Use Headless=False for Debugging
+### 3. Use the Live Viewer for Debugging
 
 Watch captcha solving in action:
 
@@ -122,7 +122,7 @@ Text CAPTCHAs are the old-school challenges that show distorted letters, numbers
 - ✅ Solve most hCaptcha challenges
 - ✅ Solve simple text and image CAPTCHA challenges
 - ✅ Work with residential proxies
-- ✅ Work in headless and non-headless mode
+- ✅ Work in remote browser sessions
 
 ### What It Cannot Do:
 - ❌ Solve 100% of captchas (some are unsolvable)
@@ -167,7 +167,7 @@ Test captcha solving on demo sites:
 
   with client.Session(
       solve_captchas=True,
-      headless=False
+      open_viewer=True
   ) as session:
       page = session.page
 

--- a/docs/src/features/sessions/configuration.mdx
+++ b/docs/src/features/sessions/configuration.mdx
@@ -4,7 +4,7 @@ description: Learn how to create and configure Notte browser sessions
 ---
 import QuickStart from '/snippets/sessions/configuration/quick_start.mdx';
 import FullConfig from '/snippets/sessions/configuration/full_config.mdx';
-import HeadlessMode from '/snippets/sessions/configuration/headless_mode.mdx';
+import AdvancedStealth from '/snippets/sessions/configuration/headless_mode.mdx';
 import CaptchaSolving from '/snippets/sessions/configuration/captcha_solving.mdx';
 import Timeout from '/snippets/sessions/configuration/timeout.mdx';
 import Viewport from '/snippets/sessions/configuration/viewport.mdx';
@@ -38,8 +38,8 @@ Customize your session with these options:
 
 ### Common Parameters
 
-<ParamField path="headless" type="boolean" default={false}>
-  Whether to run the browser in headless mode. Set to `false` to open a live viewer in your browser.
+<ParamField path="advanced_stealth" type="boolean" default={false}>
+  Enable Notte's highest-fidelity browser environment for sites with sophisticated bot detection. Access is currently available to approved workspaces; contact [hello@notte.cc](mailto:hello@notte.cc) to enable it.
 </ParamField>
 
 <ParamField path="solve_captchas" type="boolean" default={true}>
@@ -107,14 +107,14 @@ When you start a session, you get access to these properties and methods:
 
 <SessionResponse />
 
-## Headless Mode
+## Advanced Stealth
 
-Control whether to run the browser visibly or in the background:
+Use Notte's approval-gated browser environment for difficult sites:
 
-<HeadlessMode />
+<AdvancedStealth />
 
 <Tip>
-  When `headless=False`, a live viewer automatically opens in your browser so you can watch the automation in real-time.
+  Use `open_viewer=True` independently when you want the live viewer to open as the session starts.
 </Tip>
 
 ## Proxies

--- a/docs/src/features/sessions/lifecycle.mdx
+++ b/docs/src/features/sessions/lifecycle.mdx
@@ -153,7 +153,7 @@ Even with context managers, handle interrupts:
 │    with session: / session.start()                      │
 │    Status: active                                       │
 │    - Creates remote browser                             │
-│    - Opens viewer if headless=False                     │
+│    - Opens viewer if open_viewer=True                   │
 │    - Loads cookies from cookie_file                     │
 └────────────────────┬────────────────────────────────────┘
                      │

--- a/docs/src/integrations/claude-code-ai-agents.mdx
+++ b/docs/src/integrations/claude-code-ai-agents.mdx
@@ -45,7 +45,7 @@ Core workflow:
 
 ## Tips
 
-- **Viewing headless sessions**: When you start a session, the output includes a `ViewerUrl` - open it to watch your headless browser live
+- **Viewing sessions**: When you start a session, the output includes a `ViewerUrl` - open it to watch your browser live
 - **Element selectors**: Use only element IDs returned by `observe` (like `@B1`). If those don't work, use Playwright selectors validated against the live page: `#id`, `.class`, `button:has-text('Submit')`
 - **Multiple matches**: Use `>> nth=0` suffix to select the first match: `button:has-text('OK') >> nth=0`
 - **Closing modals**: `notte page press "Escape"` reliably dismisses most dialogs

--- a/docs/src/quickstart.mdx
+++ b/docs/src/quickstart.mdx
@@ -195,7 +195,6 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
           "```bash",
           "# Start a new session",
           "notte sessions start [flags]",
-          "  --headless                 Run in headless mode (default: true)",
           "  --idle-timeout-minutes     Idle timeout in minutes",
           "  --max-duration-minutes     Maximum session lifetime in minutes",
           "  --proxy                    Use default proxies",
@@ -574,13 +573,13 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
           "",
           "```bash",
           "# Scrape with session",
-          "notte sessions start --headless",
+          "notte sessions start",
           "notte page goto \"https://news.ycombinator.com\"",
           "notte page scrape --instructions \"Extract top 10 story titles\"",
           "notte sessions stop",
           "",
           "# Multi-page scraping",
-          "notte sessions start --headless",
+          "notte sessions start",
           "notte page goto \"https://example.com/products\"",
           "notte page observe",
           "notte page scrape --instructions \"Extract product names and prices\"",
@@ -701,16 +700,15 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
           "notte page click \"#target-element\"",
           "```",
           "",
-          "### Viewing Headless Sessions",
+          "### Viewing Sessions",
           "",
-          "Running with `--headless` (the default) doesn't mean you can't see the browser:",
+          "Remote sessions can always be viewed while they run:",
           "",
           "- **ViewerUrl**: When you start a session, the output includes a `ViewerUrl` - open it in your browser to watch the session live",
           "- **Viewer command**: `notte sessions viewer` opens the viewer directly",
-          "- **Non-headless mode**: Use `--headless=false` only if you need a local browser window (not available on remote/CI environments)",
           "",
           "```bash",
-          "# Start headless session and get viewer URL",
+          "# Start a session and get its viewer URL",
           "notte sessions start -o json | jq -r '.viewer_url'",
           "",
           "# Or open viewer for current session",
@@ -1053,7 +1051,6 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
     ```bash
     # Start a new session
     notte sessions start [flags]
-      --headless                 Run in headless mode (default: true)
       --idle-timeout-minutes     Idle timeout in minutes
       --max-duration-minutes     Maximum session lifetime in minutes
       --proxy                    Use default proxies
@@ -1432,13 +1429,13 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
 
     ```bash
     # Scrape with session
-    notte sessions start --headless
+    notte sessions start
     notte page goto "https://news.ycombinator.com"
     notte page scrape --instructions "Extract top 10 story titles"
     notte sessions stop
 
     # Multi-page scraping
-    notte sessions start --headless
+    notte sessions start
     notte page goto "https://example.com/products"
     notte page observe
     notte page scrape --instructions "Extract product names and prices"
@@ -1559,16 +1556,15 @@ Build reliable Python SDK automation scripts by authoring in a real browser firs
     notte page click "#target-element"
     ```
 
-    ### Viewing Headless Sessions
+    ### Viewing Sessions
 
-    Running with `--headless` (the default) doesn't mean you can't see the browser:
+    Remote sessions can always be viewed while they run:
 
     - **ViewerUrl**: When you start a session, the output includes a `ViewerUrl` - open it in your browser to watch the session live
     - **Viewer command**: `notte sessions viewer` opens the viewer directly
-    - **Non-headless mode**: Use `--headless=false` only if you need a local browser window (not available on remote/CI environments)
 
     ```bash
-    # Start headless session and get viewer URL
+    # Start a session and get its viewer URL
     notte sessions start -o json | jq -r '.viewer_url'
 
     # Or open viewer for current session
@@ -1892,7 +1888,6 @@ Control browser session lifecycle:
 ```bash
 # Start a new session
 notte sessions start [flags]
-  --headless                 Run in headless mode (default: true)
   --idle-timeout-minutes     Idle timeout in minutes
   --max-duration-minutes     Maximum session lifetime in minutes
   --proxy                    Use default proxies
@@ -2271,13 +2266,13 @@ Session ID is resolved in this order:
 
 ```bash
 # Scrape with session
-notte sessions start --headless
+notte sessions start
 notte page goto "https://news.ycombinator.com"
 notte page scrape --instructions "Extract top 10 story titles"
 notte sessions stop
 
 # Multi-page scraping
-notte sessions start --headless
+notte sessions start
 notte page goto "https://example.com/products"
 notte page observe
 notte page scrape --instructions "Extract product names and prices"
@@ -2398,16 +2393,15 @@ notte page wait 500
 notte page click "#target-element"
 ```
 
-### Viewing Headless Sessions
+### Viewing Sessions
 
-Running with `--headless` (the default) doesn't mean you can't see the browser:
+Remote sessions can always be viewed while they run:
 
 - **ViewerUrl**: When you start a session, the output includes a `ViewerUrl` - open it in your browser to watch the session live
 - **Viewer command**: `notte sessions viewer` opens the viewer directly
-- **Non-headless mode**: Use `--headless=false` only if you need a local browser window (not available on remote/CI environments)
 
 ```bash
-# Start headless session and get viewer URL
+# Start a session and get its viewer URL
 notte sessions start -o json | jq -r '.viewer_url'
 
 # Or open viewer for current session

--- a/docs/src/scripts/check_config_docs_defaults.py
+++ b/docs/src/scripts/check_config_docs_defaults.py
@@ -43,7 +43,7 @@ def code_defaults() -> dict[str, Any]:
         return fields[name].default
 
     return {
-        "headless": field_default("headless"),
+        "advanced_stealth": field_default("advanced_stealth"),
         "solve_captchas": field_default("solve_captchas"),
         "proxies": field_default("proxies"),
         # the docs param is the SDK's idle timeout

--- a/docs/src/sdk-reference/manual/agent.mdx
+++ b/docs/src/sdk-reference/manual/agent.mdx
@@ -58,7 +58,7 @@ Agents can be provided a [vault](../manual/vault) with credentials in order to s
 You can use the default parameters to create your session, or customize them:
 
 <ParamField path="session" type="UnionType[RemoteSession, None]" default="None">
-  The session to connect to. The session's `open_viewer` parameter controls         whether to display a live viewer (browsers are always headless).
+  The session to connect to. The session's `open_viewer` parameter controls whether to display a live viewer.
 </ParamField>
 
 <ParamField path="vault" type="UnionType[NotteVault, None]" default="None">

--- a/docs/src/sdk-reference/manual/session.mdx
+++ b/docs/src/sdk-reference/manual/session.mdx
@@ -60,11 +60,10 @@ You can use the default parameters to create your session, or customize them:
 </ParamField>
 
 <ParamField path="open_viewer" type="bool" default="False">
-  Whether to open the live viewer when the session starts (default: False).         Browsers are always headless; this controls only the viewer popup.
+  Whether to open the live viewer when the session starts (default: False). This controls only the viewer popup and is independent of the browser environment.
 </ParamField>
 
-<ParamField path="headless" type="bool">
-  Whether to run the session in headless mode.
+<ParamField path="advanced_stealth" type="bool">
 </ParamField>
 
 <ParamField path="solve_captchas" type="bool">

--- a/docs/src/sdk-reference/misc/sessionresponse.mdx
+++ b/docs/src/sdk-reference/misc/sessionresponse.mdx
@@ -82,10 +82,6 @@ description: ""
   The height of the viewport
 </ParamField>
 
-<ParamField path="headless" type="bool" default="True">
-  Whether to run the session in headless mode.
-</ParamField>
-
 <ParamField path="solve_captchas" type="UnionType[bool, None]">
   Whether to solve captchas.
 </ParamField>

--- a/docs/src/sdk-reference/remoteagent/__init__.mdx
+++ b/docs/src/sdk-reference/remoteagent/__init__.mdx
@@ -13,7 +13,7 @@ connections with the provided vault and session if specified.
 ## Parameters
 
 <ParamField path="session" type="UnionType[RemoteSession, None]" default="None">
-  The session to connect to. The session's `open_viewer` parameter controls         whether to display a live viewer (browsers are always headless).
+  The session to connect to. The session's `open_viewer` parameter controls         whether to display a live viewer.
 </ParamField>
 
 <ParamField path="vault" type="UnionType[NotteVault, None]" default="None">

--- a/docs/src/sdk-reference/remotesession/__init__.mdx
+++ b/docs/src/sdk-reference/remotesession/__init__.mdx
@@ -29,11 +29,7 @@ RemoteSession instance configured with the specified parameters.
 </ParamField>
 
 <ParamField path="open_viewer" type="bool" default="False">
-  Whether to open the live viewer when the session starts (default: False).         Browsers are always headless; this controls only the viewer popup.
-</ParamField>
-
-<ParamField path="headless" type="bool">
-  Whether to run the session in headless mode.
+  Whether to open the live viewer when the session starts (default: False).         This controls only the viewer popup and is independent of the browser environment.
 </ParamField>
 
 <ParamField path="solve_captchas" type="bool">
@@ -107,6 +103,9 @@ RemoteSession instance configured with the specified parameters.
 
 <ParamField path="wait_for_authentication" type="bool">
   Defaults to True. Wait for Managed Auth before returning the session; authentication failure or timeout fails session creation. When False, return after the browser is ready while authentication continues in the background.
+</ParamField>
+
+<ParamField path="advanced_stealth" type="bool">
 </ParamField>
 
 ## Returns

--- a/docs/src/snippets/agents/config/param_session.mdx
+++ b/docs/src/snippets/agents/config/param_session.mdx
@@ -2,6 +2,6 @@
 {/* @sniptest testers/agents/config/param_session.py */}
 
 ```python param_session.py
-with client.Session(headless=False) as session:
+with client.Session(open_viewer=True) as session:
     agent = client.Agent(session=session)
 ```

--- a/docs/src/snippets/agents/production.mdx
+++ b/docs/src/snippets/agents/production.mdx
@@ -9,7 +9,7 @@ client = NotteClient()
 vault = client.Vault(vault_id="prod_vault")
 persona = client.Persona(persona_id="prod_persona")
 
-with client.Session(headless=True, proxies=True) as session:
+with client.Session(proxies=True) as session:
     agent = client.Agent(
         session=session,
         reasoning_model="anthropic/claude-3.5-sonnet",

--- a/docs/src/snippets/sessions/capabilities/captcha_debug_headless.mdx
+++ b/docs/src/snippets/sessions/capabilities/captcha_debug_headless.mdx
@@ -8,7 +8,7 @@ client = NotteClient()
 
 with client.Session(
     solve_captchas=True,
-    headless=False,  # Opens live viewer
+    open_viewer=True,
 ) as session:
     # You can watch captchas being solved
     pass

--- a/docs/src/snippets/sessions/captcha/headless_debug.mdx
+++ b/docs/src/snippets/sessions/captcha/headless_debug.mdx
@@ -8,7 +8,7 @@ client = NotteClient()
 
 with client.Session(
     solve_captchas=True,
-    headless=False,  # Opens live viewer
+    open_viewer=True,
 ) as session:
     # You can watch captchas being solved
     pass

--- a/docs/src/snippets/sessions/cdp/selenium_form.mdx
+++ b/docs/src/snippets/sessions/cdp/selenium_form.mdx
@@ -5,7 +5,7 @@
   client = NotteClient()
 
   def automate_form():
-      with client.Session(headless=False) as session:
+      with client.Session(open_viewer=True) as session:
           page = session.page
 
           # Navigate to form

--- a/docs/src/snippets/sessions/configuration/full_config.mdx
+++ b/docs/src/snippets/sessions/configuration/full_config.mdx
@@ -5,7 +5,7 @@
   client = NotteClient()
 
   with client.Session(
-      headless=True,
+      advanced_stealth=False,
       solve_captchas=True,
       proxies=True,
       viewport_width=1920,

--- a/docs/src/snippets/sessions/configuration/headless_mode.mdx
+++ b/docs/src/snippets/sessions/configuration/headless_mode.mdx
@@ -4,15 +4,9 @@
 
   client = NotteClient()
 
-  # Headless mode (no viewer)
-  with client.Session(headless=True) as session:
+  # Advanced Stealth requires approval for your workspace.
+  with client.Session(advanced_stealth=True, open_viewer=True) as session:
       page = session.page
       page.goto("https://example.com")
-
-  # Non-headless (opens live viewer automatically)
-  with client.Session(headless=False) as session:
-      page = session.page
-      page.goto("https://example.com")
-      # Viewer opens automatically in your browser
   ```
 </CodeGroup>

--- a/docs/src/snippets/sessions/lifecycle/complete_example.mdx
+++ b/docs/src/snippets/sessions/lifecycle/complete_example.mdx
@@ -10,7 +10,7 @@
       print("Creating session...")
 
       with client.Session(
-          headless=False,  # Opens live viewer
+          open_viewer=True,
           timeout_minutes=10,
           cookie_file="cookies.json"  # Auto-load/save cookies
       ) as session:

--- a/docs/src/snippets/sessions/lifecycle/create_session.mdx
+++ b/docs/src/snippets/sessions/lifecycle/create_session.mdx
@@ -6,7 +6,6 @@
 
   # Recommended: Use context manager for automatic cleanup
   with client.Session(
-      headless=True,
       timeout_minutes=10,
       viewport_width=1920,
       viewport_height=1080

--- a/docs/src/testers/agents/config/param_session.py
+++ b/docs/src/testers/agents/config/param_session.py
@@ -3,5 +3,5 @@
 from notte_sdk import NotteClient
 
 client = NotteClient()
-with client.Session(headless=False) as session:
+with client.Session(open_viewer=True) as session:
     agent = client.Agent(session=session)

--- a/docs/src/testers/agents/production.py
+++ b/docs/src/testers/agents/production.py
@@ -6,7 +6,7 @@ client = NotteClient()
 vault = client.Vault(vault_id="prod_vault")
 persona = client.Persona(persona_id="prod_persona")
 
-with client.Session(headless=True, proxies=True) as session:
+with client.Session(proxies=True) as session:
     agent = client.Agent(
         session=session,
         reasoning_model="anthropic/claude-3.5-sonnet",

--- a/docs/src/testers/sessions/capabilities/captcha_debug_headless.py
+++ b/docs/src/testers/sessions/capabilities/captcha_debug_headless.py
@@ -5,7 +5,7 @@ client = NotteClient()
 
 with client.Session(
     solve_captchas=True,
-    headless=False,  # Opens live viewer
+    open_viewer=True,
 ) as session:
     # You can watch captchas being solved
     pass

--- a/docs/src/testers/sessions/captcha/headless_debug.py
+++ b/docs/src/testers/sessions/captcha/headless_debug.py
@@ -5,7 +5,7 @@ client = NotteClient()
 
 with client.Session(
     solve_captchas=True,
-    headless=False,  # Opens live viewer
+    open_viewer=True,
 ) as session:
     # You can watch captchas being solved
     pass

--- a/packages/notte-browser/src/notte_browser/playwright.py
+++ b/packages/notte-browser/src/notte_browser/playwright.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 from notte_core.common.logging import logger
 from notte_core.common.resource import AsyncResource
 from notte_core.profiling import profiler
-from notte_sdk.types import SessionStartRequest
+from notte_sdk.types import LocalSessionStartRequest
 from openai import BaseModel
 from pydantic import PrivateAttr
 from typing_extensions import override
@@ -161,7 +161,7 @@ class PlaywrightManager(BaseModel, BaseWindowManager):
     async def new_window(self, options: BrowserWindowOptions | None = None) -> BrowserWindow:
         if not self.is_started():
             _ = await self.astart()
-        options = options or BrowserWindowOptions.from_request(SessionStartRequest())
+        options = options or BrowserWindowOptions.from_request(LocalSessionStartRequest())
         browser = await self.create_playwright_browser(options)
         resource = await self.get_browser_resource(options, browser)
 

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -76,13 +76,13 @@ from notte_core.utils.webp_replay import ScreenshotReplay, WebpReplay
 from notte_llm.service import LLMService
 from notte_sdk.endpoints.personas import BasePersona
 from notte_sdk.types import (
+    LocalSessionStartRequest,
+    LocalSessionStartRequestDict,
     PaginationParams,
     PaginationParamsDict,
     ScrapeMarkdownParamsDict,
     ScrapeParams,
     ScrapeParamsDict,
-    SessionStartRequest,
-    SessionStartRequestDict,
 )
 from pydantic import RootModel, ValidationError
 from typing_extensions import override
@@ -130,7 +130,7 @@ class NotteSession(AsyncResource, SyncResource):
         persona: BasePersona | None = None,
         window: BrowserWindow | None = None,
         keep_alive: bool = False,
-        **data: Unpack[SessionStartRequestDict],
+        **data: Unpack[LocalSessionStartRequestDict],
     ) -> None:
         if storage is not None and storage.is_remote:
             raise ValueError(
@@ -139,7 +139,7 @@ class NotteSession(AsyncResource, SyncResource):
         # CAPTCHA solving is a cloud SDK capability. Keep local sessions
         # runnable by default while preserving an explicit opt-in error.
         _ = data.setdefault("solve_captchas", False)
-        self._request: SessionStartRequest = SessionStartRequest.model_validate(data)
+        self._request: LocalSessionStartRequest = LocalSessionStartRequest.model_validate(data)
         if self._request.solve_captchas and not CaptchaHandler.is_available:
             raise CaptchaSolverNotAvailableError()
         self.screenshot_type: ScreenshotType = self._request.screenshot_type
@@ -189,7 +189,7 @@ class NotteSession(AsyncResource, SyncResource):
         await self.window.set_cookies(cookies=cookies, cookie_path=cookie_file)
 
     @staticmethod
-    def script(storage: BaseStorage | None = None, **data: Unpack[SessionStartRequestDict]) -> NotteSession:
+    def script(storage: BaseStorage | None = None, **data: Unpack[LocalSessionStartRequestDict]) -> NotteSession:
         return NotteSession(storage=storage, raise_on_failure=True, perception_type="fast", **data)
 
     @track_usage("local.session.cookies.get")

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -28,7 +28,7 @@ from notte_sdk.types import (
     DEFAULT_HEADLESS_VIEWPORT_WIDTH,
     AspectRatio,
     Cookie,
-    SessionStartRequest,
+    LocalSessionStartRequest,
 )
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from typing_extensions import override
@@ -153,7 +153,7 @@ class BrowserWindowOptions(BaseModel):
         return chrome_args
 
     @staticmethod
-    def from_request(request: SessionStartRequest) -> "BrowserWindowOptions":
+    def from_request(request: LocalSessionStartRequest) -> "BrowserWindowOptions":
         return BrowserWindowOptions(
             headless=request.headless,
             solve_captchas=request.solve_captchas,

--- a/packages/notte-integrations/src/notte_integrations/sessions/cdp_session.py
+++ b/packages/notte-integrations/src/notte_integrations/sessions/cdp_session.py
@@ -8,7 +8,7 @@ from notte_core.common.config import BrowserType
 from notte_core.common.logging import logger
 from notte_sdk.client import NotteClient
 from notte_sdk.endpoints.sessions import RemoteSession
-from notte_sdk.types import SessionStartRequest
+from notte_sdk.types import LocalSessionStartRequest
 from pydantic import BaseModel, Field
 from typing_extensions import override
 
@@ -45,7 +45,7 @@ class CDPSessionManager(PlaywrightManager, ABC):
         if self.client is None:
             logger.info("Creating new Notte client")
             self.client = NotteClient()
-        self.session = self.create_session_cdp(BrowserWindowOptions.from_request(SessionStartRequest()))
+        self.session = self.create_session_cdp(BrowserWindowOptions.from_request(LocalSessionStartRequest()))
         self.notte_session = self.client.Session(cdp_url=self.session.cdp_url)
         return self.notte_session.__enter__()
 

--- a/packages/notte-integrations/src/notte_integrations/sessions/notte.py
+++ b/packages/notte-integrations/src/notte_integrations/sessions/notte.py
@@ -24,7 +24,7 @@ class NotteSessionsManager(CDPSessionManager):
         logger.info("Creating Notte session...")
 
         session = self.notte.Session(
-            headless=options.headless,
+            advanced_stealth=not options.headless,
             viewport_width=options.viewport_width,
             viewport_height=options.viewport_height,
             proxies=options.proxy is not None,

--- a/packages/notte-sdk/src/notte_sdk/client.py
+++ b/packages/notte-sdk/src/notte_sdk/client.py
@@ -86,7 +86,7 @@ class NotteClient:
 
     @property
     def Session(self) -> type[RemoteSession]:
-        return cast(type[RemoteSession], partial(RemoteSession, _client=self.sessions, headless=True))
+        return cast(type[RemoteSession], partial(RemoteSession, _client=self.sessions))
 
     @property
     def Agent(self) -> type[RemoteAgent]:

--- a/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/agents.py
@@ -901,7 +901,7 @@ class RemoteAgent:
         Args:
             vault: A notte vault instance, if the agent requires authentication
             session: The session to connect to. The session's `open_viewer` parameter controls
-                whether to display a live viewer (browsers are always headless).
+                whether to display a live viewer.
             notifier: A notifier (for example, email), which will get called upon task completion.
             session_id: (deprecated) use session instead
             **data: Additional keyword arguments for the agent creation request.

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -626,7 +626,8 @@ class RemoteSession(SyncResource):
         Args:
             storage: File Storage to attach to the session
             open_viewer: Whether to open the live viewer when the session starts (default: False).
-                Browsers are always headless; this controls only the viewer popup.
+                This controls only the viewer popup and is independent of the browser environment.
+            advanced_stealth: Enable Notte's highest-fidelity browser environment. Available to approved workspaces.
             wait_for_authentication: Defaults to True. Wait for Managed Auth before returning the
                 session; authentication failure or timeout fails session creation. When False,
                 return after the browser is ready while authentication continues in the background.

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -36,7 +36,17 @@ from notte_core.storage import FileInfo as FileInfo  # noqa: E402
 from notte_core.trajectory import ElementLiteral
 from notte_core.utils.pydantic_schema import convert_response_format_to_pydantic_model
 from notte_core.utils.url import get_root_domain
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializerFunctionWrapHandler,
+    computed_field,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 from pyotp import TOTP
 from typing_extensions import NotRequired, TypedDict, deprecated, override
 
@@ -734,11 +744,10 @@ class SessionProfile(SdkRequest):
     persist: Annotated[bool, Field(description="Whether to save browser state to profile on session close")] = False
 
 
-class SessionStartRequestDict(TypedDict, total=False):
+class _SessionStartRequestDict(TypedDict, total=False):
     """Request dictionary for starting a session.
 
     Args:
-        headless: Whether to run the session in headless mode.
         solve_captchas: Whether to try to automatically solve captchas
         max_duration_minutes: Maximum session lifetime in minutes (absolute maximum).
         idle_timeout_minutes: Idle timeout in minutes. Session closes after this period of inactivity.
@@ -759,7 +768,6 @@ class SessionStartRequestDict(TypedDict, total=False):
             ready while authentication continues in the background.
     """
 
-    headless: bool
     solve_captchas: bool
     max_duration_minutes: int
     idle_timeout_minutes: int
@@ -783,8 +791,19 @@ class SessionStartRequestDict(TypedDict, total=False):
     wait_for_authentication: bool
 
 
-class SessionStartRequest(SdkRequest):
-    headless: Annotated[bool, Field(description="Whether to run the session in headless mode.")] = config.headless
+class SessionStartRequestDict(_SessionStartRequestDict, total=False):
+    """Public request dictionary for starting a remote session."""
+
+    advanced_stealth: bool
+
+
+class LocalSessionStartRequestDict(_SessionStartRequestDict, total=False):
+    """Request dictionary for starting a browser session on the local machine."""
+
+    headless: bool
+
+
+class _SessionStartRequest(SdkRequest):
     solve_captchas: Annotated[bool, Field(description="Whether to try to automatically solve captchas")] = True
 
     max_duration_minutes: Annotated[
@@ -884,7 +903,7 @@ class SessionStartRequest(SdkRequest):
         return values  # pyright: ignore[reportUnknownVariableType]
 
     @model_validator(mode="after")
-    def validate_unique_auth_ids(self) -> "SessionStartRequest":
+    def validate_unique_auth_ids(self) -> "_SessionStartRequest":
         if len(self.auth_ids) != len(set(self.auth_ids)):
             raise ValueError("auth_ids must not contain duplicates")
         return self
@@ -908,13 +927,13 @@ class SessionStartRequest(SdkRequest):
         return data
 
     @model_validator(mode="after")
-    def check_viewport(self) -> "SessionStartRequest":
+    def check_viewport(self) -> "_SessionStartRequest":
         if (self.viewport_width is None) != (self.viewport_height is None):
             raise ValueError("Both viewport_width and viewport_height must be set together or both must be None")
         return self
 
     @model_validator(mode="after")
-    def check_solve_captchas(self) -> "SessionStartRequest":
+    def check_solve_captchas(self) -> "_SessionStartRequest":
         if self.browser_type in ("chrome-nightly", "chrome-turbo") and self.solve_captchas and not self.proxies:
             raise ValueError(
                 f"`proxies` parameter cannot be falsy when setting `solve_captchas=True` with `browser_type` '{self.browser_type}'."
@@ -923,7 +942,7 @@ class SessionStartRequest(SdkRequest):
         return self
 
     @model_validator(mode="after")
-    def validate_cdp_url_constraints(self) -> "SessionStartRequest":
+    def validate_cdp_url_constraints(self) -> "_SessionStartRequest":
         """
         Validate that when cdp_url is provided, certain fields are set to their default values.
 
@@ -931,11 +950,6 @@ class SessionStartRequest(SdkRequest):
             ValueError: If cdp_url is provided but other fields are not set to defaults.
         """
         if self.cdp_url is not None:
-            if not self.headless:
-                raise ValueError(
-                    "When cdp_url is provided, headless must be True. "
-                    + "Headed mode (headless=False) only works with a local browser."
-                )
             if self.user_agent is not None:
                 raise ValueError(
                     "When cdp_url is provided, user_agent must be None. Set the user agent with your external session CDP provider."
@@ -955,7 +969,7 @@ class SessionStartRequest(SdkRequest):
         return self
 
     @model_validator(mode="after")
-    def validate_timeout_relationship(self) -> "SessionStartRequest":
+    def validate_timeout_relationship(self) -> "_SessionStartRequest":
         """
         Validate that idle_timeout_minutes does not exceed max_duration_minutes.
 
@@ -1008,6 +1022,65 @@ class SessionStartRequest(SdkRequest):
         raise ValueError(f"Unsupported proxy type: {base_proxy.type}")  # pyright: ignore[reportUnreachable]
 
 
+class SessionStartRequest(_SessionStartRequest):
+    """Public request for starting a remote Notte browser session."""
+
+    advanced_stealth: Annotated[
+        bool,
+        Field(
+            description=(
+                "Enable Notte's highest-fidelity browser environment for sites with sophisticated bot detection. "
+                "Available to approved workspaces."
+            )
+        ),
+    ] = False
+
+    @model_serializer(mode="wrap")
+    def omit_disabled_advanced_stealth(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        data = cast(dict[str, Any], handler(self))
+        if not self.advanced_stealth:
+            data.pop("advanced_stealth", None)
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def handle_legacy_headless(cls, values: Any) -> Any:
+        """Keep old SDKs working without exposing remote browser launch mode."""
+        if not isinstance(values, dict):
+            return values
+        data = dict(cast(dict[str, Any], values))
+        if "headless" not in data:
+            return data
+        headless = data.pop("headless")
+        if headless is not True:
+            raise ValueError(
+                "Remote `headless=False` is no longer supported. "
+                + "`headless=True` sessions still include session replays and access to the live viewer."
+            )
+        return data
+
+    @model_validator(mode="after")
+    def validate_advanced_stealth_cdp_url(self) -> "SessionStartRequest":
+        if self.advanced_stealth and self.cdp_url is not None:
+            raise ValueError("advanced_stealth cannot be used with an external cdp_url")
+        return self
+
+
+class LocalSessionStartRequest(_SessionStartRequest):
+    """Request for starting a browser session on the local machine."""
+
+    headless: Annotated[bool, Field(description="Whether to run the local browser in headless mode.")] = config.headless
+
+    @model_validator(mode="after")
+    def validate_local_cdp_headless(self) -> "LocalSessionStartRequest":
+        if self.cdp_url is not None and not self.headless:
+            raise ValueError(
+                "When cdp_url is provided, headless must be True. "
+                + "Headed mode (headless=False) only works with a locally launched browser."
+            )
+        return self
+
+
 class ListRequestDict(TypedDict, total=False):
     only_active: bool
     page_size: int
@@ -1057,6 +1130,9 @@ def _drop_duration_format(schema: dict[str, Any]) -> None:
 
 
 class SessionResponse(SdkResponse):
+    # Preserve unknown response fields so legacy wire metadata such as
+    # ``headless`` remains available without becoming part of current schemas.
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
     session_id: Annotated[
         str,
         Field(
@@ -1115,7 +1191,13 @@ class SessionResponse(SdkResponse):
     user_agent: Annotated[str | None, Field(description="The user agent to use for the session")] = None
     viewport_width: Annotated[int | None, Field(description="The width of the viewport")] = None
     viewport_height: Annotated[int | None, Field(description="The height of the viewport")] = None
-    headless: Annotated[bool, Field(description="Whether to run the session in headless mode.")] = True
+
+    @property
+    def headless(self) -> bool:
+        """Legacy launch metadata retained for old session-status consumers."""
+        extra = self.__pydantic_extra__
+        return True if extra is None else bool(extra.get("headless", True))
+
     solve_captchas: Annotated[bool | NoneType, Field(description="Whether to solve captchas.")] = None
     cdp_url: Annotated[str | None, Field(description="The URL to connect to the CDP server.")] = None
     viewer_url: Annotated[str | None, Field(description="The remote session viewer URL.")] = None

--- a/tests/browser/test_window_options.py
+++ b/tests/browser/test_window_options.py
@@ -3,13 +3,13 @@ from notte_browser.window import BrowserWindowOptions
 from notte_sdk.types import (
     DEFAULT_HEADLESS_VIEWPORT_HEIGHT,
     DEFAULT_HEADLESS_VIEWPORT_WIDTH,
-    SessionStartRequest,
+    LocalSessionStartRequest,
 )
 from pydantic import ValidationError
 
 
 def test_headless_window_options_preserve_16_9_aspect_ratio() -> None:
-    request = SessionStartRequest(headless=True, aspect_ratio="16:9")
+    request = LocalSessionStartRequest(headless=True, aspect_ratio="16:9")
 
     options = BrowserWindowOptions.from_request(request)
 
@@ -18,7 +18,7 @@ def test_headless_window_options_preserve_16_9_aspect_ratio() -> None:
 
 
 def test_headless_window_options_preserve_5_4_aspect_ratio() -> None:
-    request = SessionStartRequest(headless=True, aspect_ratio="5:4")
+    request = LocalSessionStartRequest(headless=True, aspect_ratio="5:4")
 
     options = BrowserWindowOptions.from_request(request)
 
@@ -29,7 +29,7 @@ def test_headless_window_options_preserve_5_4_aspect_ratio() -> None:
 
 def test_explicit_viewport_takes_precedence_over_aspect_ratio_defaulting() -> None:
     options = BrowserWindowOptions.from_request(
-        SessionStartRequest(headless=True, viewport_width=1000, viewport_height=500)
+        LocalSessionStartRequest(headless=True, viewport_width=1000, viewport_height=500)
     )
 
     assert options.viewport_width == 1000
@@ -38,7 +38,7 @@ def test_explicit_viewport_takes_precedence_over_aspect_ratio_defaulting() -> No
 
 def test_aspect_ratio_rejects_explicit_viewport() -> None:
     with pytest.raises(ValidationError, match="aspect_ratio cannot be set together with viewport_width"):
-        SessionStartRequest(headless=True, aspect_ratio="16:9", viewport_width=1000, viewport_height=500)
+        LocalSessionStartRequest(headless=True, aspect_ratio="16:9", viewport_width=1000, viewport_height=500)
 
 
 def test_headless_cdp_window_options_do_not_synthesize_viewport() -> None:

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -114,8 +114,7 @@ def test_open_viewer_false_no_viewer(client: NotteClient, session_id: str) -> No
             mock_viewer.assert_not_called()
 
 
-def test_session_always_headless_true_on_wire(client: NotteClient, session_id: str, headers: dict[str, str]) -> None:
-    """Test that session start requests always include headless=True."""
+def test_remote_session_omits_headless_on_wire(client: NotteClient, session_id: str, headers: dict[str, str]) -> None:
     with patch("requests.post") as mock_post:
         mock_response = session_response_dict(session_id)
         mock_post.return_value.status_code = 200
@@ -133,11 +132,8 @@ def test_session_always_headless_true_on_wire(client: NotteClient, session_id: s
         if calls:
             call_args = calls[0]
             request_data = json.loads(call_args.kwargs["data"])
-            # Verify headless is always True in the wire request
-            assert request_data["headless"] is True
-        else:
-            # Fallback: check the request attribute directly
-            assert session.request.headless is True
+            assert "headless" not in request_data
+            assert "advanced_stealth" not in request_data
 
 
 def _start_session(mock_post: MagicMock, client: NotteClient, session_id: str) -> SessionResponse:
@@ -165,7 +161,6 @@ def _stop_session(mock_delete: MagicMock, client: NotteClient, session_id: str) 
 @pytest.mark.order(1)
 def test_start_session(mock_post: MagicMock, client: NotteClient, session_id: str, headers: dict[str, str]) -> None:
     session_data: SessionStartRequestDict = {
-        "headless": True,
         "solve_captchas": True,
         "idle_timeout_minutes": DEFAULT_SESSION_IDLE_TIMEOUT_IN_MINUTES,
         "max_duration_minutes": DEFAULT_SESSION_MAX_DURATION_IN_MINUTES,

--- a/tests/sdk/test_dict_types.py
+++ b/tests/sdk/test_dict_types.py
@@ -299,7 +299,7 @@ def test_agent_create_request_with_valid_model():
 
 
 def test_should_be_able_to_start_cdp_session_with_default_session_parameters():
-    _ = SessionStartRequest(cdp_url="test", headless=True)
+    _ = SessionStartRequest(cdp_url="test")
 
 
 def test_execution_request_dict_alignment():
@@ -425,6 +425,7 @@ def test_all_request_classes_have_dict_types_and_proper_inheritance():
         "SetCookiesRequest",  # Uses existing Cookie structures
         "StartFunctionRunRequest",  # Complex composition, may not need Dict
         "TabSessionDebugRequest",  # Simple debug request with single field
+        "_SessionStartRequest",  # Shared implementation for local and remote session requests
     }
 
     # Create mapping of expected Dict names, excluding exceptions
@@ -446,6 +447,7 @@ def test_all_request_classes_have_dict_types_and_proper_inheritance():
         "PersonaListRequestDict",  # For PersonaListRequest (inherits from SessionListRequest)
         "ListFunctionsRequestDict",  # For ListFunctionsRequest (inherits from SessionListRequest)
         "ListFunctionRunsRequestDict",  # For ListFunctionRunsRequest (inherits from SessionListRequest)
+        "_SessionStartRequestDict",  # Shared implementation for local and remote session request dicts
     }
 
     # Remove mappings that have special dict types
@@ -460,7 +462,13 @@ def test_all_request_classes_have_dict_types_and_proper_inheritance():
     # Valid inheritance patterns - build hierarchy aware validation
     def is_valid_inheritance(class_name: str, inheritance_chain: str) -> bool:
         valid_direct_bases = ["SdkRequest", "BaseModel"]
-        valid_request_bases = ["ListRequest", "SessionListRequest", "PaginationParams", "ScrapeParams"]
+        valid_request_bases = [
+            "ListRequest",
+            "SessionListRequest",
+            "PaginationParams",
+            "ScrapeParams",
+            "_SessionStartRequest",
+        ]
         valid_composite_bases = [
             "SdkAgentCreateRequest",
             "AgentRunRequest",

--- a/tests/sdk/test_types.py
+++ b/tests/sdk/test_types.py
@@ -222,8 +222,25 @@ def test_unknown_proxy_type_should_raise_error():
 
 
 def test_cdp_url_with_headless_false_should_raise_error():
-    with pytest.raises(ValidationError, match=r"headless must be True.*only works with a local browser"):
+    with pytest.raises(
+        ValidationError,
+        match=r"`headless=True` sessions still include session replays and access to the live viewer",
+    ):
         _ = SessionStartRequest.model_validate({"cdp_url": "ws://localhost:9222", "headless": False})
+
+
+def test_remote_headless_true_is_accepted_for_legacy_sdks_but_not_serialized():
+    request = SessionStartRequest.model_validate({"headless": True})
+    assert "headless" not in request.model_dump()
+
+
+def test_advanced_stealth_is_public_but_headless_response_is_hidden_from_schema():
+    assert "advanced_stealth" in SessionStartRequest.model_json_schema()["properties"]
+    assert "advanced_stealth" not in SessionStartRequest().model_dump()
+    assert SessionStartRequest(advanced_stealth=True).model_dump()["advanced_stealth"] is True
+    assert "headless" not in SessionStartRequest.model_json_schema()["properties"]
+    assert "headless" not in SessionResponse.model_json_schema()["properties"]
+    assert _session_response(dt.timedelta()).model_dump()["headless"] is True
 
 
 # ABNF `duration` rule from RFC 3339 Appendix A, which is what JSON Schema's
@@ -240,6 +257,7 @@ def _session_response(duration: dt.timedelta) -> SessionResponse:
         last_accessed_at=now,
         status="active",
         duration=duration,
+        headless=True,
     )
 
 


### PR DESCRIPTION
## Summary

- split local and remote session-start models so headless remains local-only
- expose advanced_stealth for remote sessions and keep legacy headless=true requests compatible
- keep the legacy headless session-status value on the wire while removing it from current schemas and docs
- update SDK documentation and examples to advertise Advanced Stealth and the live viewer

## Compatibility

- old remote headless=true input is accepted and ignored
- remote headless=false is rejected with migration guidance
- old session-status consumers continue receiving and reading headless

## Validation

- 98 focused SDK and browser tests passed
- Ruff, basedpyright, documentation generation, defaults checks, and all commit hooks passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790263777&installation_model_id=8247&pr_number=911&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F911&signature=20f9073e9dbcc845e0fa3f2e85989fd3ea1a674ba3270a2a65837020f4cfcbc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable advanced stealth mode for approved access.
  - Separated live viewer controls from browser environment settings.
  - Improved local and remote session configuration.

- **Documentation**
  - Updated guides, references, examples, and lifecycle diagrams.
  - Clarified CAPTCHA debugging and live viewer workflows.
  - Removed outdated headless-browser terminology and options.

- **Bug Fixes**
  - Improved session validation and request serialization.
  - Preserved legacy session metadata for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->