### PR TITLE
fix(sdk): extend captcha solve request timeout

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/page.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/page.py
@@ -26,6 +26,8 @@ from notte_sdk.types import (
 if TYPE_CHECKING:
     from notte_sdk.client import NotteClient
 
+CAPTCHA_SOLVE_REQUEST_TIMEOUT_SECONDS = 150
+
 
 @final
 class PageClient(BaseClient):
@@ -290,7 +292,7 @@ class PageClient(BaseClient):
         """
         endpoint = PageClient._page_execute_endpoint(session_id=session_id)
         is_captcha = isinstance(action, CaptchaSolveAction)
-        request_timeout = 100 if is_captcha else self.DEFAULT_REQUEST_TIMEOUT_SECONDS
+        request_timeout = CAPTCHA_SOLVE_REQUEST_TIMEOUT_SECONDS if is_captcha else self.DEFAULT_REQUEST_TIMEOUT_SECONDS
 
         for _ in range(3):
             try:

--- a/tests/sdk/test_page_execute_timeout.py
+++ b/tests/sdk/test_page_execute_timeout.py
@@ -1,0 +1,14 @@
+from unittest.mock import MagicMock
+
+from notte_core.actions import CaptchaSolveAction
+from notte_sdk.endpoints.page import CAPTCHA_SOLVE_REQUEST_TIMEOUT_SECONDS, PageClient
+
+
+def test_captcha_solve_uses_150_second_request_timeout() -> None:
+    client = PageClient.__new__(PageClient)
+    client.request = MagicMock(return_value=MagicMock())
+
+    client.execute("session-id", CaptchaSolveAction(captcha_type="recaptcha"))
+
+    assert CAPTCHA_SOLVE_REQUEST_TIMEOUT_SECONDS == 150
+    assert client.request.call_args.kwargs["timeout"] == CAPTCHA_SOLVE_REQUEST_TIMEOUT_SECONDS


### PR DESCRIPTION
## Summary

- raise the SDK HTTP timeout for captcha solve requests from 100s to 150s
- leave the default timeout for other page actions unchanged
- add focused coverage for the captcha request budget

Companion to nottelabs/monorepo#2345, where captcha polling is 120s, the worker request budget is 130s, and the gateway read budget is 140s.

## Test plan

- `PYTHONPATH=packages/notte-sdk/src:packages/notte-core/src pytest tests/sdk/test_page_execute_timeout.py -q`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790326495&installation_model_id=8247&pr_number=913&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F913&signature=db49e0adddbe0a99ab3b495c7a65d5ec23c840e19da5e026f02c69683b175496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CAPTCHA-solving requests now have up to 150 seconds to complete, improving reliability for longer-running challenges.
  * Other page execution requests retain their existing timeout behavior.

* **Tests**
  * Added coverage to verify the extended CAPTCHA request timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->