### PR TITLE
fix(ci): merge the submodule bump pull request with --admin

### DIFF
--- a/.github/workflows/bump-submodules.yml
+++ b/.github/workflows/bump-submodules.yml
@@ -113,11 +113,11 @@ jobs:
 
           echo "PR: https://github.com/${{ github.repository }}/pull/$PR_NUMBER"
 
-          # main requires one approving review. A bypass allowance lets this
-          # token merge without that review, but GitHub does not extend the
-          # bypass to the auto-merge queue acting on its behalf, so --auto would
-          # park the pull request at REVIEW_REQUIRED forever. Wait for the checks
-          # here and merge explicitly, which does honour the bypass.
+          # main requires one approving review, so the pull request sits at
+          # mergeStateStatus BLOCKED and --auto would park there forever. This
+          # token's account is exempt server side, but `gh pr merge` refuses a
+          # BLOCKED pull request client side, before it ever calls the API.
+          # --admin skips only that local guard; the merge itself is ordinary.
           #
           # Merging the pull request this job just created, by number, is also
           # what keeps the merge safe: nothing is looked up by branch name, so a
@@ -131,8 +131,9 @@ jobs:
           done
 
           if gh pr checks "$PR_NUMBER" --watch --fail-fast --interval 30; then
-            gh pr merge "$PR_NUMBER" --squash --delete-branch
+            gh pr merge "$PR_NUMBER" --squash --delete-branch --admin
             echo "Merged PR #$PR_NUMBER."
           else
-            echo "::warning::Checks did not pass on PR #$PR_NUMBER, so it was left open. The next scheduled run rebuilds the branch from main and retries."
+            echo "::error::Checks did not pass on PR #$PR_NUMBER, so it was left open. The next scheduled run rebuilds the branch from main and retries."
+            exit 1
           fi


### PR DESCRIPTION
The daily `bump-submodules` job has never actually merged its own pull request. It opens the bump, waits for the required checks, and then the merge is refused:

```
X Pull request nottelabs/notte#928 is not mergeable: the base branch policy prohibits the merge.
```

`main` requires an approving review, so the bump sits at `mergeStateStatus: BLOCKED`. The account behind the token is exempt from that server side, but `gh pr merge` rejects a `BLOCKED` pull request client side before it ever calls the API, so the merge never reached GitHub. `--admin` skips only that local guard; the merge it then performs is the ordinary one.

Also make the "checks did not pass" branch exit non-zero. Today it exits 0, so a bump whose checks failed reports a green run and is only noticeable by spotting that the pull request is still open.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790844974&installation_model_id=8247&pr_number=929&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F929&signature=e51b196aaddb84f35c03d0ba3cf4f93910550c1c3e996e16c1c2e60d6e0d06c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated pull request merging to use administrative merge handling.
  - Improved workflow comments describing automatic merge behavior.
  - Workflow failures are now reported as errors and stop execution with a failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->