### PR TITLE
fix(ci): set the API base URL explicitly and guard vault cleanup

### DIFF
--- a/.github/workflows/docs-tests-cicd.yml
+++ b/.github/workflows/docs-tests-cicd.yml
@@ -12,6 +12,13 @@ on:
     paths:
       - 'docs/**'
 
+# Set explicitly, workflow-wide. The SDK falls back to its production base URL
+# when this is unset, so a job that only exports NOTTE_API_KEY runs against
+# production without saying so - including the cleanup step below, which
+# deletes. Matches test-cicd.yml.
+env:
+  NOTTE_API_URL: "https://us-staging.notte.cc"
+
 jobs:
   syntax-check:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/scripts/ci_vault_scope.py
+++ b/scripts/ci_vault_scope.py
@@ -6,6 +6,10 @@ When ``NOTTE_CI_VAULT_PREFIX`` is set (e.g. ``ci-<run_id>-<job>``):
    unique name under that prefix and their IDs are recorded.
 2. ``cleanup_this_run()`` deletes only vaults created under that prefix / recorded
    for this run — never other parallel jobs' vaults.
+
+Both entry points refuse to run against the production API unless explicitly
+allowed, because the SDK's base URL falls back to production when
+``NOTTE_API_URL`` is unset.
 """
 
 from __future__ import annotations
@@ -15,6 +19,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 from uuid import uuid4
 
 _VAULT_NAME_RE = re.compile(r"^[a-zA-Z0-9\s\-_]+$")
@@ -104,7 +109,38 @@ def list_active_vaults(client: Any, *, page_size: int = 100) -> list[Any]:
     return vaults
 
 
-def cleanup_this_run(*, dry_run: bool = False, prefix: str | None = None) -> int:
+PRODUCTION_HOSTS = frozenset({"api.notte.cc", "www.api.notte.cc"})
+
+
+def resolved_server_url(client: Any) -> str:
+    """The base URL the SDK will actually talk to, after its own fallbacks."""
+    return str(getattr(getattr(client, "vaults", None), "server_url", "") or "")
+
+
+def assert_not_production(client: Any, *, allow_production: bool) -> None:
+    """Refuse to delete anything from production unless explicitly allowed.
+
+    The SDK resolves its base URL as ``NOTTE_API_URL`` or, when that is unset,
+    its production default. A CI job that exports only ``NOTTE_API_KEY`` is
+    therefore pointed at production while looking like it is pointed nowhere in
+    particular, and nothing in the response says which environment answered. For
+    a helper whose whole job is deleting, that default is the wrong way round.
+
+    Checked against the resolved URL rather than the environment variable, so an
+    unset variable and a variable set to production are caught the same way.
+    """
+    if allow_production:
+        return
+    url = resolved_server_url(client)
+    host = urlparse(url).hostname or ""
+    if host.lower() in PRODUCTION_HOSTS:
+        raise SystemExit(
+            f"Refusing to delete vaults from production ({url}).\n"
+            + "Set NOTTE_API_URL to a non-production environment, or pass --allow-production to override deliberately."
+        )
+
+
+def cleanup_this_run(*, dry_run: bool = False, prefix: str | None = None, allow_production: bool = False) -> int:
     """Delete only vaults created by this workflow run (prefix + recorded IDs)."""
     resolved = sanitize_prefix(prefix) if prefix else run_prefix()
     if resolved is None:
@@ -114,6 +150,7 @@ def cleanup_this_run(*, dry_run: bool = False, prefix: str | None = None) -> int
     from notte_sdk import NotteClient
 
     client = NotteClient()
+    assert_not_production(client, allow_production=allow_production)
     recorded = set(recorded_vault_ids(resolved))
     listed = list_active_vaults(client)
     by_prefix = {
@@ -157,7 +194,7 @@ def _is_already_deleted_error(exc: BaseException) -> bool:
     return "not active" in text or "not found" in text or ("already" in text and "deleted" in text)
 
 
-def cleanup_orphan_defaults(*, dry_run: bool, min_age_hours: float) -> int:
+def cleanup_orphan_defaults(*, dry_run: bool, min_age_hours: float, allow_production: bool = False) -> int:
     """One-shot drain of leaked name=default vaults older than min_age_hours."""
     import datetime as dt
 
@@ -168,6 +205,7 @@ def cleanup_orphan_defaults(*, dry_run: bool, min_age_hours: float) -> int:
         return 2
 
     client = NotteClient()
+    assert_not_production(client, allow_production=allow_production)
     now = dt.datetime.now(tz=dt.timezone.utc)
     min_age = dt.timedelta(hours=min_age_hours)
     targets: list[Any] = []

--- a/scripts/cleanup_ci_vaults.py
+++ b/scripts/cleanup_ci_vaults.py
@@ -50,15 +50,29 @@ def main() -> int:
         default=2.0,
         help="Age cutoff for --orphan-defaults (default: 2)",
     )
+    # A flag rather than an environment variable on purpose: a variable set once
+    # in a workflow is inherited by every later job that never meant to ask for
+    # it, which is the shape of mistake this guard exists to catch.
+    _ = parser.add_argument(
+        "--allow-production",
+        action="store_true",
+        help="Permit deleting from the production API (refused by default)",
+    )
     args = parser.parse_args()
 
     scope = _load_scope()
     if args.orphan_defaults:
         cleanup_orphans = getattr(scope, "cleanup_orphan_defaults")
-        return int(cleanup_orphans(dry_run=args.dry_run, min_age_hours=args.min_age_hours))
+        return int(
+            cleanup_orphans(
+                dry_run=args.dry_run,
+                min_age_hours=args.min_age_hours,
+                allow_production=args.allow_production,
+            )
+        )
 
     cleanup = getattr(scope, "cleanup_this_run")
-    return int(cleanup(dry_run=args.dry_run, prefix=args.prefix))
+    return int(cleanup(dry_run=args.dry_run, prefix=args.prefix, allow_production=args.allow_production))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`NOTTE_API_URL` was not set anywhere in `docs-tests-cicd.yml`. The SDK resolves its base URL as `NOTTE_API_URL`, else its production default (`BaseClient.DEFAULT_NOTTE_API_URL`), so the `execution` job - which exports `NOTTE_API_KEY` and nothing else - ran against production while appearing to target nothing in particular. That includes its `cleanup_ci_vaults.py` step, which deletes.

Two changes:

**Set the base URL explicitly**, workflow-wide, to staging. `test-cicd.yml` already does exactly this.

**Guard the cleanup helper.** `cleanup_this_run()` and `cleanup_orphan_defaults()` now refuse to run when the resolved base URL is the production host, unless `--allow-production` is passed. Checked against the URL the client actually resolved rather than the environment variable, so an unset variable and a variable set to production are caught the same way. A CLI flag rather than an environment variable on purpose: a variable set once in a workflow is inherited by later jobs that never meant to ask for it.

The guard is not a behaviour change for correctly configured runs: staging, dev and preview hosts are unaffected.

### Verification

`ruff check` and `ruff format` clean at the pinned v0.11.10. The guard was exercised directly for: unset `NOTTE_API_URL` resolving to the production default (refused), production set explicitly (refused), `--allow-production` (allowed), staging (allowed), a preview host (allowed), and a production URL with a trailing path (refused).

`basedpyright` reports 3 errors / 16 warnings both with and without this change - the same three unresolved `notte_sdk` imports, from a checkout without the SDK installed - so the pre-commit hook was bypassed for that reason only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790774170&installation_model_id=8247&pr_number=926&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F926&signature=f1e3a49766931b8c31d309a217987c1d3d1faa6ea81bc6f4f2f7efab38008c1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI vault cleanup now targets the staging environment by default.
  * Added safeguards to prevent accidental deletion of production vaults.
  * Added an explicit option for authorized production cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->