### PR TITLE
fix(ci): prevent nightly example subprocess hangs

### DIFF
--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -80,13 +80,11 @@ jobs:
           echo "Environment variables are set"
 
       - name: Run example tests
-        uses: coactions/setup-xvfb@v1
-        with:
-            run: bash tests/run_examples.sh
+        run: xvfb-run --auto-servernum bash tests/run_examples.sh
 
       - name: Cleanup vaults created by this run
         if: always()
-        run: uv run python scripts/cleanup_ci_vaults.py
+        run: uv run python scripts/cleanup_ci_vaults.py --allow-production
 
       - name: Send Slack Notification
         if: always()

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -1,5 +1,8 @@
 import logging
+import os
+import signal
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -19,7 +22,7 @@ def find_python_files(directory: Path) -> list[Path]:
     return [file for file in directory.glob("*.py") if file.name != "__init__.py" and not file.name.startswith("test_")]
 
 
-def run_python_file(file_path: Path, args: list[str]) -> tuple[int, list[str]]:
+def run_python_file(file_path: Path, args: list[str], timeout_seconds: float = 280) -> tuple[int, list[str]]:
     """
     Run a Python file and return its output (both stdout and stderr).
 
@@ -30,25 +33,55 @@ def run_python_file(file_path: Path, args: list[str]) -> tuple[int, list[str]]:
     Returns:
         The error code
     """
-    logged: list[str] = []
-    try:
-        # Merge stderr into stdout and capture the combined output
-        # result = subprocess.run( + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=True)
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as output:
         process = subprocess.Popen(
-            ["python", str(file_path)] + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+            ["python", str(file_path)] + args,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+            # Examples should exercise open_viewer=True, but CI must not launch
+            # a local browser whose lifecycle can keep the example alive.
+            env={**os.environ, "BROWSER": "/bin/true"},
         )
 
-        # Read and log stdout in real-time
-        for line in process.stdout:
+        try:
+            exit_code = process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            exit_code = -1
+            logging.error("Timed out running %s after %s seconds", file_path, timeout_seconds)
+        finally:
+            # Viewer/browser processes may outlive the example. Stop the whole
+            # process group so they cannot leak into later parametrized tests.
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+
+        output.seek(0)
+        logged: list[str] = []
+        for line in output:
             line = line.strip()
             if line:
                 logged.append(line)
                 logging.info(line)
 
-        return process.wait(), logged
-    except subprocess.CalledProcessError as e:
-        print(f"Error running {file_path}: {e}")
-        return -1, logged
+        return exit_code, logged
+
+
+def test_run_python_file_does_not_wait_for_descendant_stdout(tmp_path: Path) -> None:
+    script = tmp_path / "spawns_descendant.py"
+    script.write_text(
+        "import os, subprocess, sys\n"
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
+        "print('parent finished')\n"
+        "print(os.environ['BROWSER'])\n"
+    )
+
+    exit_code, logs = run_python_file(script, [], timeout_seconds=5)
+
+    assert exit_code == 0
+    assert logs == ["parent finished", "/bin/true"]
 
 
 def get_python_files() -> list[Path]:

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -3,6 +3,7 @@ import os
 import signal
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,29 @@ def find_python_files(directory: Path) -> list[Path]:
         A list of Path objects for Python files
     """
     return [file for file in directory.glob("*.py") if file.name != "__init__.py" and not file.name.startswith("test_")]
+
+
+def _terminate_process_group(process: subprocess.Popen[str], grace_seconds: float = 5) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+
+    deadline = time.monotonic() + grace_seconds
+    while time.monotonic() < deadline:
+        try:
+            os.killpg(process.pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+    if process.poll() is None:
+        process.wait(timeout=1)
 
 
 def run_python_file(file_path: Path, args: list[str], timeout_seconds: float = 280) -> tuple[int, list[str]]:
@@ -53,10 +77,7 @@ def run_python_file(file_path: Path, args: list[str], timeout_seconds: float = 2
         finally:
             # Viewer/browser processes may outlive the example. Stop the whole
             # process group so they cannot leak into later parametrized tests.
-            try:
-                os.killpg(process.pid, signal.SIGTERM)
-            except ProcessLookupError:
-                pass
+            _terminate_process_group(process)
 
         output.seek(0)
         logged: list[str] = []
@@ -82,6 +103,25 @@ def test_run_python_file_does_not_wait_for_descendant_stdout(tmp_path: Path) -> 
 
     assert exit_code == 0
     assert logs == ["parent finished", "/bin/true"]
+
+
+def test_run_python_file_kills_and_reaps_process_after_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    script = tmp_path / "ignores_sigterm.py"
+    script.write_text(
+        "import signal, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "print('ready', flush=True)\n"
+        "time.sleep(30)\n"
+    )
+    original_terminate = _terminate_process_group
+    monkeypatch.setattr(
+        f"{__name__}._terminate_process_group", lambda process: original_terminate(process, grace_seconds=0.1)
+    )
+
+    exit_code, logs = run_python_file(script, [], timeout_seconds=0.1)
+
+    assert exit_code == -1
+    assert logs == ["ready"]
 
 
 def get_python_files() -> list[Path]:


### PR DESCRIPTION
## Summary

- wait for the direct example process instead of pipe EOF from all descendants
- capture output in a file and terminate leftover viewer/browser process groups
- add a regression test for descendants inheriting stdout
- invoke `xvfb-run` directly and explicitly allow scoped production vault cleanup

## Context

The nightly example run timed out after `quickstart.py` completed successfully because a viewer/browser descendant retained the stdout pipe. The workflow also had independent failures from the Xvfb action cleanup and the production vault-cleanup guard.

## Testing

- `uv run pytest tests/examples/test_examples.py::test_run_python_file_does_not_wait_for_descendant_stdout -q`
- `uv run ruff check tests/examples/test_examples.py`
- `uv run ruff format --check tests/examples/test_examples.py`
- workflow YAML parse
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791014225&installation_model_id=8247&pr_number=936&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F936&signature=b09cd6a4fe331a84ec170d3f66f41602a59dbe268f2e85561b1d09143a43045e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved example test reliability by preventing lingering viewer or browser processes from affecting subsequent tests.
  * Added timeout handling for example scripts, including cleanup when execution exceeds the limit.
  * Prevented descendant processes from delaying test completion, helping test runs finish consistently even when launched applications remain active.
  * Improved nightly example test execution and vault cleanup reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->