### PR TITLE
test: retry two live-site integration tests on transient failure

### DIFF
--- a/tests/integration/sdk/test_scraping.py
+++ b/tests/integration/sdk/test_scraping.py
@@ -194,6 +194,7 @@ class SiteUpdate(BaseModel):
     update_text: str | None
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_scraping_structured_data_with_response_format_and_raise_on_failure_false():
     _ = load_dotenv()
     notte = NotteClient()

--- a/tests/integration/test_webvoyager_scripts.py
+++ b/tests/integration/test_webvoyager_scripts.py
@@ -14,6 +14,7 @@ from notte_core.actions import (
 #         )
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 @pytest.mark.asyncio
 async def test_huggingface_model_search():
     async with NotteSession() as page:


### PR DESCRIPTION
Two integration tests drive live third-party sites and fail the whole run on a transient hiccup:

- `test_scraping_structured_data_with_response_format_and_raise_on_failure_false` - the news site was unreachable, so structured extraction returned `success=False` and `result.get()` raised.
- `test_huggingface_model_search` - the script replays hardcoded action ids against the live page; on a partial render `L12` is not in the page context.

Both get `@pytest.mark.flaky(reruns=3, reruns_delay=5)`, consistent with the other live-site tests in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test resilience by allowing selected scraping and model-search tests to retry up to three times, with a five-second delay between attempts.
  * This reduces failures caused by temporary issues during automated test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->