### PR TITLE
feat(personas): expose readable and internal emails

### DIFF
--- a/packages/notte-sdk/src/notte_sdk/endpoints/personas.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/personas.py
@@ -272,6 +272,16 @@ class BasePersona(ABC):
     def info(self) -> PersonaResponse:
         return self._get_info()
 
+    @property
+    def email(self) -> str:
+        """Readable email address intended for external senders."""
+        return self.info.email
+
+    @property
+    def internal_email(self) -> str:
+        """Stable UUID-backed address for the persona mailbox."""
+        return self.info.internal_email
+
     @cached_property
     def vault(self) -> BaseVault:
         vault = self._get_vault()

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -1622,7 +1622,8 @@ class PersonaResponse(SdkResponse):
     status: Annotated[str, Field(description="Status of the persona (active, closed)")]
     first_name: Annotated[str, Field(description="First name of the persona")]
     last_name: Annotated[str, Field(description="Last name of the persona")]
-    email: Annotated[str, Field(description="Email of the persona")]
+    email: Annotated[str, Field(description="Readable email alias of the persona")]
+    internal_email: Annotated[str, Field(description="Internal UUID-backed email address of the persona")]
     vault_id: Annotated[str | None, Field(description="ID of the vault")]
     phone_number: Annotated[str | None, Field(description="Phone number of the persona (optional)")]
 

--- a/tests/integration/sdk/test_personas.py
+++ b/tests/integration/sdk/test_personas.py
@@ -197,6 +197,8 @@ def test_persona_get_operations():
         assert retrieved_persona.first_name is not None
         assert retrieved_persona.last_name is not None
         assert retrieved_persona.email is not None
+        email_domain = retrieved_persona.email.rsplit("@", 1)[1]
+        assert retrieved_persona.internal_email == f"{persona_id}@{email_domain}"
     finally:
         # Clean up
         if persona_id is not None:

--- a/tests/test_session_persona_helpers.py
+++ b/tests/test_session_persona_helpers.py
@@ -32,6 +32,7 @@ class StubPersona(BasePersona):
             first_name="Test",
             last_name="Persona",
             email="persona@example.com",
+            internal_email=f"{persona_id}@example.com",
             vault_id="vault_123" if vault else None,
             phone_number=None,
         )
@@ -47,6 +48,13 @@ class StubPersona(BasePersona):
 
     def _get_vault(self):  # type: ignore[override]
         return self._vault
+
+
+def test_persona_exposes_readable_and_internal_email_addresses() -> None:
+    persona = StubPersona(emails=[], sms=[])
+
+    assert persona.email == "persona@example.com"
+    assert persona.internal_email == "persona_test@example.com"
 
 
 def test_session_read_emails_and_sms() -> None:


### PR DESCRIPTION
## Summary

- add `internal_email` to `PersonaResponse`
- expose `persona.email` as the readable alias
- expose `persona.internal_email` as the stable UUID-backed mailbox address
- validate the response against the live staging API

## Tests

- `uv run pytest tests/test_session_persona_helpers.py tests/integration/sdk/test_personas.py::test_persona_get_operations -q`
- targeted Ruff checks and formatting

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791033690&installation_model_id=8247&pr_number=938&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F938&signature=91a4bbc62dc7ceb536f05fe8fd41b7adc3ae1132c9633a01363bdfdc0b8e1a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persona details now include both a readable email alias and a stable internal email address.
  * The internal address is consistently derived from the persona’s unique identifier.

* **Bug Fixes**
  * Improved persona email data validation to ensure both email formats are exposed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->