### PR TITLE
feat(personas): expose public and internal emails

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/personas.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/personas.py
@@ -272,6 +272,16 @@ class BasePersona(ABC):
     def info(self) -> PersonaResponse:
         return self._get_info()
 
+    @property
+    def email(self) -> str:
+        """Public, human-readable email address of the persona."""
+        return self.info.email
+
+    @property
+    def internal_email(self) -> str:
+        """Internal UUID-backed mailbox address of the persona."""
+        return self.info.internal_email
+
     @cached_property
     def vault(self) -> BaseVault:
         vault = self._get_vault()

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1603,7 +1603,8 @@ class PersonaResponse(SdkResponse):
     status: Annotated[str, Field(description="Status of the persona (active, closed)")]
     first_name: Annotated[str, Field(description="First name of the persona")]
     last_name: Annotated[str, Field(description="Last name of the persona")]
-    email: Annotated[str, Field(description="Email of the persona")]
+    email: Annotated[str, Field(description="Public, human-readable email address of the persona")]
+    internal_email: Annotated[str, Field(description="Internal UUID-backed mailbox address of the persona")]
     vault_id: Annotated[str | None, Field(description="ID of the vault")]
     phone_number: Annotated[str | None, Field(description="Phone number of the persona (optional)")]
 

--- a/tests/test_session_persona_helpers.py
+++ b/tests/test_session_persona_helpers.py
@@ -32,6 +32,7 @@ class StubPersona(BasePersona):
             first_name="Test",
             last_name="Persona",
             email="persona@example.com",
+            internal_email=f"{persona_id}@mail-sand.com",
             vault_id="vault_123" if vault else None,
             phone_number=None,
         )
@@ -47,6 +48,13 @@ class StubPersona(BasePersona):
 
     def _get_vault(self):  # type: ignore[override]
         return self._vault
+
+
+def test_persona_exposes_public_and_internal_email_addresses() -> None:
+    persona = StubPersona(emails=[], sms=[])
+
+    assert persona.email == "persona@example.com"
+    assert persona.internal_email == "persona_test@mail-sand.com"
 
 
 def test_session_read_emails_and_sms() -> None:


### PR DESCRIPTION
## Summary

- define `PersonaResponse.email` as the public, human-readable persona address
- add `PersonaResponse.internal_email` for the stable UUID-backed mailbox address
- expose both values directly as `persona.email` and `persona.internal_email`

Depends on nottelabs/monorepo#2520 for the API response contract.

## Testing

- `uv run pytest -q tests/test_session_persona_helpers.py` — 10 passed
- Ruff check/format
- basedpyright — 0 errors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791015986&installation_model_id=8247&pr_number=937&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F937&signature=0b358bcaf6b8408aa146552631d7b667d51e5c779eef8ef495bbfd417827bbc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Personas now expose both a public, human-readable email address and a separate internal mailbox address.
  - Persona details distinguish between public and internal email fields.

- **Tests**
  - Added coverage verifying that both email addresses are correctly available on personas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->