### PR TITLE
test: build the client explicitly in uploaded workflow fixtures

### DIFF
--- a/tests/integration/sdk/test_workflow_runs.py
+++ b/tests/integration/sdk/test_workflow_runs.py
@@ -30,10 +30,14 @@ def client():
 @pytest.fixture
 def sample_workflow_content():
     """Sample valid script content for testing."""
-    return '''def run(test_var: str = "default"):
+    return '''from notte_sdk import NotteClient
+
+
+def run(test_var: str = "default"):
     """Sample script that navigates to a URL and scrapes content."""
     url = f"https://httpbin.org/get?test={test_var}"
-    with notte.Session(open_viewer=False, perception_type="fast") as session:
+    client = NotteClient()
+    with client.Session(open_viewer=False, perception_type="fast") as session:
         session.execute({"type": "goto", "url": url})
         session.observe()
         result = session.scrape()

--- a/tests/integration/sdk/test_workflow_runs.py
+++ b/tests/integration/sdk/test_workflow_runs.py
@@ -30,10 +30,7 @@ def client():
 @pytest.fixture
 def sample_workflow_content():
     """Sample valid script content for testing."""
-    return '''import notte
-
-
-def run(test_var: str = "default"):
+    return '''def run(test_var: str = "default"):
     """Sample script that navigates to a URL and scrapes content."""
     url = f"https://httpbin.org/get?test={test_var}"
     with notte.Session(open_viewer=False, perception_type="fast") as session:

--- a/tests/integration/sdk/test_workflows.py
+++ b/tests/integration/sdk/test_workflows.py
@@ -339,11 +339,14 @@ def run():
         valid_content = """import json
 import datetime
 
+from notte_sdk import NotteClient
+
 def run():
     data = {"timestamp": datetime.datetime.now().isoformat()}
     json_data = json.dumps(data)
 
-    with notte.Session(open_viewer=False) as session:
+    client = NotteClient()
+    with client.Session(open_viewer=False) as session:
         session.execute({"type": "goto", "url": "https://httpbin.org/get"})
         result = session.scrape()
         return {"json_data": json_data, "scrape_result": result}

--- a/tests/integration/sdk/test_workflows.py
+++ b/tests/integration/sdk/test_workflows.py
@@ -317,7 +317,6 @@ def invalid_function():
     def test_invalid_workflow_forbidden_imports(self, client: NotteClient):
         """Test that workflows with forbidden imports are rejected."""
         invalid_content = """import os
-import notte
 
 def run():
     os.system("echo hello")  # This should be forbidden
@@ -339,7 +338,6 @@ def run():
         """Test that workflows with allowed imports are accepted."""
         valid_content = """import json
 import datetime
-import notte
 
 def run():
     data = {"timestamp": datetime.datetime.now().isoformat()}


### PR DESCRIPTION
Workflow code runs in a sandbox where `notte` is provided as a global, and the API now rejects `import notte` in uploaded code. That fails `test_valid_workflow_allowed_imports` on `main`:

```
Request to `functions/` failed with status code 400:
Uploaded function code is invalid: "Import of 'notte' is not allowed."
```

These fixtures now construct the client explicitly instead:

```python
from notte_sdk import NotteClient

def run():
    client = NotteClient()
    with client.Session(...) as session:
        ...
```

That is what the other fixtures in the same suite already do, and it does not depend on the injected global, so the workflow reads the same way a user would write it.

The `import os` fixture keeps its own import, since rejecting it is what that test asserts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workflow validation scenarios to use the current SDK client and session access pattern.
  * Refined sample workflow content and import-allowance checks for more accurate test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->