### PR TITLE
docs: refresh generated llms.txt and fix its auto-merge

### DIFF
--- a/.github/workflows/refresh-llms.yml
+++ b/.github/workflows/refresh-llms.yml
@@ -129,11 +129,11 @@ jobs:
 
           echo "PR: https://github.com/${{ github.repository }}/pull/$PR_NUMBER"
 
-          # main requires one approving review. A bypass allowance lets this
-          # token merge without that review, but GitHub does not extend the
-          # bypass to the auto-merge queue acting on its behalf, so --auto would
-          # park the pull request at REVIEW_REQUIRED forever. Wait for the checks
-          # here and merge explicitly, which does honour the bypass.
+          # main requires one approving review, so the pull request sits at
+          # mergeStateStatus BLOCKED and --auto would park there forever. This
+          # token's account is exempt server side, but `gh pr merge` refuses a
+          # BLOCKED pull request client side, before it ever calls the API.
+          # --admin skips only that local guard; the merge itself is ordinary.
           #
           # Merging the pull request this job just created, by number, is also
           # what keeps the merge safe: nothing is looked up by branch name, so a
@@ -147,8 +147,9 @@ jobs:
           done
 
           if gh pr checks "$PR_NUMBER" --watch --fail-fast --interval 30; then
-            gh pr merge "$PR_NUMBER" --squash --delete-branch
+            gh pr merge "$PR_NUMBER" --squash --delete-branch --admin
             echo "Merged PR #$PR_NUMBER."
           else
-            echo "::warning::Checks did not pass on PR #$PR_NUMBER, so it was left open. The next scheduled run rebuilds the branch from main and retries."
+            echo "::error::Checks did not pass on PR #$PR_NUMBER, so it was left open. The next scheduled run rebuilds the branch from main and retries."
+            exit 1
           fi

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -222,10 +222,12 @@ The SDK docs below are for generated-code editing and reference. They are not th
 - [GET Function Download Url](https://docs.notte.cc/api-reference/functions/function-download-url.md)
 - [POST Function Fork](https://docs.notte.cc/api-reference/functions/function-fork.md)
 - [PATCH Function Metadata Update](https://docs.notte.cc/api-reference/functions/function-metadata-update.md)
+- [POST Function Rollback](https://docs.notte.cc/api-reference/functions/function-rollback.md)
 - [GET Function Run Get Metadata](https://docs.notte.cc/api-reference/functions/function-run-get-metadata.md)
 - [POST Function Run Start](https://docs.notte.cc/api-reference/functions/function-run-start.md)
 - [DELETE Function Run Stop](https://docs.notte.cc/api-reference/functions/function-run-stop.md)
 - [PATCH Function Run Update Metadata](https://docs.notte.cc/api-reference/functions/function-run-update-metadata.md)
+- [GET Function Runtime Health](https://docs.notte.cc/api-reference/functions/function-runtime-health.md)
 - [DELETE Function Schedule Delete](https://docs.notte.cc/api-reference/functions/function-schedule-delete.md)
 - [POST Function Schedule Set](https://docs.notte.cc/api-reference/functions/function-schedule-set.md)
 - [POST Function Update](https://docs.notte.cc/api-reference/functions/function-update.md)
@@ -245,6 +247,16 @@ The SDK docs below are for generated-code editing and reference. They are not th
 - [GET Mailbox List](https://docs.notte.cc/api-reference/mailboxes/mailbox-list.md)
 - [POST Mailbox Sync](https://docs.notte.cc/api-reference/mailboxes/mailbox-sync.md)
 - [PATCH Mailbox Update](https://docs.notte.cc/api-reference/mailboxes/mailbox-update.md)
+
+## Managed-Auth
+
+- [POST  Connect Link Context](https://docs.notte.cc/api-reference/managed-auth/connect-link-context.md)
+- [POST  Connect Link Mailbox Connect](https://docs.notte.cc/api-reference/managed-auth/connect-link-mailbox-connect.md)
+- [POST  Connect Link Mailbox Sync](https://docs.notte.cc/api-reference/managed-auth/connect-link-mailbox-sync.md)
+- [POST  Connect Link Mailboxes](https://docs.notte.cc/api-reference/managed-auth/connect-link-mailboxes.md)
+- [GET  Connect Link Status](https://docs.notte.cc/api-reference/managed-auth/connect-link-status.md)
+- [POST  Connect Link Submit](https://docs.notte.cc/api-reference/managed-auth/connect-link-submit.md)
+- [POST Managed Auth Connect Link Create](https://docs.notte.cc/api-reference/managed-auth/managed-auth-connect-link-create.md)
 
 ## Personas
 


### PR DESCRIPTION
`main` is red: the `docs-sdk-generate` pre-commit hook fails with `files were modified by this hook`.

`docs/src/llms.txt` is generated from the live OpenAPI spec at `api.notte.cc`, so it goes stale on its own whenever the API gains endpoints - no commit here has to change for the hook to start failing. The spec picked up the managed-auth connect-link endpoints plus `function-rollback` and `function-runtime-health`, and the checked-in file had not caught up.

Two commits:

1. **Refresh `llms.txt`.** The output of `make docs-sdk`, no hand edits. `llms.txt` is the only file that drifted; the generated SDK reference is unchanged.
2. **Let `refresh-llms.yml` merge its own pull request.** That workflow exists to catch this drift daily, but its merge step is the same one that was just fixed in `bump-submodules.yml`: `gh pr merge` refuses a `BLOCKED` pull request client side, before it ever calls the API, so the refresh would open a pull request and then fail to land it. It has run five times and never found drift, so this path had never executed. Same two-line fix, and the `else` branch now exits non-zero instead of reporting a green run with the pull request left open.

Without the second commit the first one is temporary: the next API deploy turns `main` red again and nothing self-heals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added API reference entries for Function Rollback and Function Runtime Health.
  - Added a Managed Auth API section covering connection links, mailbox synchronization, status, submission, and related endpoints.

- **Chores**
  - Improved automated documentation refresh handling by stopping when checks fail and enabling approved administrative merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->