### PR TITLE
fix(browser): persist manually fetched downloads

### DIFF
--- a/packages/notte-browser/src/notte_browser/controller.py
+++ b/packages/notte-browser/src/notte_browser/controller.py
@@ -149,6 +149,11 @@ async def _resolve_locator_frame(locator: Locator) -> Frame:
     return frame
 
 
+def _should_persist_download(*, manually_fetched: bool, captures_browser_downloads: bool) -> bool:
+    """Return whether the controller owns persistence for a downloaded file."""
+    return manually_fetched or not captures_browser_downloads
+
+
 async def _evaluate_blob_expression(
     frame: Frame,
     expression: str,
@@ -476,7 +481,8 @@ class BrowserController:
                 if self.storage is None or self.storage.download_dir is None:
                     raise NoStorageObjectProvidedError(action.name())
 
-                if window.is_file():
+                manually_fetched = window.is_file()
+                if manually_fetched:
                     file_content, filename = await window.download_file()
                     logger.info(f"Saving raw file with this filename: {filename}")
                     file_path = Path(self.storage.download_dir) / filename
@@ -551,7 +557,15 @@ class BrowserController:
                     with open(file_path, "wb") as f:
                         _ = f.write(file_bytes)
 
-                if not self.storage.captures_browser_downloads:
+                # Raw URLs are fetched and written by the controller itself; no
+                # browser download event is emitted for an out-of-band collector
+                # to capture. Native click downloads do emit such an event, so a
+                # collector-backed storage must remain the sole ingester there to
+                # avoid creating duplicate catalog entries.
+                if _should_persist_download(
+                    manually_fetched=manually_fetched,
+                    captures_browser_downloads=self.storage.captures_browser_downloads,
+                ):
                     res = await self.storage.set_file(str(file_path))
                     if not res:
                         raise FailedToDownloadFileError()

--- a/tests/browser/test_controller_download.py
+++ b/tests/browser/test_controller_download.py
@@ -8,6 +8,7 @@ from notte_browser.controller import (
     _evaluate_blob_expression,
     _main_world_evaluate,
     _resolve_locator_frame,
+    _should_persist_download,
 )
 from notte_browser.playwright_async_api import CDPSession, Frame, Locator
 
@@ -62,3 +63,19 @@ def test_blob_capture_hook_can_release_retained_blobs() -> None:
     assert "clear: () => blobs.clear()" in _BLOB_CAPTURE_HOOK
     assert "URL.createObjectURL = origCreate" in _BLOB_CAPTURE_HOOK
     assert _BLOB_CAPTURE_DISPOSE == "window.__notte_blob_capture?.dispose?.()"
+
+
+@pytest.mark.parametrize("captures_browser_downloads", [False, True])
+def test_controller_persists_manually_fetched_raw_files(captures_browser_downloads: bool) -> None:
+    assert _should_persist_download(
+        manually_fetched=True,
+        captures_browser_downloads=captures_browser_downloads,
+    )
+
+
+def test_collector_owns_native_browser_download_persistence() -> None:
+    assert not _should_persist_download(manually_fetched=False, captures_browser_downloads=True)
+
+
+def test_controller_persists_native_download_without_collector() -> None:
+    assert _should_persist_download(manually_fetched=False, captures_browser_downloads=False)

--- a/tests/integration/sdk/file_storage/test_download.py
+++ b/tests/integration/sdk/file_storage/test_download.py
@@ -1,4 +1,5 @@
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -6,8 +7,9 @@ from dotenv import load_dotenv
 from notte_browser.errors import NoStorageObjectProvidedError
 from notte_core.actions import DownloadFileAction
 from notte_sdk import NotteClient
+from notte_sdk.endpoints.files import RemoteFileStorage
 from notte_sdk.errors import NotteAPIError
-from notte_sdk.types import FileSource
+from notte_sdk.types import FileSource, SessionFile
 from pydantic import BaseModel, Field
 
 import notte
@@ -40,6 +42,18 @@ class FixtureDownloadCase(BaseModel):
 
 def _local_bytes(name: str) -> bytes:
     return (DATA_DIR / name).read_bytes()
+
+
+def _wait_for_download(storage: RemoteFileStorage, filename_suffix: str, timeout: float = 10) -> list[SessionFile]:
+    deadline = time.monotonic() + timeout
+    files = []
+    while time.monotonic() < deadline:
+        files = storage.list(FileSource.SESSION_DOWNLOAD, limit=1000).files
+        matching = [file for file in files if file.filename.endswith(filename_suffix)]
+        if matching:
+            return matching
+        time.sleep(0.25)
+    return []
 
 
 fixture_download_cases = [
@@ -107,16 +121,12 @@ def test_download_against_local_fixture(case: FixtureDownloadCase):
         _ = session.execute(type="download_file", selector=case.selector)
 
         try:
-            downloaded = storage.list(FileSource.SESSION_DOWNLOAD, limit=1000).files
+            matching = _wait_for_download(storage, case.expected_filename_suffix)
         except NotteAPIError as exc:
             if exc.status_code == 404:
                 pytest.skip("Session-file API is not deployed to the integration environment yet")
             raise
-        names = [f.filename for f in downloaded]
-        matching = [f for f in downloaded if f.filename.endswith(case.expected_filename_suffix)]
-        assert len(matching) == 1, (
-            f"expected exactly one file ending with {case.expected_filename_suffix!r}, got {names}"
-        )
+        assert len(matching) == 1, f"expected exactly one file ending with {case.expected_filename_suffix!r}"
         stored = matching[0]
 
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/integration/sdk/file_storage/test_readonly_robust.py
+++ b/tests/integration/sdk/file_storage/test_readonly_robust.py
@@ -1,4 +1,3 @@
-import asyncio
 import builtins
 import contextlib
 import os
@@ -12,8 +11,19 @@ import pytest
 os.environ["DISABLE_TELEMETRY"] = "true"
 
 from notte_sdk import NotteClient
+from notte_sdk.endpoints.files import RemoteFileStorage
 from notte_sdk.errors import NotteAPIError
-from notte_sdk.types import FileSource
+from notte_sdk.types import FileSource, SessionFile
+
+
+def _wait_for_download(storage: RemoteFileStorage, timeout: float = 10) -> SessionFile:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        files = storage.list(FileSource.SESSION_DOWNLOAD, limit=1000).files
+        if files:
+            return files[0]
+        time.sleep(0.25)
+    pytest.fail("session download did not appear before timeout")
 
 
 @contextlib.contextmanager
@@ -118,12 +128,12 @@ def test_download_file_action_is_strictly_readonly():
             # This can trigger either "Filesystem modification denied" (mkdir) or "Write access denied" (open)
             with pytest.raises(PermissionError, match="Filesystem modification denied|Write access denied"):
                 try:
-                    files = storage.list(FileSource.SESSION_DOWNLOAD, limit=1000).files
+                    file = _wait_for_download(storage)
                 except NotteAPIError as exc:
                     if exc.status_code == 404:
                         pytest.skip("Session-file API is not deployed to the integration environment yet")
                     raise
-                _ = asyncio.run(storage.get_file(files[0].filename))
+                _ = storage.download(file.id)
 
         except PermissionError as e:
             pytest.fail(f"Read-only violation detected: {e}")


### PR DESCRIPTION
## Summary
- always persist raw files fetched by `window.download_file()` even when native browser downloads are captured out of band
- keep collector-backed native downloads single-owner to avoid duplicate catalog entries
- poll boundedly for asynchronous native download ingestion in integration tests
- use ID-based session download retrieval in the readonly test

## Validation
- `uv run pytest tests/browser/test_controller_download.py tests/sdk/test_file_storage.py -q` (17 passed)
- `uv run ruff check ...`
- `uv run basedpyright ...` (0 errors)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791036025&installation_model_id=8247&pr_number=939&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F939&signature=3ba44ed81d9a10fa665d635d8fd999d1f2e0d01962cb5dc5d736583ebe10b9eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download handling to prevent duplicate file ingestion when the browser natively captures downloads.
  - Ensured manually fetched files and native downloads without browser capture are persisted correctly.

- **Tests**
  - Added coverage for download persistence scenarios.
  - Improved integration tests to reliably wait for downloaded files before verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->