### PR TITLE
fix(sdk): enable proxies by default

### DIFF
--- a/docs/src/features/sessions/configuration.mdx
+++ b/docs/src/features/sessions/configuration.mdx
@@ -46,8 +46,8 @@ Customize your session with these options:
   Automatically detect and solve captchas (reCAPTCHA, hCaptcha, etc.)
 </ParamField>
 
-<ParamField path="proxies" type="boolean | list[ProxySettings]" default={false}>
-  Enable residential proxies. Set to `true` for default proxies or provide custom proxy configuration.
+<ParamField path="proxies" type="boolean | list[ProxySettings]" default={true}>
+  Residential proxies are enabled by default. Set to `false` to disable them or provide custom proxy configuration.
   See [Proxy Configuration](#proxies) for details.
 </ParamField>
 

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -832,7 +832,7 @@ class _SessionStartRequest(SdkRequest):
         Field(
             description="List of custom proxies to use for the session. If True, the default proxies will be used.",
         ),
-    ] = True
+    ] = False
     browser_type: Annotated[
         BrowserType, Field(description="The browser type to use. Can be chromium, chrome or firefox.")
     ] = DEFAULT_BROWSER_TYPE
@@ -1024,6 +1024,13 @@ class _SessionStartRequest(SdkRequest):
 
 class SessionStartRequest(_SessionStartRequest):
     """Public request for starting a remote Notte browser session."""
+
+    proxies: Annotated[
+        list[ProxySettings] | bool,
+        Field(
+            description="List of custom proxies to use for the session. If True, the default proxies will be used.",
+        ),
+    ] = True
 
     advanced_stealth: Annotated[
         bool,

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -813,7 +813,7 @@ class SessionStartRequest(SdkRequest):
         Field(
             description="List of custom proxies to use for the session. If True, the default proxies will be used.",
         ),
-    ] = False
+    ] = True
     browser_type: Annotated[
         BrowserType, Field(description="The browser type to use. Can be chromium, chrome or firefox.")
     ] = DEFAULT_BROWSER_TYPE

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -169,7 +169,7 @@ def test_start_session(mock_post: MagicMock, client: NotteClient, session_id: st
         "solve_captchas": True,
         "idle_timeout_minutes": DEFAULT_SESSION_IDLE_TIMEOUT_IN_MINUTES,
         "max_duration_minutes": DEFAULT_SESSION_MAX_DURATION_IN_MINUTES,
-        "proxies": False,
+        "proxies": True,
         "browser_type": "chromium",
         "viewport_width": 1920,
         "viewport_height": 1080,
@@ -419,6 +419,12 @@ def test_solve_captchas_defaults_to_enabled_but_can_be_disabled() -> None:
     request = SessionStartRequest()
     assert request.solve_captchas is True
     assert SessionStartRequest(solve_captchas=False).solve_captchas is False
+
+
+def test_proxies_default_to_enabled_but_can_be_disabled() -> None:
+    request = SessionStartRequest()
+    assert request.proxies is True
+    assert SessionStartRequest(proxies=False).proxies is False
 
 
 def test_managed_auth_ids_are_serialized_and_must_be_unique() -> None:

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -17,6 +17,7 @@ from notte_sdk.types import (
     AgentListRequest,
     ExecutionRequest,
     ExecutionRequestDict,
+    LocalSessionStartRequest,
     ObserveResponse,
     SessionListRequest,
     SessionResponse,
@@ -420,6 +421,7 @@ def test_proxies_default_to_enabled_but_can_be_disabled() -> None:
     request = SessionStartRequest()
     assert request.proxies is True
     assert SessionStartRequest(proxies=False).proxies is False
+    assert LocalSessionStartRequest().proxies is False
 
 
 def test_managed_auth_ids_are_serialized_and_must_be_unique() -> None:


### PR DESCRIPTION
## Summary
- enable residential proxies by default for SDK session starts
- document the new default
- cover opting out with `proxies=False`

## Context
The monorepo currently pins this branch commit directly. Landing it on `main` lets the monorepo return to tracking `notte/main` without changing runtime behavior.

## Validation
- existing focused SDK test added on the branch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790437064&installation_model_id=8247&pr_number=914&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F914&signature=ff2bf011c146b95f0230b965c4417703a9ef8d9709fe5a11a1ecebd5b9386e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now use residential proxies by default.
  * Proxy usage can still be disabled explicitly or customized with proxy settings.
  * Local sessions continue to run without proxies by default.
* **Documentation**
  * Updated session configuration guidance to reflect the new proxy defaults.
* **Tests**
  * Added coverage confirming proxy behavior for remote and local sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->