### PR TITLE
fix(examples): repair the nightly example run

### DIFF
--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -89,6 +89,7 @@ jobs:
         run: uv run python scripts/cleanup_ci_vaults.py
 
       - name: Send Slack Notification
+        if: always()
         uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |

--- a/examples/cli_agent.py
+++ b/examples/cli_agent.py
@@ -11,9 +11,8 @@ import notte
 def main(
     task: Annotated[str, typer.Option(..., help="Task to perform")],
     reasoning_model: Annotated[str, typer.Option(help="Reasoning model to use")] = LlmModel.default(),  # type: ignore[reportArgumentType]
-    open_viewer: Annotated[bool, typer.Option(help="Open live viewer")] = False,
 ) -> AgentResponse:
-    with notte.Session(open_viewer=open_viewer) as session:
+    with notte.Session() as session:
         agent = notte.Agent(reasoning_model=reasoning_model, session=session)
         return agent.run(task=task)
 

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from notte_core.common.config import LlmModel
 
 
 def find_python_files(directory: Path) -> list[Path]:
@@ -82,7 +83,10 @@ def test_root_level_scripts(python_file: Path) -> None:
     Args:
         python_file: Path to the Python file to test
     """
-    OVERRIDE_ARGS: dict[str, list[str]] = {"cli_agent.py": ["--task", "go to duckduckgo"]}
+    OVERRIDE_ARGS: dict[str, list[str]] = {
+        "cli_agent.py": ["--task", "go to duckduckgo"],
+        "quickstart.py": ["go to duckduckgo", "3", str(LlmModel.default())],
+    }
     print(f"Running {python_file.name}...")
     exit_code, logs = run_python_file(python_file, OVERRIDE_ARGS.get(python_file.name, []))
 


### PR DESCRIPTION
The nightly example run has failed every night for over a month. Two of the two root-level example scripts fail, and the alert that should have reported it never fires.

**`examples/cli_agent.py` passes a cloud-only argument to a local session.** `notte.Session` is the local browser session, and `open_viewer` belongs to the remote one - the SDK filters it out before validating a remote request, but the local path has no such filter and `LocalSessionStartRequest` forbids extra fields. The example therefore raises before it opens a browser:

```
ValidationError: 1 validation error for LocalSessionStartRequest
open_viewer
  Extra inputs are not permitted [type=extra_forbidden, input_value=False, input_type=bool]
```

Anyone copying the example, including the usage line in its own trailing comment, hits this. The flag is dropped, since a local session has nothing to open a viewer onto.

**`examples/quickstart.py` is never given arguments.** It requires a task, a step budget and a model, and exits 1 with its usage message otherwise. The test harness only supplied arguments for `cli_agent.py`, so this was guaranteed to fail. It now gets a task and the default model.

**The Slack notification only ran when the tests passed.** It had no `if:` condition, so a failing test step aborted the job before the notification could be sent - the one case where it is worth sending. It now runs with `if: always()`, like the cleanup step above it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790849718&installation_model_id=8247&pr_number=931&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F931&signature=2d5ae191dd4412a192f9d92b261cddf11ce64ebd8d618838dab746566fd796db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly example runs now send Slack notifications even when an earlier step fails, improving failure visibility.
* **CLI Improvements**
  * Simplified the example agent command by removing the viewer-opening option.
  * The agent session now starts with streamlined default behavior.
* **Examples**
  * Updated the quickstart example to use the default reasoning model automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->