### PR TITLE
fix(browser): bound stalled navigation screenshots

### DIFF
--- a/packages/notte-browser/src/notte_browser/playwright_async_api.py
+++ b/packages/notte-browser/src/notte_browser/playwright_async_api.py
@@ -4,7 +4,6 @@ from notte_core.common.config import BrowserBackend, config
 
 if TYPE_CHECKING:
     from patchright.async_api import Frame as PatchrightFrame
-    from patchright.async_api import Request as Request
 from notte_core.common.logging import logger
 
 match config.browser_backend:

--- a/packages/notte-browser/src/notte_browser/playwright_async_api.py
+++ b/packages/notte-browser/src/notte_browser/playwright_async_api.py
@@ -4,6 +4,7 @@ from notte_core.common.config import BrowserBackend, config
 
 if TYPE_CHECKING:
     from patchright.async_api import Frame as PatchrightFrame
+    from patchright.async_api import Request as Request
 from notte_core.common.logging import logger
 
 match config.browser_backend:

--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -114,6 +114,10 @@ enable_nest_asyncio()
 
 # TODO: ACT callback
 class NotteSession(AsyncResource, SyncResource):
+    # Screenshots appended to the trajectory are best-effort and must not keep a
+    # completed action request open when Chromium's compositor stops responding.
+    POST_ACTION_SCREENSHOT_TIMEOUT_SECONDS: ClassVar[float] = 5.0
+
     observe_max_retry_after_snapshot_update: ClassVar[int] = 2
     nb_seconds_between_snapshots_check: ClassVar[int] = 10
 
@@ -337,6 +341,20 @@ class NotteSession(AsyncResource, SyncResource):
         screenshot = Screenshot(raw=screenshot_bytes, bboxes=[], last_action_id=None)
         await self.trajectory.append(screenshot)
         return screenshot
+
+    async def _capture_post_action_screenshot(self) -> None:
+        try:
+            _ = await asyncio.wait_for(
+                self.ascreenshot(),
+                timeout=self.POST_ACTION_SCREENSHOT_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Post-action screenshot timed out after "
+                + f"{self.POST_ACTION_SCREENSHOT_TIMEOUT_SECONDS:.1f}s; returning the action result without it"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to capture post-action screenshot: {e}")
 
     def screenshot(
         self,
@@ -895,10 +913,7 @@ class NotteSession(AsyncResource, SyncResource):
 
         # add screenshot to trajectory (after the execution)
         if self._window is not None:
-            try:
-                _ = await self.ascreenshot()
-            except Exception as e:
-                logger.warning(f"Failed to capture post-action screenshot: {e}")
+            await self._capture_post_action_screenshot()
 
         _raise_on_failure = raise_on_failure if raise_on_failure is not None else self.default_raise_on_failure
         # Gate on "did the action fail", not "did something throw": after the synthesis

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -611,7 +611,16 @@ class BrowserWindow(BaseModel):
                     logger.info(
                         f"Goto for {url=} succeeded with HTTP {self.goto_response.status}: {self.goto_response.status_text}"
                     )
-            except PlaywrightTimeoutError:
+            except PlaywrightTimeoutError as e:
+                # Chromium updates page.url as soon as navigation starts, before the
+                # main resource receives a response. Treating that URL change as a
+                # successful navigation leaves the page in a pending-navigation state;
+                # Page.captureScreenshot can then block indefinitely waiting for a
+                # rendered frame. A response proves that navigation reached the server,
+                # so preserve the existing best-effort load-state handling only then.
+                if self.goto_response is None:
+                    logger.warning(f"Goto for {url=} timed out before receiving an HTTP response")
+                    raise PageLoadingError(url=url or self.page.url) from e
                 await self.long_wait()
             except Exception as e:
                 if self.goto_response is not None:

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -212,7 +212,7 @@ class BrowserWindow(BaseModel):
 
         self.apply_page_callbacks()
 
-    def _record_navigation_response(self, response: Response) -> None:
+    def _is_final_main_document_response(self, response: Response) -> bool:
         request = response.request
         is_redirect = response.status in {
             HTTPStatus.MOVED_PERMANENTLY,
@@ -221,7 +221,10 @@ class BrowserWindow(BaseModel):
             HTTPStatus.TEMPORARY_REDIRECT,
             HTTPStatus.PERMANENT_REDIRECT,
         }
-        if request.is_navigation_request() and request.frame == self.page.main_frame and not is_redirect:
+        return request.is_navigation_request() and request.frame == self.page.main_frame and not is_redirect
+
+    def _record_navigation_response(self, response: Response) -> None:
+        if self._is_final_main_document_response(response):
             self.goto_response = response
 
     def apply_page_callbacks(self):
@@ -599,21 +602,32 @@ class BrowserWindow(BaseModel):
             return self.page.url == "about:blank" and not url == "about:blank"
 
         while True:
+            attempt_response: Response | None = None
+
+            def on_response(response: Response) -> None:
+                nonlocal attempt_response
+                if self._is_final_main_document_response(response):
+                    attempt_response = response
+
             self.goto_response = None
+            self.page.on("response", on_response)
             tries -= 1
 
             try:
                 match operation:
                     case None:
                         assert url is not None, "URL is required for goto"
-                        _ = await self.page.goto(url, timeout=config.timeout_goto_ms)
+                        response = await self.page.goto(url, timeout=config.timeout_goto_ms)
                     case "back":
-                        _ = await self.page.go_back(timeout=config.timeout_goto_ms)
+                        response = await self.page.go_back(timeout=config.timeout_goto_ms)
                     case "forward":
-                        _ = await self.page.go_forward(timeout=config.timeout_goto_ms)
-                if self.goto_response is not None:
+                        response = await self.page.go_forward(timeout=config.timeout_goto_ms)
+                if response is not None and self._is_final_main_document_response(response):
+                    attempt_response = response
+                    self.goto_response = response
+                if attempt_response is not None:
                     logger.info(
-                        f"Goto for {url=} succeeded with HTTP {self.goto_response.status}: {self.goto_response.status_text}"
+                        f"Goto for {url=} succeeded with HTTP {attempt_response.status}: {attempt_response.status_text}"
                     )
             except PlaywrightTimeoutError as e:
                 # Chromium updates page.url as soon as navigation starts, before the
@@ -622,23 +636,25 @@ class BrowserWindow(BaseModel):
                 # Page.captureScreenshot can then block indefinitely waiting for a
                 # rendered frame. A response proves that navigation reached the server,
                 # so preserve the existing best-effort load-state handling only then.
-                if self.goto_response is None:
+                if attempt_response is None:
                     logger.warning(f"Goto for {url=} timed out before receiving an HTTP response")
                     raise PageLoadingError(url=url or self.page.url) from e
                 await self.long_wait()
             except Exception as e:
-                if self.goto_response is not None:
-                    if self.goto_response.status == HTTPStatus.PROXY_AUTHENTICATION_REQUIRED:
+                if attempt_response is not None:
+                    if attempt_response.status == HTTPStatus.PROXY_AUTHENTICATION_REQUIRED:
                         raise InvalidProxyError(url=url or self.page.url)
 
                     # retry if it seems like it loaded correctly?
-                    if self.goto_response.status == HTTPStatus.OK and tries > 0:
+                    if attempt_response.status == HTTPStatus.OK and tries > 0:
                         continue
 
                     logger.error(
-                        f"Goto for {url=} failed with HTTP {self.goto_response.status}: {self.goto_response.status_text}, {traceback.format_exc()}"
+                        f"Goto for {url=} failed with HTTP {attempt_response.status}: {attempt_response.status_text}, {traceback.format_exc()}"
                     )
                 raise PageLoadingError(url=url or self.page.url) from e
+            finally:
+                self.page.remove_listener("response", on_response)
 
             # extra wait to make sure that css animations can start
             # to make extra element visible

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -7,7 +7,7 @@ import traceback
 from collections.abc import Awaitable
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, Self
+from typing import Any, Callable, ClassVar, Literal, Self
 
 import httpx
 from notte_core.browser.dom_tree import A11yNode, A11yTree, DomNode
@@ -47,9 +47,6 @@ from notte_browser.errors import (
     UnexpectedBrowserError,
 )
 from notte_browser.playwright_async_api import CDPSession, Locator, Page, Response
-
-if TYPE_CHECKING:
-    from notte_browser.playwright_async_api import Request
 
 
 class BrowserWindowOptions(BaseModel):
@@ -215,10 +212,8 @@ class BrowserWindow(BaseModel):
 
         self.apply_page_callbacks()
 
-    def _is_main_frame_navigation_request(self, request: "Request") -> bool:
-        return request.is_navigation_request() and request.frame == self.page.main_frame
-
     def _is_final_main_document_response(self, response: Response) -> bool:
+        request = response.request
         is_redirect = response.status in {
             HTTPStatus.MOVED_PERMANENTLY,
             HTTPStatus.FOUND,
@@ -226,14 +221,7 @@ class BrowserWindow(BaseModel):
             HTTPStatus.TEMPORARY_REDIRECT,
             HTTPStatus.PERMANENT_REDIRECT,
         }
-        return self._is_main_frame_navigation_request(response.request) and not is_redirect
-
-    @staticmethod
-    def _response_belongs_to_request(response: Response, expected_request: "Request") -> bool:
-        request = response.request
-        while request.redirected_from is not None:
-            request = request.redirected_from
-        return request == expected_request
+        return request.is_navigation_request() and request.frame == self.page.main_frame and not is_redirect
 
     def _record_navigation_response(self, response: Response) -> None:
         if self._is_final_main_document_response(response):
@@ -614,82 +602,53 @@ class BrowserWindow(BaseModel):
             return self.page.url == "about:blank" and not url == "about:blank"
 
         while True:
-            attempt_request: "Request | None" = None
-            attempt_response: Response | None = None
-
-            def on_request(request: "Request") -> None:
-                nonlocal attempt_request
-                if attempt_request is not None or not self._is_main_frame_navigation_request(request):
-                    return
-                if operation is None:
-                    assert url is not None
-                    requested_url = httpx.URL(url).copy_with(fragment=None)
-                    actual_url = httpx.URL(request.url).copy_with(fragment=None)
-                    if actual_url != requested_url:
-                        return
-                attempt_request = request
-
-            def on_response(response: Response) -> None:
-                nonlocal attempt_response
-                if (
-                    attempt_request is not None
-                    and self._is_final_main_document_response(response)
-                    and self._response_belongs_to_request(response, attempt_request)
-                ):
-                    attempt_response = response
-
             self.goto_response = None
-            self.page.on("request", on_request)
-            self.page.on("response", on_response)
+            response: Response | None = None
             tries -= 1
 
             try:
+                # Waiting for commit makes Playwright return the response for this
+                # exact navigation while still failing if the main document never
+                # receives response headers. Later load states remain best-effort.
                 match operation:
                     case None:
                         assert url is not None, "URL is required for goto"
-                        response = await self.page.goto(url, timeout=config.timeout_goto_ms)
+                        response = await self.page.goto(
+                            url,
+                            timeout=config.timeout_goto_ms,
+                            wait_until="commit",
+                        )
                     case "back":
-                        response = await self.page.go_back(timeout=config.timeout_goto_ms)
+                        response = await self.page.go_back(
+                            timeout=config.timeout_goto_ms,
+                            wait_until="commit",
+                        )
                     case "forward":
-                        response = await self.page.go_forward(timeout=config.timeout_goto_ms)
-                if response is not None and self._is_final_main_document_response(response):
-                    attempt_response = response
+                        response = await self.page.go_forward(
+                            timeout=config.timeout_goto_ms,
+                            wait_until="commit",
+                        )
+                if response is not None:
                     self.goto_response = response
-                if attempt_response is not None:
-                    logger.info(
-                        f"Goto for {url=} succeeded with HTTP {attempt_response.status}: {attempt_response.status_text}"
-                    )
-            except PlaywrightTimeoutError as e:
-                # Chromium updates page.url as soon as navigation starts, before the
-                # main resource receives a response. Treating that URL change as a
-                # successful navigation leaves the page in a pending-navigation state;
-                # Page.captureScreenshot can then block indefinitely waiting for a
-                # rendered frame. A response proves that navigation reached the server,
-                # so preserve the existing best-effort load-state handling only then.
-                if attempt_response is None:
-                    logger.warning(f"Goto for {url=} timed out before receiving an HTTP response")
-                    raise PageLoadingError(url=url or self.page.url) from e
-                await self.long_wait()
-            except Exception as e:
-                if attempt_response is not None:
-                    if attempt_response.status == HTTPStatus.PROXY_AUTHENTICATION_REQUIRED:
+                    if response.status == HTTPStatus.PROXY_AUTHENTICATION_REQUIRED:
                         raise InvalidProxyError(url=url or self.page.url)
-
-                    # retry if it seems like it loaded correctly?
-                    if attempt_response.status == HTTPStatus.OK and tries > 0:
+                    logger.info(f"Goto for {url=} committed with HTTP {response.status}: {response.status_text}")
+                await self.long_wait()
+            except PlaywrightTimeoutError as e:
+                logger.warning(f"Goto for {url=} timed out before the main document committed")
+                raise PageLoadingError(url=url or self.page.url) from e
+            except InvalidProxyError:
+                raise
+            except Exception as e:
+                if response is not None:
+                    # Preserve the existing retry behavior for failures that occur
+                    # after a successful main-document response.
+                    if response.status == HTTPStatus.OK and tries > 0:
                         continue
-
                     logger.error(
-                        f"Goto for {url=} failed with HTTP {attempt_response.status}: {attempt_response.status_text}, {traceback.format_exc()}"
+                        f"Goto for {url=} failed with HTTP {response.status}: {response.status_text}, {traceback.format_exc()}"
                     )
                 raise PageLoadingError(url=url or self.page.url) from e
-            finally:
-                self.page.remove_listener("request", on_request)
-                self.page.remove_listener("response", on_response)
-
-            # extra wait to make sure that css animations can start
-            # to make extra element visible
-            await self.short_wait()
 
             if not is_default_page() or tries < 0:
                 break

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -7,7 +7,7 @@ import traceback
 from collections.abc import Awaitable
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Literal, Self
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, Self
 
 import httpx
 from notte_core.browser.dom_tree import A11yNode, A11yTree, DomNode
@@ -47,6 +47,9 @@ from notte_browser.errors import (
     UnexpectedBrowserError,
 )
 from notte_browser.playwright_async_api import CDPSession, Locator, Page, Response
+
+if TYPE_CHECKING:
+    from notte_browser.playwright_async_api import Request
 
 
 class BrowserWindowOptions(BaseModel):
@@ -212,8 +215,10 @@ class BrowserWindow(BaseModel):
 
         self.apply_page_callbacks()
 
+    def _is_main_frame_navigation_request(self, request: "Request") -> bool:
+        return request.is_navigation_request() and request.frame == self.page.main_frame
+
     def _is_final_main_document_response(self, response: Response) -> bool:
-        request = response.request
         is_redirect = response.status in {
             HTTPStatus.MOVED_PERMANENTLY,
             HTTPStatus.FOUND,
@@ -221,7 +226,14 @@ class BrowserWindow(BaseModel):
             HTTPStatus.TEMPORARY_REDIRECT,
             HTTPStatus.PERMANENT_REDIRECT,
         }
-        return request.is_navigation_request() and request.frame == self.page.main_frame and not is_redirect
+        return self._is_main_frame_navigation_request(response.request) and not is_redirect
+
+    @staticmethod
+    def _response_belongs_to_request(response: Response, expected_request: "Request") -> bool:
+        request = response.request
+        while request.redirected_from is not None:
+            request = request.redirected_from
+        return request == expected_request
 
     def _record_navigation_response(self, response: Response) -> None:
         if self._is_final_main_document_response(response):
@@ -602,14 +614,32 @@ class BrowserWindow(BaseModel):
             return self.page.url == "about:blank" and not url == "about:blank"
 
         while True:
+            attempt_request: "Request | None" = None
             attempt_response: Response | None = None
+
+            def on_request(request: "Request") -> None:
+                nonlocal attempt_request
+                if attempt_request is not None or not self._is_main_frame_navigation_request(request):
+                    return
+                if operation is None:
+                    assert url is not None
+                    requested_url = httpx.URL(url).copy_with(fragment=None)
+                    actual_url = httpx.URL(request.url).copy_with(fragment=None)
+                    if actual_url != requested_url:
+                        return
+                attempt_request = request
 
             def on_response(response: Response) -> None:
                 nonlocal attempt_response
-                if self._is_final_main_document_response(response):
+                if (
+                    attempt_request is not None
+                    and self._is_final_main_document_response(response)
+                    and self._response_belongs_to_request(response, attempt_request)
+                ):
                     attempt_response = response
 
             self.goto_response = None
+            self.page.on("request", on_request)
             self.page.on("response", on_response)
             tries -= 1
 
@@ -654,6 +684,7 @@ class BrowserWindow(BaseModel):
                     )
                 raise PageLoadingError(url=url or self.page.url) from e
             finally:
+                self.page.remove_listener("request", on_request)
                 self.page.remove_listener("response", on_response)
 
             # extra wait to make sure that css animations can start

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -239,7 +239,7 @@ class BrowserWindow(BaseModel):
             and len(self.resource.page.context.pages) > 0
         ):
             # reset to the last created page
-            self.resource.page = self.resource.page.context.pages[-1]
+            self.page = self.resource.page.context.pages[-1]
         return self.resource.page
 
     @property

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -205,15 +205,24 @@ class BrowserWindow(BaseModel):
     def model_post_init(self, __context: Any) -> None:
         self.resource.page.set_default_timeout(config.timeout_default_ms)
 
-        # Response callbacks to set self.goto_response for all navigation requests
-        # used for determining if the page is a raw file and making the download file action available
-        def on_response(response: Response):
-            if response.request.is_navigation_request():
-                self.goto_response = response
-
-        self.page_callbacks["response"] = on_response  # pyright: ignore [reportArgumentType]
+        # Keep the final main-document response for navigation error handling and
+        # raw-file detection. Iframe, subresource, and intermediate redirect
+        # responses do not prove that the requested document reached the browser.
+        self.page_callbacks["response"] = self._record_navigation_response  # pyright: ignore [reportArgumentType]
 
         self.apply_page_callbacks()
+
+    def _record_navigation_response(self, response: Response) -> None:
+        request = response.request
+        is_redirect = response.status in {
+            HTTPStatus.MOVED_PERMANENTLY,
+            HTTPStatus.FOUND,
+            HTTPStatus.SEE_OTHER,
+            HTTPStatus.TEMPORARY_REDIRECT,
+            HTTPStatus.PERMANENT_REDIRECT,
+        }
+        if request.is_navigation_request() and request.frame == self.page.main_frame and not is_redirect:
+            self.goto_response = response
 
     def apply_page_callbacks(self):
         for key, callback in self.page_callbacks.items():
@@ -589,13 +598,8 @@ class BrowserWindow(BaseModel):
         def is_default_page():
             return self.page.url == "about:blank" and not url == "about:blank"
 
-        def on_response(resp: Response) -> None:
-            """Store the response so its available for exception handling."""
-            self.goto_response = resp
-
         while True:
             self.goto_response = None
-            self.page.once("response", on_response)
             tries -= 1
 
             try:

--- a/tests/browser/test_navigation_timeouts.py
+++ b/tests/browser/test_navigation_timeouts.py
@@ -23,6 +23,8 @@ def make_response(page: MagicMock, *, status: int = 200) -> MagicMock:
     response = MagicMock()
     response.status = status
     response.status_text = "OK"
+    response.request.url = page.url
+    response.request.redirected_from = None
     response.request.is_navigation_request.return_value = True
     response.request.frame = page.main_frame
     return response
@@ -85,15 +87,14 @@ async def test_goto_timeout_with_response_keeps_best_effort_load_wait() -> None:
     page.url = "https://example.com"
     page.is_closed.return_value = False
     response = make_response(page)
-    response_callback: Callable[[MagicMock], None] | None = None
+    callbacks: dict[str, Callable[[MagicMock], None]] = {}
 
     def register_response_callback(_event: str, callback: Callable[[MagicMock], None]) -> None:
-        nonlocal response_callback
-        response_callback = callback
+        callbacks[_event] = callback
 
     def capture_response(_url: str, **_kwargs: object) -> None:
-        assert callable(response_callback)
-        response_callback(response)
+        callbacks["request"](response.request)
+        callbacks["response"](response)
         raise PlaywrightTimeoutError("load event timed out")
 
     page.on.side_effect = register_response_callback
@@ -108,7 +109,7 @@ async def test_goto_timeout_with_response_keeps_best_effort_load_wait() -> None:
 
     long_wait.assert_awaited_once()
     short_wait.assert_awaited_once()
-    page.remove_listener.assert_called_once_with("response", response_callback)
+    assert page.remove_listener.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -116,20 +117,39 @@ async def test_late_response_from_previous_navigation_does_not_affect_next_timeo
     page = MagicMock()
     page.url = "https://example.com"
     page.is_closed.return_value = False
-    page.goto = AsyncMock(side_effect=PlaywrightTimeoutError("navigation timed out"))
+    callbacks: dict[str, Callable[[MagicMock], None]] = {}
+    page.on.side_effect = lambda event, callback: callbacks.__setitem__(event, callback)
+    call_count = 0
+
+    late_response = make_response(page)
+    late_response.request.url = "https://first.example.com"
+    second_request = MagicMock()
+    second_request.url = "https://second.example.com"
+    second_request.is_navigation_request.return_value = True
+    second_request.frame = page.main_frame
+    second_request.redirected_from = None
+
+    def timeout_with_late_response(_url: str, **_kwargs: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            callbacks["request"](second_request)
+            callbacks["response"](late_response)
+        raise PlaywrightTimeoutError("navigation timed out")
+
+    page.goto = AsyncMock(side_effect=timeout_with_late_response)
     window = make_window(page)
 
     with pytest.raises(PageLoadingError):
         await window.goto_and_wait("https://first.example.com")
 
-    late_response = make_response(page)
     window._record_navigation_response(late_response)
     assert window.goto_response is late_response
 
     with pytest.raises(PageLoadingError):
         await window.goto_and_wait("https://second.example.com")
 
-    assert page.remove_listener.call_count == 2
+    assert page.remove_listener.call_count == 4
 
 
 @pytest.mark.asyncio
@@ -148,13 +168,15 @@ async def test_replacement_page_receives_persistent_and_attempt_response_callbac
     active_page.is_closed.return_value = True
 
     response = make_response(replacement_page)
-    response_callbacks: list[Callable[[MagicMock], None]] = []
+    callbacks: dict[str, list[Callable[[MagicMock], None]]] = {"request": [], "response": []}
 
-    def register_response_callback(_event: str, callback: Callable[[MagicMock], None]) -> None:
-        response_callbacks.append(callback)
+    def register_response_callback(event: str, callback: Callable[[MagicMock], None]) -> None:
+        callbacks[event].append(callback)
 
     def capture_response(_url: str, **_kwargs: object) -> None:
-        for callback in response_callbacks:
+        for callback in callbacks["request"]:
+            callback(response.request)
+        for callback in callbacks["response"]:
             callback(response)
         raise PlaywrightTimeoutError("load event timed out")
 
@@ -168,6 +190,7 @@ async def test_replacement_page_receives_persistent_and_attempt_response_callbac
         await window.goto_and_wait("https://replacement.example.com")
 
     assert resource.page is replacement_page
-    assert len(response_callbacks) == 2
+    assert len(callbacks["request"]) == 1
+    assert len(callbacks["response"]) == 2
     assert window.goto_response is response
     long_wait.assert_awaited_once()

--- a/tests/browser/test_navigation_timeouts.py
+++ b/tests/browser/test_navigation_timeouts.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -82,34 +81,20 @@ async def test_goto_timeout_without_response_is_not_reported_as_success() -> Non
 
 
 @pytest.mark.asyncio
-async def test_goto_timeout_with_response_keeps_best_effort_load_wait() -> None:
+async def test_committed_navigation_keeps_best_effort_load_wait() -> None:
     page = MagicMock()
     page.url = "https://example.com"
     page.is_closed.return_value = False
     response = make_response(page)
-    callbacks: dict[str, Callable[[MagicMock], None]] = {}
-
-    def register_response_callback(_event: str, callback: Callable[[MagicMock], None]) -> None:
-        callbacks[_event] = callback
-
-    def capture_response(_url: str, **_kwargs: object) -> None:
-        callbacks["request"](response.request)
-        callbacks["response"](response)
-        raise PlaywrightTimeoutError("load event timed out")
-
-    page.on.side_effect = register_response_callback
-    page.goto = AsyncMock(side_effect=capture_response)
+    page.goto = AsyncMock(return_value=response)
     window = make_window(page)
 
-    with (
-        patch.object(BrowserWindow, "long_wait", new_callable=AsyncMock) as long_wait,
-        patch.object(BrowserWindow, "short_wait", new_callable=AsyncMock) as short_wait,
-    ):
+    with patch.object(BrowserWindow, "long_wait", new_callable=AsyncMock) as long_wait:
         await window.goto_and_wait("https://example.com")
 
+    page.goto.assert_awaited_once_with("https://example.com", timeout=10000, wait_until="commit")
     long_wait.assert_awaited_once()
-    short_wait.assert_awaited_once()
-    assert page.remove_listener.call_count == 2
+    assert window.goto_response is response
 
 
 @pytest.mark.asyncio
@@ -117,24 +102,16 @@ async def test_late_response_from_previous_navigation_does_not_affect_next_timeo
     page = MagicMock()
     page.url = "https://example.com"
     page.is_closed.return_value = False
-    callbacks: dict[str, Callable[[MagicMock], None]] = {}
-    page.on.side_effect = lambda event, callback: callbacks.__setitem__(event, callback)
     call_count = 0
 
     late_response = make_response(page)
     late_response.request.url = "https://first.example.com"
-    second_request = MagicMock()
-    second_request.url = "https://second.example.com"
-    second_request.is_navigation_request.return_value = True
-    second_request.frame = page.main_frame
-    second_request.redirected_from = None
 
     def timeout_with_late_response(_url: str, **_kwargs: object) -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 2:
-            callbacks["request"](second_request)
-            callbacks["response"](late_response)
+            window._record_navigation_response(late_response)
         raise PlaywrightTimeoutError("navigation timed out")
 
     page.goto = AsyncMock(side_effect=timeout_with_late_response)
@@ -148,8 +125,6 @@ async def test_late_response_from_previous_navigation_does_not_affect_next_timeo
 
     with pytest.raises(PageLoadingError):
         await window.goto_and_wait("https://second.example.com")
-
-    assert page.remove_listener.call_count == 4
 
 
 @pytest.mark.asyncio
@@ -168,29 +143,12 @@ async def test_replacement_page_receives_persistent_and_attempt_response_callbac
     active_page.is_closed.return_value = True
 
     response = make_response(replacement_page)
-    callbacks: dict[str, list[Callable[[MagicMock], None]]] = {"request": [], "response": []}
+    replacement_page.goto = AsyncMock(return_value=response)
 
-    def register_response_callback(event: str, callback: Callable[[MagicMock], None]) -> None:
-        callbacks[event].append(callback)
-
-    def capture_response(_url: str, **_kwargs: object) -> None:
-        for callback in callbacks["request"]:
-            callback(response.request)
-        for callback in callbacks["response"]:
-            callback(response)
-        raise PlaywrightTimeoutError("load event timed out")
-
-    replacement_page.on.side_effect = register_response_callback
-    replacement_page.goto = AsyncMock(side_effect=capture_response)
-
-    with (
-        patch.object(BrowserWindow, "long_wait", new_callable=AsyncMock) as long_wait,
-        patch.object(BrowserWindow, "short_wait", new_callable=AsyncMock),
-    ):
+    with patch.object(BrowserWindow, "long_wait", new_callable=AsyncMock) as long_wait:
         await window.goto_and_wait("https://replacement.example.com")
 
     assert resource.page is replacement_page
-    assert len(callbacks["request"]) == 1
-    assert len(callbacks["response"]) == 2
+    replacement_page.on.assert_any_call("response", window._record_navigation_response)
     assert window.goto_response is response
     long_wait.assert_awaited_once()

--- a/tests/browser/test_navigation_timeouts.py
+++ b/tests/browser/test_navigation_timeouts.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,6 +17,15 @@ def make_window(page: MagicMock) -> BrowserWindow:
         page_callbacks={},
         goto_response=None,
     )
+
+
+def make_response(page: MagicMock, *, status: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.status_text = "OK"
+    response.request.is_navigation_request.return_value = True
+    response.request.frame = page.main_frame
+    return response
 
 
 @pytest.mark.parametrize(
@@ -42,10 +52,7 @@ def test_only_final_main_document_response_is_recorded(is_navigation: bool, is_m
 
 def test_final_main_document_response_is_recorded() -> None:
     page = MagicMock()
-    response = MagicMock()
-    response.status = 200
-    response.request.is_navigation_request.return_value = True
-    response.request.frame = page.main_frame
+    response = make_response(page)
     window = make_window(page)
 
     window._record_navigation_response(response)
@@ -74,20 +81,22 @@ async def test_goto_timeout_without_response_is_not_reported_as_success() -> Non
 
 @pytest.mark.asyncio
 async def test_goto_timeout_with_response_keeps_best_effort_load_wait() -> None:
-    response = MagicMock()
-    response.status = 200
-    response.status_text = "OK"
-
     page = MagicMock()
     page.url = "https://example.com"
     page.is_closed.return_value = False
+    response = make_response(page)
+    response_callback: Callable[[MagicMock], None] | None = None
+
+    def register_response_callback(_event: str, callback: Callable[[MagicMock], None]) -> None:
+        nonlocal response_callback
+        response_callback = callback
 
     def capture_response(_url: str, **_kwargs: object) -> None:
-        response.request.is_navigation_request.return_value = True
-        response.request.frame = page.main_frame
-        window._record_navigation_response(response)
+        assert callable(response_callback)
+        response_callback(response)
         raise PlaywrightTimeoutError("load event timed out")
 
+    page.on.side_effect = register_response_callback
     page.goto = AsyncMock(side_effect=capture_response)
     window = make_window(page)
 
@@ -99,3 +108,25 @@ async def test_goto_timeout_with_response_keeps_best_effort_load_wait() -> None:
 
     long_wait.assert_awaited_once()
     short_wait.assert_awaited_once()
+    page.remove_listener.assert_called_once_with("response", response_callback)
+
+
+@pytest.mark.asyncio
+async def test_late_response_from_previous_navigation_does_not_affect_next_timeout() -> None:
+    page = MagicMock()
+    page.url = "https://example.com"
+    page.is_closed.return_value = False
+    page.goto = AsyncMock(side_effect=PlaywrightTimeoutError("navigation timed out"))
+    window = make_window(page)
+
+    with pytest.raises(PageLoadingError):
+        await window.goto_and_wait("https://first.example.com")
+
+    late_response = make_response(page)
+    window._record_navigation_response(late_response)
+    assert window.goto_response is late_response
+
+    with pytest.raises(PageLoadingError):
+        await window.goto_and_wait("https://second.example.com")
+
+    assert page.remove_listener.call_count == 2

--- a/tests/browser/test_navigation_timeouts.py
+++ b/tests/browser/test_navigation_timeouts.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from notte_browser.errors import PageLoadingError
 from notte_browser.playwright_async_api import TimeoutError as PlaywrightTimeoutError
-from notte_browser.window import BrowserWindow
+from notte_browser.window import BrowserResource, BrowserWindow
 
 
 def make_window(page: MagicMock) -> BrowserWindow:
@@ -130,3 +130,44 @@ async def test_late_response_from_previous_navigation_does_not_affect_next_timeo
         await window.goto_and_wait("https://second.example.com")
 
     assert page.remove_listener.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_replacement_page_receives_persistent_and_attempt_response_callbacks() -> None:
+    active_page = MagicMock()
+    active_page.url = "https://closed.example.com"
+    active_page.is_closed.return_value = False
+
+    replacement_page = MagicMock()
+    replacement_page.url = "https://replacement.example.com"
+    replacement_page.is_closed.return_value = False
+    active_page.context.pages = [replacement_page]
+
+    resource = BrowserResource.model_construct(page=active_page, options=MagicMock())
+    window = BrowserWindow(resource=resource)
+    active_page.is_closed.return_value = True
+
+    response = make_response(replacement_page)
+    response_callbacks: list[Callable[[MagicMock], None]] = []
+
+    def register_response_callback(_event: str, callback: Callable[[MagicMock], None]) -> None:
+        response_callbacks.append(callback)
+
+    def capture_response(_url: str, **_kwargs: object) -> None:
+        for callback in response_callbacks:
+            callback(response)
+        raise PlaywrightTimeoutError("load event timed out")
+
+    replacement_page.on.side_effect = register_response_callback
+    replacement_page.goto = AsyncMock(side_effect=capture_response)
+
+    with (
+        patch.object(BrowserWindow, "long_wait", new_callable=AsyncMock) as long_wait,
+        patch.object(BrowserWindow, "short_wait", new_callable=AsyncMock),
+    ):
+        await window.goto_and_wait("https://replacement.example.com")
+
+    assert resource.page is replacement_page
+    assert len(response_callbacks) == 2
+    assert window.goto_response is response
+    long_wait.assert_awaited_once()

--- a/tests/browser/test_navigation_timeouts.py
+++ b/tests/browser/test_navigation_timeouts.py
@@ -18,6 +18,41 @@ def make_window(page: MagicMock) -> BrowserWindow:
     )
 
 
+@pytest.mark.parametrize(
+    ("is_navigation", "is_main_frame", "status"),
+    [
+        (False, True, 200),
+        (True, False, 200),
+        (True, True, 302),
+        (True, True, 307),
+    ],
+)
+def test_only_final_main_document_response_is_recorded(is_navigation: bool, is_main_frame: bool, status: int) -> None:
+    page = MagicMock()
+    response = MagicMock()
+    response.status = status
+    response.request.is_navigation_request.return_value = is_navigation
+    response.request.frame = page.main_frame if is_main_frame else MagicMock()
+    window = make_window(page)
+
+    window._record_navigation_response(response)
+
+    assert window.goto_response is None
+
+
+def test_final_main_document_response_is_recorded() -> None:
+    page = MagicMock()
+    response = MagicMock()
+    response.status = 200
+    response.request.is_navigation_request.return_value = True
+    response.request.frame = page.main_frame
+    window = make_window(page)
+
+    window._record_navigation_response(response)
+
+    assert window.goto_response is response
+
+
 @pytest.mark.asyncio
 async def test_goto_timeout_without_response_is_not_reported_as_success() -> None:
     page = MagicMock()
@@ -48,7 +83,9 @@ async def test_goto_timeout_with_response_keeps_best_effort_load_wait() -> None:
     page.is_closed.return_value = False
 
     def capture_response(_url: str, **_kwargs: object) -> None:
-        window.goto_response = response
+        response.request.is_navigation_request.return_value = True
+        response.request.frame = page.main_frame
+        window._record_navigation_response(response)
         raise PlaywrightTimeoutError("load event timed out")
 
     page.goto = AsyncMock(side_effect=capture_response)

--- a/tests/browser/test_navigation_timeouts.py
+++ b/tests/browser/test_navigation_timeouts.py
@@ -1,0 +1,64 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from notte_browser.errors import PageLoadingError
+from notte_browser.playwright_async_api import TimeoutError as PlaywrightTimeoutError
+from notte_browser.window import BrowserWindow
+
+
+def make_window(page: MagicMock) -> BrowserWindow:
+    resource = MagicMock()
+    resource.page = page
+    return BrowserWindow.model_construct(
+        resource=resource,
+        screenshot_mask=None,
+        on_close=None,
+        page_callbacks={},
+        goto_response=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_goto_timeout_without_response_is_not_reported_as_success() -> None:
+    page = MagicMock()
+    page.url = "https://www.duckduckgo.com"
+    page.is_closed.return_value = False
+    page.goto = AsyncMock(side_effect=PlaywrightTimeoutError("navigation timed out"))
+    window = make_window(page)
+
+    with (
+        patch.object(BrowserWindow, "long_wait", new_callable=AsyncMock) as long_wait,
+        patch.object(BrowserWindow, "short_wait", new_callable=AsyncMock) as short_wait,
+        pytest.raises(PageLoadingError),
+    ):
+        await window.goto_and_wait("https://www.duckduckgo.com")
+
+    long_wait.assert_not_awaited()
+    short_wait.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_goto_timeout_with_response_keeps_best_effort_load_wait() -> None:
+    response = MagicMock()
+    response.status = 200
+    response.status_text = "OK"
+
+    page = MagicMock()
+    page.url = "https://example.com"
+    page.is_closed.return_value = False
+
+    def capture_response(_url: str, **_kwargs: object) -> None:
+        window.goto_response = response
+        raise PlaywrightTimeoutError("load event timed out")
+
+    page.goto = AsyncMock(side_effect=capture_response)
+    window = make_window(page)
+
+    with (
+        patch.object(BrowserWindow, "long_wait", new_callable=AsyncMock) as long_wait,
+        patch.object(BrowserWindow, "short_wait", new_callable=AsyncMock) as short_wait,
+    ):
+        await window.goto_and_wait("https://example.com")
+
+    long_wait.assert_awaited_once()
+    short_wait.assert_awaited_once()

--- a/tests/browser/test_navigation_timeouts_integration.py
+++ b/tests/browser/test_navigation_timeouts_integration.py
@@ -7,6 +7,7 @@ import notte_browser.window as window_module
 import pytest
 from aiohttp import web
 from notte_browser.errors import PageLoadingError
+from notte_browser.playwright_async_api import Error as PlaywrightError
 from notte_browser.playwright_async_api import async_playwright
 from notte_browser.window import BrowserResource, BrowserWindow
 from notte_core.common.config import config
@@ -38,7 +39,12 @@ async def test_redirect_response_does_not_hide_stalled_main_document() -> None:
 
         try:
             async with async_playwright() as playwright:
-                browser = await playwright.chromium.launch(headless=True)
+                try:
+                    browser = await playwright.chromium.launch(headless=True)
+                except PlaywrightError as exc:
+                    if "Executable doesn't exist" not in str(exc):
+                        raise
+                    browser = await playwright.chromium.launch(channel="chromium", headless=True)
                 page = await browser.new_page()
                 resource = BrowserResource.model_construct(page=page, options=None)
                 window = BrowserWindow(resource=resource)

--- a/tests/browser/test_navigation_timeouts_integration.py
+++ b/tests/browser/test_navigation_timeouts_integration.py
@@ -1,0 +1,61 @@
+import asyncio
+import socket
+from contextlib import closing
+from unittest.mock import patch
+
+import notte_browser.window as window_module
+import pytest
+from aiohttp import web
+from notte_browser.errors import PageLoadingError
+from notte_browser.playwright_async_api import async_playwright
+from notte_browser.window import BrowserResource, BrowserWindow
+from notte_core.common.config import config
+
+
+@pytest.mark.asyncio
+async def test_redirect_response_does_not_hide_stalled_main_document() -> None:
+    release_stalled_request = asyncio.Event()
+
+    async def redirect(_request: web.Request) -> web.StreamResponse:
+        raise web.HTTPFound("/stall")
+
+    async def stall(_request: web.Request) -> web.StreamResponse:
+        await release_stalled_request.wait()
+        return web.Response(text="loaded")
+
+    app = web.Application()
+    app.router.add_get("/redirect", redirect)
+    app.router.add_get("/stall", stall)
+    runner = web.AppRunner(app)
+    await runner.setup()
+
+    with closing(socket.socket()) as server_socket:
+        server_socket.bind(("127.0.0.1", 0))
+        server_socket.listen()
+        port = server_socket.getsockname()[1]
+        site = web.SockSite(runner, server_socket)
+        await site.start()
+
+        try:
+            async with async_playwright() as playwright:
+                browser = await playwright.chromium.launch(headless=True)
+                page = await browser.new_page()
+                resource = BrowserResource.model_construct(page=page, options=None)
+                window = BrowserWindow(resource=resource)
+                test_config = config.model_copy(update={"timeout_goto_ms": 250})
+
+                try:
+                    with (
+                        patch.object(window_module, "config", test_config),
+                        pytest.raises(PageLoadingError),
+                    ):
+                        await window.goto_and_wait(f"http://127.0.0.1:{port}/redirect")
+
+                    assert window.goto_response is None
+                finally:
+                    release_stalled_request.set()
+                    await window.close()
+                    await browser.close()
+        finally:
+            release_stalled_request.set()
+            await runner.cleanup()

--- a/tests/browser/test_post_action_screenshot.py
+++ b/tests/browser/test_post_action_screenshot.py
@@ -1,0 +1,35 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from notte_browser.session import NotteSession
+
+
+@pytest.mark.asyncio
+async def test_post_action_screenshot_has_total_deadline() -> None:
+    session = object.__new__(NotteSession)
+    cancelled = asyncio.Event()
+
+    async def stalled_screenshot() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    session.ascreenshot = AsyncMock(side_effect=stalled_screenshot)
+
+    with patch.object(NotteSession, "POST_ACTION_SCREENSHOT_TIMEOUT_SECONDS", 0.01):
+        await session._capture_post_action_screenshot()
+
+    assert cancelled.is_set()
+    session.ascreenshot.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_action_screenshot_failure_is_best_effort() -> None:
+    session = object.__new__(NotteSession)
+    session.ascreenshot = AsyncMock(side_effect=RuntimeError("renderer unavailable"))
+
+    await session._capture_post_action_screenshot()
+
+    session.ascreenshot.assert_awaited_once()


### PR DESCRIPTION
## Summary

- report navigation timeouts without an HTTP response as PageLoadingError
- retain best-effort load-state handling when a response was received
- cap the complete post-action screenshot path at five seconds
- add regression coverage for both timeout paths

## Why

A monorepo code-sample run stalled while navigating to DuckDuckGo:
https://github.com/nottelabs/monorepo/actions/runs/33397649170/job/99505978005?pr=2441

Chromium updated page.url before the main document returned a response. The navigation timeout was therefore treated as success, leaving the renderer in a pending-navigation state. The automatic post-action screenshot then spent about 31 seconds across three CDP attempts before falling back to Playwright, causing the outer 60-second pytest timeout.

This change makes the navigation failure explicit and ensures a best-effort trajectory screenshot cannot keep an otherwise completed request open indefinitely.

## Testing

- uv run pytest tests/browser/test_navigation_timeouts.py tests/browser/test_post_action_screenshot.py -q
- uv run ruff check on changed implementation and test files
- uv run ty check on both new test files
- all pre-commit hooks passed

A broader tests/browser run reached 65 passed and 2 skipped; four environment-dependent tests could not run locally because Chromium was not installed and the configured SMTP credentials were rejected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790780714&installation_model_id=8247&pr_number=927&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F927&signature=f29233ab228eaf455c657191e6725277d362de32bf06894cf6c8e4086c9d7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page navigation timeout handling to prevent delayed responses from affecting later attempts.
  * Ensured stalled navigations report a clear loading error and clean up correctly.
  * Post-action screenshots now use a time limit and fail gracefully if capture stalls or encounters an error.
  * Ensured replacement pages retain the expected navigation callbacks.

* **Tests**
  * Added coverage for navigation timeouts, redirects, response tracking, listener cleanup, and post-action screenshot failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->