### PR TITLE
fix(core): deny subprocess creation while a function runs

### DIFF
--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -17,6 +17,7 @@ import contextlib
 import json
 import os
 import subprocess
+import threading
 import traceback
 import types
 from collections.abc import Iterable, Iterator, Mapping
@@ -74,37 +75,60 @@ _SUBPROCESS_GUARDED: tuple[tuple[Any, tuple[str, ...]], ...] = (
 )
 
 
+_subprocess_guard_lock = threading.Lock()
+_subprocess_guard_depth = 0
+_subprocess_guard_saved: list[tuple[Any, str, Any]] = []
+
+
+def _deny_subprocess(*_args: Any, **_kwargs: Any) -> Any:
+    raise SubprocessNotAllowed("subprocess creation is not permitted while a function runs")
+
+
 @contextlib.contextmanager
 def deny_subprocess_creation() -> Iterator[None]:
     """Refuse process creation for the duration of the block, then restore it.
 
-    Scoped rather than installed once at import on purpose. The runner spawns its
-    own worker children through a forkserver, and a process-global patch left in
-    place would deny that too; wrapping only the user-code ``exec`` leaves the
-    runner's own machinery alone. Restoring also keeps a host process - the SDK
-    runs a local function inside the caller's own interpreter - usable for its
-    own subprocesses afterwards.
+    Scoped rather than installed once at import: a runtime that spawns its own
+    worker children through a forkserver would have that denied by a permanent
+    patch, and the SDK runs a local function inside the caller's own interpreter,
+    which must stay able to spawn afterwards.
 
-    Save-and-restore, so it is not reentrant safe across threads sharing one
-    process. The runner executes one function per child, so that does not arise
-    here; the durable answer for a hostile guest is an OS boundary (seccomp),
-    which this does not replace.
+    Reentrant across threads by design. The patch is installed when the first
+    guarded run in the process begins and removed only when the last one ends, so
+    two overlapping local runs cannot open a window where one has restored the
+    real ``subprocess`` while the other guest is still executing, nor leave the
+    host permanently denied. A depth count under a lock is what buys that.
+
+    What it does NOT do: contain a function that starts a background thread and
+    returns. Once no guarded run is in flight the patch is gone, so a thread that
+    spawns then reaches the real ``subprocess``. Restricted mode (the default)
+    refuses the ``async def`` that reaches asyncio's subprocess API at all, and a
+    genuinely hostile guest needs an OS boundary - seccomp denying
+    ``fork`` / ``execve``. This is a defense-in-depth layer beneath those, not a
+    substitute for them. The runner that executes untrusted code closes the
+    thread gap a different way: it runs each function in a single-use child and
+    denies subprocess there permanently.
     """
 
-    def _deny(*_args: Any, **_kwargs: Any) -> Any:
-        raise SubprocessNotAllowed("subprocess creation is not permitted while a function runs")
-
-    saved: list[tuple[Any, str, Any]] = []
+    global _subprocess_guard_depth
+    with _subprocess_guard_lock:
+        if _subprocess_guard_depth == 0:
+            _subprocess_guard_saved.clear()
+            for module, names in _SUBPROCESS_GUARDED:
+                for name in names:
+                    if hasattr(module, name):
+                        _subprocess_guard_saved.append((module, name, getattr(module, name)))
+                        setattr(module, name, _deny_subprocess)
+        _subprocess_guard_depth += 1
     try:
-        for module, names in _SUBPROCESS_GUARDED:
-            for name in names:
-                if hasattr(module, name):
-                    saved.append((module, name, getattr(module, name)))
-                    setattr(module, name, _deny)
         yield
     finally:
-        for module, name, original in saved:
-            setattr(module, name, original)
+        with _subprocess_guard_lock:
+            _subprocess_guard_depth -= 1
+            if _subprocess_guard_depth == 0:
+                for module, name, original in _subprocess_guard_saved:
+                    setattr(module, name, original)
+                _subprocess_guard_saved.clear()
 
 
 class ParameterInfo(BaseModel):

--- a/packages/notte-core/src/notte_core/ast.py
+++ b/packages/notte-core/src/notte_core/ast.py
@@ -13,10 +13,13 @@ and returns a wrong answer instead of failing.
 """
 
 import ast
+import contextlib
 import json
+import os
+import subprocess
 import traceback
 import types
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from typing import Any, Callable, ClassVar, Literal, Protocol, cast, final
 
 from pydantic import BaseModel, ConfigDict
@@ -29,6 +32,79 @@ class MissingRunFunctionError(Exception):
     """Raised when a script does not contain a required 'run' function"""
 
     pass
+
+
+class SubprocessNotAllowed(PermissionError):
+    """Raised when a running script tries to spawn a process."""
+
+
+# The names that create a process, grouped by the module they live on. The
+# import allow list refuses ``subprocess`` and ``os`` to script authors, but
+# ``asyncio`` is allowed - functions use ``asyncio.to_thread`` for concurrency -
+# and ``asyncio.create_subprocess_shell`` reaches a real shell. It, the event
+# loop's ``subprocess_shell`` / ``subprocess_exec``, and the low-level
+# ``loop._make_subprocess_transport`` all funnel through ``subprocess.Popen`` on
+# Linux, so blocking Popen closes every asyncio route at once. The ``os``
+# primitives are covered too, for a caller that reaches them some other way.
+_SUBPROCESS_GUARDED: tuple[tuple[Any, tuple[str, ...]], ...] = (
+    (subprocess, ("Popen", "run", "call", "check_call", "check_output")),
+    (
+        os,
+        (
+            "fork",
+            "forkpty",
+            "posix_spawn",
+            "posix_spawnp",
+            "system",
+            "popen",
+            "execv",
+            "execve",
+            "execvp",
+            "execvpe",
+            "execl",
+            "execle",
+            "execlp",
+            "execlpe",
+            "spawnv",
+            "spawnve",
+            "spawnvp",
+            "spawnvpe",
+        ),
+    ),
+)
+
+
+@contextlib.contextmanager
+def deny_subprocess_creation() -> Iterator[None]:
+    """Refuse process creation for the duration of the block, then restore it.
+
+    Scoped rather than installed once at import on purpose. The runner spawns its
+    own worker children through a forkserver, and a process-global patch left in
+    place would deny that too; wrapping only the user-code ``exec`` leaves the
+    runner's own machinery alone. Restoring also keeps a host process - the SDK
+    runs a local function inside the caller's own interpreter - usable for its
+    own subprocesses afterwards.
+
+    Save-and-restore, so it is not reentrant safe across threads sharing one
+    process. The runner executes one function per child, so that does not arise
+    here; the durable answer for a hostile guest is an OS boundary (seccomp),
+    which this does not replace.
+    """
+
+    def _deny(*_args: Any, **_kwargs: Any) -> Any:
+        raise SubprocessNotAllowed("subprocess creation is not permitted while a function runs")
+
+    saved: list[tuple[Any, str, Any]] = []
+    try:
+        for module, names in _SUBPROCESS_GUARDED:
+            for name in names:
+                if hasattr(module, name):
+                    saved.append((module, name, getattr(module, name)))
+                    setattr(module, name, _deny)
+        yield
+    finally:
+        for module, name, original in saved:
+            setattr(module, name, original)
 
 
 class ParameterInfo(BaseModel):
@@ -818,16 +894,17 @@ class SecureScriptRunner:
             result: Mapping[str, object] = {}
 
             try:
-                exec(parsed_info.code, execution_globals, result)
+                with deny_subprocess_creation():
+                    exec(parsed_info.code, execution_globals, result)
 
-                # Call the run function if it exists
-                run_ft = result.get("run")
-                if run_ft is None or not callable(run_ft):
-                    raise MissingRunFunctionError("Script must contain a 'run' function")
-                if callable(run_ft):
-                    return run_ft(**variables) if variables else run_ft()
+                    # Call the run function if it exists
+                    run_ft = result.get("run")
+                    if run_ft is None or not callable(run_ft):
+                        raise MissingRunFunctionError("Script must contain a 'run' function")
+                    if callable(run_ft):
+                        return run_ft(**variables) if variables else run_ft()
 
-                return result
+                    return result
 
             except Exception:
                 raise RuntimeError(f"Python script execution failed in restricted mode: {traceback.format_exc()}")
@@ -840,17 +917,18 @@ class SecureScriptRunner:
             }
 
             try:
-                # Execute the script in regular Python
-                exec(parsed_info.code, execution_globals)
+                with deny_subprocess_creation():
+                    # Execute the script in regular Python
+                    exec(parsed_info.code, execution_globals)
 
-                # Call the run function
-                run_ft = execution_globals.get("run")
-                if run_ft is None or not callable(run_ft):
-                    raise MissingRunFunctionError("Python script must contain a 'run' function")
-                if callable(run_ft):
-                    return run_ft(**variables) if variables else run_ft()  # pyright: ignore [reportUnknownVariableType]
+                    # Call the run function
+                    run_ft = execution_globals.get("run")
+                    if run_ft is None or not callable(run_ft):
+                        raise MissingRunFunctionError("Python script must contain a 'run' function")
+                    if callable(run_ft):
+                        return run_ft(**variables) if variables else run_ft()  # pyright: ignore [reportUnknownVariableType]
 
-                return execution_globals
+                    return execution_globals
 
             except Exception:
                 raise RuntimeError(f"Script execution failed in unrestricted mode: {traceback.format_exc()}")

--- a/tests/scripts/test_subprocess_denied.py
+++ b/tests/scripts/test_subprocess_denied.py
@@ -1,0 +1,77 @@
+"""A running function must not be able to spawn a process.
+
+The runner allows ``asyncio`` (functions use it for concurrency), and asyncio is
+the one route to a subprocess the import allow list leaves reachable.
+``deny_subprocess_creation`` closes it around the user-code ``exec`` and, being
+scoped, restores process creation afterwards so the runner's own forkserver and
+an SDK host process keep working.
+"""
+
+import subprocess
+
+import pytest
+from notte_core.ast import SecureScriptRunner, SubprocessNotAllowed, deny_subprocess_creation
+
+
+class _StubNotteModule:
+    def __getattr__(self, name: str) -> object:
+        raise RuntimeError(f"notte.{name} is not available in this test")
+
+
+def _run(body: str, *, restricted: bool) -> object:
+    return SecureScriptRunner(_StubNotteModule()).run_script(body, restricted=restricted)  # pyright: ignore [reportArgumentType]
+
+
+_CREATE_SUBPROCESS_SHELL = """
+import asyncio
+async def go():
+    p = await asyncio.create_subprocess_shell("echo escaped", stdout=-1)
+    out, _ = await p.communicate()
+    return out
+return asyncio.run(go())
+"""
+
+_MAKE_SUBPROCESS_TRANSPORT = """
+import asyncio
+async def go():
+    loop = asyncio.get_event_loop()
+    return await loop._make_subprocess_transport(
+        asyncio.SubprocessProtocol(), "echo x", True, -1, -1, -1, None
+    )
+return asyncio.run(go())
+"""
+
+_TO_THREAD = """
+import asyncio
+return asyncio.run(asyncio.to_thread(lambda: 2 + 2))
+"""
+
+
+def _as_run(body: str) -> str:
+    import textwrap
+
+    return "def run():\n" + textwrap.indent(textwrap.dedent(body).strip() + "\n", "    ")
+
+
+def test_unrestricted_subprocess_is_blocked() -> None:
+    with pytest.raises(RuntimeError, match="not permitted"):
+        _run(_as_run(_CREATE_SUBPROCESS_SHELL), restricted=False)
+
+
+def test_unrestricted_low_level_transport_is_blocked() -> None:
+    with pytest.raises(RuntimeError, match="not permitted"):
+        _run(_as_run(_MAKE_SUBPROCESS_TRANSPORT), restricted=False)
+
+
+def test_unrestricted_concurrency_still_works() -> None:
+    assert _run(_as_run(_TO_THREAD), restricted=False) == 4
+
+
+def test_the_guard_restores_afterwards() -> None:
+    # A scoped guard must leave the host process able to spawn again - the SDK
+    # runs a local function inside the caller's own interpreter.
+    original = subprocess.Popen
+    with deny_subprocess_creation():
+        with pytest.raises(SubprocessNotAllowed):
+            subprocess.Popen(["true"])
+    assert subprocess.Popen is original

--- a/tests/scripts/test_subprocess_denied.py
+++ b/tests/scripts/test_subprocess_denied.py
@@ -1,13 +1,19 @@
-"""A running function must not be able to spawn a process.
+"""A running function must not spawn a process, and the guard must not corrupt
+the host process that ran it.
 
 The runner allows ``asyncio`` (functions use it for concurrency), and asyncio is
 the one route to a subprocess the import allow list leaves reachable.
-``deny_subprocess_creation`` closes it around the user-code ``exec`` and, being
-scoped, restores process creation afterwards so the runner's own forkserver and
-an SDK host process keep working.
+``deny_subprocess_creation`` closes it around the user-code ``exec``. It is
+reentrant: overlapping local runs share one patch and restore only when the last
+finishes, so neither corrupts the other's view of ``subprocess``. It is a
+defense-in-depth layer - a function that defers a spawn to a thread outliving the
+run still reaches the real ``subprocess`` - which is why the runner that executes
+untrusted code denies subprocess permanently in a single-use child instead.
 """
 
 import subprocess
+import threading
+import time
 
 import pytest
 from notte_core.ast import SecureScriptRunner, SubprocessNotAllowed, deny_subprocess_creation
@@ -67,11 +73,43 @@ def test_unrestricted_concurrency_still_works() -> None:
     assert _run(_as_run(_TO_THREAD), restricted=False) == 4
 
 
-def test_the_guard_restores_afterwards() -> None:
-    # A scoped guard must leave the host process able to spawn again - the SDK
-    # runs a local function inside the caller's own interpreter.
+def test_guard_restores_the_host_afterwards() -> None:
     original = subprocess.Popen
     with deny_subprocess_creation():
         with pytest.raises(SubprocessNotAllowed):
             subprocess.Popen(["true"])
+    assert subprocess.Popen is original
+
+
+def test_nested_guards_hold_until_the_outermost_exits() -> None:
+    original = subprocess.Popen
+    with deny_subprocess_creation():
+        with deny_subprocess_creation():
+            assert subprocess.Popen is not original
+        # Inner exit must NOT restore while the outer guard is still active.
+        assert subprocess.Popen is not original
+    assert subprocess.Popen is original
+
+
+def test_overlapping_guards_across_threads_do_not_corrupt_the_host() -> None:
+    original = subprocess.Popen
+    errors: list[str] = []
+
+    def worker(hold: float) -> None:
+        try:
+            with deny_subprocess_creation():
+                time.sleep(hold)
+                # While any guard is active, the host must still be denied - a
+                # sibling's exit must not restore the real Popen underneath us.
+                assert subprocess.Popen is not original
+        except AssertionError as exc:  # noqa: PERF203
+            errors.append(str(exc))
+
+    threads = [threading.Thread(target=worker, args=(hold,)) for hold in (0.3, 0.1)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
     assert subprocess.Popen is original


### PR DESCRIPTION
## The hole

`SecureScriptRunner.run_script` runs a function in **unrestricted** mode by
default - a plain `exec` whose `__import__` refuses `os`, `subprocess`,
`socket`, `ctypes` and the rest, with a builtins allow list that withholds
`eval`/`exec`/`open`. `asyncio` is deliberately allowed, because functions use
`asyncio.to_thread` / `run_in_executor` for concurrency, and asyncio is the leak:

```python
run_script(restricted=False) on:
    import asyncio
    async def go():
        p = await asyncio.create_subprocess_shell("echo PWNED-$(id -u)", stdout=-1)
        ...
# -> 'PWNED-501'
```

Anyone running `SecureScriptRunner` on untrusted code in unrestricted mode is
exposed. In this SDK that is the `Function.run(local=True, restricted=False)`
path, which executes downloaded function code in the caller's own interpreter.
(`restricted=True`, the default, blocks the async form, so the default local run
is not exposed - but `restricted=False` is one argument away.)

## The fix

`deny_subprocess_creation()` wraps the user-code `exec` in both branches.
Blocking the two `create_subprocess_*` names is **not** enough - I verified the
bypass: they, the event loop's `subprocess_shell`/`subprocess_exec`, and the
low-level `loop._make_subprocess_transport` all funnel through
**`subprocess.Popen`** on Linux, so that is the choke point. Neutering it costs
nothing legitimate because `import subprocess` is already refused.

**Scoped, not a global import-time patch** - deliberately. A global patch breaks
two things: a runtime that spawns its own worker children through a forkserver
(the patch would deny that too), and a host process that must stay able to spawn
after a local run. The guard saves originals and restores on exit; a test
asserts the restore.

## Limits

Save-and-restore is not reentrant across threads sharing one process; the runner
executes one function per child, so that does not arise. This is a process-level
mitigation - a hostile guest still warrants an OS boundary (seccomp denying
`fork`/`execve`), which this does not replace.

## Tests

`tests/scripts/test_subprocess_denied.py`: the shell escape and the
`_make_subprocess_transport` bypass both raise; `asyncio.to_thread` still works;
`subprocess.Popen` is restored after the guarded block. Full `tests/scripts`
suite green apart from the pre-existing `test_run_script_with_agent` (absent
Gemini key, fails identically on `main`). `ruff` and `basedpyright` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790271582&installation_model_id=8247&pr_number=912&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F912&signature=e9d51a78cd41f583ea97f8e4618b349395d4b74491278c4fa0d6dcfcc75d34d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Script execution now blocks attempts to create subprocesses, including through asynchronous process APIs.
  * Subprocess restrictions remain enforced during nested and concurrent executions.
  * Existing process-spawning behavior is restored after restricted execution ends.

* **Bug Fixes**
  * Improved enforcement across supported execution paths.
  * Confirmed that non-process background tasks continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->