### PR TITLE
fix(sdk): leave native dialogs to backend

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -90,6 +90,22 @@ CONSOLE_VIEWER_URL = (
 _playwright_available = False
 _async_playwright_available = False
 
+
+def _observe_server_owned_dialog(_dialog: Any) -> None:
+    """Keep the external CDP client from competing with Notte for native dialogs.
+
+    Playwright automatically handles a JavaScript dialog when no listener is
+    registered. Native dialogs are target-global, so that default races the
+    Notte browser controller attached to the same target. The backend owns
+    dialog handling; this listener makes the SDK Playwright connection an
+    observer without issuing a second ``Page.handleJavaScriptDialog`` command.
+    """
+
+
+def _install_server_owned_dialog_policy(browser: Any) -> None:
+    for context in browser.contexts:
+        context.on("dialog", _observe_server_owned_dialog)
+
 try:
     from playwright.sync_api import Browser as BrowserSync
     from playwright.sync_api import Page as PageSync
@@ -1150,6 +1166,7 @@ class RemoteSession(SyncResource):
             if self._playwright_browser is None:
                 cdp_url = self.cdp_url()
                 self._playwright_browser = self._playwright_context.chromium.connect_over_cdp(cdp_url)
+                _install_server_owned_dialog_policy(self._playwright_browser)
 
             # Get the first page from the first context
             self._playwright_page = self._playwright_browser.contexts[0].pages[0]
@@ -1205,6 +1222,7 @@ class RemoteSession(SyncResource):
             if self._async_playwright_browser is None:
                 cdp_url = self.cdp_url()
                 self._async_playwright_browser = await self._async_playwright_context.chromium.connect_over_cdp(cdp_url)
+                _install_server_owned_dialog_policy(self._async_playwright_browser)
 
             # Get the first page from the first context
             self._async_playwright_page = self._async_playwright_browser.contexts[0].pages[0]

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -106,6 +106,7 @@ def _install_server_owned_dialog_policy(browser: Any) -> None:
     for context in browser.contexts:
         context.on("dialog", _observe_server_owned_dialog)
 
+
 try:
     from playwright.sync_api import Browser as BrowserSync
     from playwright.sync_api import Page as PageSync

--- a/tests/integration/sdk/test_cdp.py
+++ b/tests/integration/sdk/test_cdp.py
@@ -17,3 +17,17 @@ def test_cdp_connection():
             with tempfile.TemporaryDirectory() as tmp_dir:
                 screenshot = page.screenshot(path=f"{tmp_dir}/screenshot.png")
             assert screenshot is not None
+
+
+def test_session_page_leaves_native_dialogs_to_backend():
+    client = NotteClient()
+    with client.Session(proxies=False) as session:
+        page = session.page
+        _ = page.goto("https://example.com")
+        _ = page.evaluate("window.onbeforeunload = () => 'leave?'")
+
+        result = session.execute(type="goto", url="https://example.org", raise_on_failure=True)
+
+        page.wait_for_url("https://example.org/**")
+        assert result.success
+        assert page.title() == "Example Domain"

--- a/tests/sdk/test_session_playwright_dialog_policy.py
+++ b/tests/sdk/test_session_playwright_dialog_policy.py
@@ -1,0 +1,59 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from notte_sdk.endpoints import sessions
+from notte_sdk.endpoints.sessions import RemoteSession
+
+
+def _bare_session() -> RemoteSession:
+    session = object.__new__(RemoteSession)
+    session._playwright_browser = None
+    session._playwright_context = None
+    session._playwright_page = None
+    session._async_playwright_browser = None
+    session._async_playwright_context = None
+    session._async_playwright_page = None
+    session.cdp_url = MagicMock(return_value="ws://notte.example/cdp")
+    return session
+
+
+def _browser_with_page() -> tuple[MagicMock, MagicMock, MagicMock]:
+    page = MagicMock()
+    context = MagicMock()
+    context.pages = [page]
+    browser = MagicMock()
+    browser.contexts = [context]
+    return browser, context, page
+
+
+def test_sync_page_makes_backend_the_native_dialog_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _bare_session()
+    browser, context, page = _browser_with_page()
+    playwright = MagicMock()
+    playwright.chromium.connect_over_cdp.return_value = browser
+    starter = MagicMock()
+    starter.start.return_value = playwright
+    monkeypatch.setattr(sessions, "_playwright_available", True)
+    monkeypatch.setattr(sessions, "_sync_playwright", MagicMock(return_value=starter))
+
+    assert session.page is page
+
+    context.on.assert_called_once_with("dialog", sessions._observe_server_owned_dialog)
+    assert sessions._observe_server_owned_dialog(MagicMock()) is None
+
+
+@pytest.mark.asyncio
+async def test_async_page_makes_backend_the_native_dialog_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _bare_session()
+    browser, context, page = _browser_with_page()
+    playwright = MagicMock()
+    playwright.chromium.connect_over_cdp = AsyncMock(return_value=browser)
+    starter = MagicMock()
+    starter.start = AsyncMock(return_value=playwright)
+    monkeypatch.setattr(sessions, "_async_playwright_available", True)
+    monkeypatch.setattr(sessions, "_async_playwright", MagicMock(return_value=starter))
+
+    assert await session.apage is page
+
+    context.on.assert_called_once_with("dialog", sessions._observe_server_owned_dialog)
+    assert sessions._observe_server_owned_dialog(MagicMock()) is None


### PR DESCRIPTION
## Summary

- make Notte backend the sole native JavaScript dialog owner for SDK Playwright CDP connections
- install an observer-only dialog listener for both `session.page` and `session.apage`
- cover sync, async, and live two-controller `beforeunload` behavior

## Root cause

Native dialogs are target-global. The Notte backend and the SDK Playwright-over-CDP client both received the event and attempted `Page.handleJavaScriptDialog`; stock Playwright could lose that race and terminate its Node driver with `No dialog is showing`.

## Verification

- `uv run pytest -q tests/sdk/test_session_playwright_dialog_policy.py tests/sdk/test_session_context_close_reason.py` (5 passed)
- `uv run ruff check packages/notte-sdk/src/notte_sdk/endpoints/sessions.py tests/sdk/test_session_playwright_dialog_policy.py tests/integration/sdk/test_cdp.py`
- live Notte `beforeunload` reproduction: backend navigation completed and SDK page remained usable
- live BenefitsCal earned-income and other-income replays completed at the income summary with `submitted=false`

## Notes

The broader `tests/sdk` run reaches the new tests successfully; two unrelated replay-frame tests fail because their local replay artifacts are absent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790948077&installation_model_id=8247&pr_number=934&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F934&signature=a202af2a2377b35168299490dd6dd510293d88d652361bcb661fb8fd5d1da8b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of native browser dialogs during remote sessions.
  * Dialogs are now left for backend handling, preventing client-side interruptions during navigation.

* **Tests**
  * Added coverage for synchronous and asynchronous page access.
  * Added integration coverage for navigation when a native dialog is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->