### PR TITLE
fix(docs): update notte browser usage pricing 

### DIFF
--- a/docs/src/intro/pricing.mdx
+++ b/docs/src/intro/pricing.mdx
@@ -22,7 +22,7 @@ Notte tracks your usage via dollar-based credits which can be acquired through a
     <tbody>
       <tr className="hover:bg-gray-50 dark:hover:bg-gray-700">
         <td className="border border-gray-300 dark:border-gray-600 px-11 py-3 font-medium">Browser Usage</td>
-        <td className="border border-gray-300 dark:border-gray-600 px-11 py-3">\$0.05 / hour</td>
+        <td className="border border-gray-300 dark:border-gray-600 px-11 py-3">\$0.00 / hour</td>
         <td className="border border-gray-300 dark:border-gray-600 px-11 py-3">Charged per minute, rounded up</td>
       </tr>
 
@@ -46,9 +46,9 @@ Notte tracks your usage via dollar-based credits which can be acquired through a
 An agent running for 1 minute with 10 steps using Chrome with US proxies enabled:
 
 * **LLM Usage (Gemini 2.0 Flash)**: 112k tokens ≈ **\$0.015**
-* **Browser Usage**: 1 minute at \$0.05/hour ≈ **\$0.001**
+* **Browser Usage**: 1 minute at \$0.00/hour ≈ **\$0.00**
 * **Proxy Usage**: 10MB Data Transfer at \$10/GB ≈ **\$0.10**
-* **Total: \~\$0.116**
+* **Total: \~\$0.115**
 
 > Gemini 2.0 Flash pricing: \$0.10/1M input / \$0.40/1M output tokens
 

--- a/docs/src/pricing.mdx
+++ b/docs/src/pricing.mdx
@@ -7,7 +7,7 @@ url: https://www.notte.cc/pricing
 
 <CardGroup cols={3}>
   <Card title="Browser Usage" icon="tv">
-    **$0.05 / hour**
+    **$0.00 / hour**
 
     Charged per minute, rounded up.
   </Card>


### PR DESCRIPTION
Browser usage is now $0/hour. Updates the two pricing pages:

- `docs/src/pricing.mdx` - Browser Usage card
- `docs/src/intro/pricing.mdx` - usage table row, and the worked example (browser line and total, now ~$0.115)

Proxy and LLM rates are unchanged. The cost-optimization snippets quote the function rate, not browser runtime, so they are untouched.

Draft until the rate is live.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790548303&installation_model_id=8247&pr_number=923&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F923&signature=e6b81f96042f757e3899e6991d4ff3090f549d05ee674e62659e852c516b1ca9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Browser Usage pricing to **$0.00 per hour**.
  * Revised the usage cost example to reflect the new rate and updated total estimate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->