### PR TITLE
test: pin proxies=false on remote sessions in the test suite

### DIFF
--- a/tests/integration/sdk/file_storage/test_download.py
+++ b/tests/integration/sdk/file_storage/test_download.py
@@ -116,7 +116,7 @@ def test_download_against_local_fixture(case: FixtureDownloadCase):
     notte = NotteClient()
     storage = notte.FileStorage()
 
-    with notte.Session(storage=storage) as session:
+    with notte.Session(proxies=False, storage=storage) as session:
         _ = session.execute(type="goto", url=case.url)
         _ = session.execute(type="download_file", selector=case.selector)
 

--- a/tests/integration/sdk/file_storage/test_readonly_robust.py
+++ b/tests/integration/sdk/file_storage/test_readonly_robust.py
@@ -115,7 +115,7 @@ def test_download_file_action_is_strictly_readonly():
             # ----------------------------------------------------------------
 
             # Mock the session start and execute methods to avoid network calls
-            with client.Session(storage=storage, open_viewer=False) as session:
+            with client.Session(proxies=False, storage=storage, open_viewer=False) as session:
                 _ = session.execute(type="goto", url="https://arxiv.org/abs/1706.03762")
                 _ = session.execute(type="click", selector='internal:role=link[name="View PDF"i]')
                 time.sleep(5)  # reduced sleep for test speed

--- a/tests/integration/sdk/file_storage/test_upload.py
+++ b/tests/integration/sdk/file_storage/test_upload.py
@@ -57,7 +57,7 @@ def test_upload_against_local_fixture(case: FixtureUploadCase):
     notte = NotteClient()
     storage = notte.FileStorage()
 
-    with notte.Session(storage=storage) as session:
+    with notte.Session(proxies=False, storage=storage) as session:
         try:
             uploaded = storage.upload(str(DATA_DIR / case.file_name))
         except NotteAPIError as exc:

--- a/tests/integration/sdk/test_agent.py
+++ b/tests/integration/sdk/test_agent.py
@@ -8,7 +8,7 @@ import notte
 def test_start_stop_agent():
     _ = load_dotenv()
     notte = NotteClient()
-    with notte.Session() as session:
+    with notte.Session(proxies=False) as session:
         agent = notte.Agent(session=session, max_steps=10)
         _ = agent.start(task="Go to google image and dom scrool cat memes")
         resp = agent.status()
@@ -22,7 +22,7 @@ def test_start_stop_agent():
 def test_agent_ff():
     _ = load_dotenv()
     notte = NotteClient()
-    with notte.Session(browser_type="chrome") as session:
+    with notte.Session(proxies=False, browser_type="chrome") as session:
         agent = notte.Agent(session=session, max_steps=3)
         _ = agent.run(task="Go to google image and find a dog picture")
 
@@ -32,7 +32,7 @@ def test_agent_gemini_form_fill_no_null_fields():
     """Gemini should only fill requested fields, not all fields with null."""
     _ = load_dotenv()
     client = NotteClient()
-    with client.Session() as session:
+    with client.Session(proxies=False) as session:
         agent = client.Agent(session=session, max_steps=3, reasoning_model="vertex_ai/gemini-2.5-flash")
         response = agent.run(
             task="Ignore the web page. Simply return a form fill action with email='lucas@notte.cc' and password='123456'. Stop immediately after this",
@@ -64,7 +64,7 @@ def test_local_agent_gemini_form_fill_no_null_fields():
 def test_start_agent_with_gemini_reasoning():
     _ = load_dotenv()
     notte = NotteClient()
-    with notte.Session() as session:
+    with notte.Session(proxies=False) as session:
         agent = notte.Agent(session=session, reasoning_model="gemini/gemini-2.5-flash", max_steps=3)
         _ = agent.run(task="Go notte.cc and describe the page")
     resp = agent.status()

--- a/tests/integration/sdk/test_agent_fallback.py
+++ b/tests/integration/sdk/test_agent_fallback.py
@@ -9,7 +9,7 @@ _ = load_dotenv()
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_agent_fallback():
     client = NotteClient()
-    with client.Session(open_viewer=False) as session:
+    with client.Session(proxies=False, open_viewer=False) as session:
         _ = session.execute({"type": "goto", "url": "https://shop.notte.cc/"})
         _ = session.observe()
         # close modal if it appears
@@ -52,7 +52,7 @@ def test_agent_fallback():
 
 def test_agent_fallback_scrape_should_raise_error():
     client = NotteClient()
-    with client.Session(open_viewer=False) as session:
+    with client.Session(proxies=False, open_viewer=False) as session:
         _ = session.execute({"type": "goto", "url": "https://shop.notte.cc/"})
 
         with pytest.raises(ValueError):

--- a/tests/integration/sdk/test_cookies.py
+++ b/tests/integration/sdk/test_cookies.py
@@ -36,7 +36,7 @@ def test_set_cookies(cookies: list[CookieDict]):
             json.dump(cookies, f)
 
         # create a new session
-        with notte.Session(timeout_minutes=1) as session:
+        with notte.Session(proxies=False, timeout_minutes=1) as session:
             _ = session.set_cookies(cookie_file=str(cookie_path))
 
 
@@ -45,7 +45,7 @@ def test_get_cookies():
     notte = NotteClient()
 
     # create a new session
-    with notte.Session(timeout_minutes=1) as session:
+    with notte.Session(proxies=False, timeout_minutes=1) as session:
         _ = session.execute(type="goto", value="https://www.ecosia.org")
         _ = session.observe()
         resp = session.get_cookies()
@@ -63,7 +63,7 @@ def test_get_set_cookies(cookies: list[CookieDict]):
             json.dump(cookies, f)
 
         # create a new session
-        with notte.Session(timeout_minutes=1) as session:
+        with notte.Session(proxies=False, timeout_minutes=1) as session:
             _ = session.set_cookies(cookie_file=str(cookie_path))
 
             resp = session.get_cookies()

--- a/tests/integration/sdk/test_error_serialization.py
+++ b/tests/integration/sdk/test_error_serialization.py
@@ -13,7 +13,7 @@ from notte_sdk.client import NotteClient
 
 def test_failed_action_rehydrates_concrete_exception_over_the_wire():
     client = NotteClient()
-    with client.Session(open_viewer=False) as page:
+    with client.Session(proxies=False, open_viewer=False) as page:
         _ = page.execute(type="goto", value="https://www.example.com")
         _ = page.observe(perception_type="fast")
 

--- a/tests/integration/sdk/test_interaction.py
+++ b/tests/integration/sdk/test_interaction.py
@@ -8,7 +8,7 @@ from notte_sdk.client import NotteClient
 async def test_sdk_special_action_validation():
     client = NotteClient()
     """Test validation of special action parameters"""
-    with client.Session(open_viewer=False) as page:
+    with client.Session(proxies=False, open_viewer=False) as page:
         _ = page.execute(type="goto", value="https://github.com/")
         _ = page.observe(perception_type="fast")
         # Test S1 requires URL parameter

--- a/tests/integration/sdk/test_personas.py
+++ b/tests/integration/sdk/test_personas.py
@@ -59,7 +59,7 @@ def test_persona_with_vault_in_remote_agent():
 
     client = NotteClient()
     # Create a new persona with vault
-    with client.Persona(create_vault=True) as persona, client.Session(open_viewer=False) as session:
+    with client.Persona(create_vault=True) as persona, client.Session(proxies=False, open_viewer=False) as session:
         # Add credentials to the persona's vault
         with pytest.raises(NotteAPIError, match="This vault can only store one email address accross all credentials"):
             _ = persona.vault.add_credentials(
@@ -321,7 +321,7 @@ def test_persona_form_filling():
 
     with client.Persona(create_vault=False, create_phone_number=False) as persona:
         with client.Session(
-            browser_type="chrome", viewport_width=1280, viewport_height=1080, open_viewer=False
+            proxies=False, browser_type="chrome", viewport_width=1280, viewport_height=1080, open_viewer=False
         ) as session:
             agent = client.Agent(
                 session=session,

--- a/tests/integration/sdk/test_profiles.py
+++ b/tests/integration/sdk/test_profiles.py
@@ -125,6 +125,7 @@ def test_session_with_profile_read_only(client: NotteClient) -> None:
     try:
         # Create session with profile in read-only mode
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": False},
             open_viewer=False,
         ) as session:
@@ -147,6 +148,7 @@ def test_session_with_profile_persist(client: NotteClient) -> None:
     try:
         # First session: persist changes
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": True},
             open_viewer=False,
         ) as session:
@@ -172,6 +174,7 @@ def test_profile_state_persists_across_sessions(client: NotteClient) -> None:
     try:
         # First session: visit a page and persist
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": True},
             open_viewer=False,
         ) as session:
@@ -182,6 +185,7 @@ def test_profile_state_persists_across_sessions(client: NotteClient) -> None:
 
         # Second session: use same profile in read-only mode
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": False},
             open_viewer=False,
         ) as session:
@@ -199,6 +203,7 @@ def test_profile_cookies_persist(client: NotteClient) -> None:
     try:
         # First session: set cookies and persist
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": True},
             open_viewer=False,
         ) as session:
@@ -209,6 +214,7 @@ def test_profile_cookies_persist(client: NotteClient) -> None:
 
         # Second session: cookies should be loaded
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": False},
             open_viewer=False,
         ) as session:
@@ -227,6 +233,7 @@ def test_profile_localstorage_persist(client: NotteClient) -> None:
     try:
         # First session: set localStorage and persist
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": True},
             open_viewer=False,
         ) as session:
@@ -239,6 +246,7 @@ def test_profile_localstorage_persist(client: NotteClient) -> None:
 
         # Second session: localStorage should be restored
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": False},
             open_viewer=False,
         ) as session:
@@ -255,6 +263,7 @@ def test_profile_sessionstorage_persist(client: NotteClient) -> None:
     try:
         # First session: set sessionStorage and persist
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": True},
             open_viewer=False,
         ) as session:
@@ -266,6 +275,7 @@ def test_profile_sessionstorage_persist(client: NotteClient) -> None:
 
         # Second session: sessionStorage should be restored
         with client.Session(
+            proxies=False,
             profile={"id": profile.profile_id, "persist": False},
             open_viewer=False,
         ) as session:

--- a/tests/integration/sdk/test_scraping.py
+++ b/tests/integration/sdk/test_scraping.py
@@ -151,7 +151,7 @@ async def test_readme_async_scraping_example():
 def test_readme_sync_scraping_example():
     _ = load_dotenv()
     client = NotteClient(api_key=os.getenv("NOTTE_API_KEY"))
-    with client.Session() as session:
+    with client.Session(proxies=False) as session:
         result = session.execute({"type": "goto", "url": "https://www.notte.cc"})
         assert result.success
         data = session.scrape()
@@ -173,7 +173,7 @@ async def test_scraping_images_only():
 async def test_scraping_structured_data():
     _ = load_dotenv()
     client = NotteClient(api_key=os.getenv("NOTTE_API_KEY"))
-    with client.Session() as session:
+    with client.Session(proxies=False) as session:
         _ = session.execute(type="goto", url="https://gymbeam.pl")
         data = session.scrape(instructions="Extract the company name")
         assert isinstance(data, dict)
@@ -198,7 +198,7 @@ class SiteUpdate(BaseModel):
 def test_scraping_structured_data_with_response_format_and_raise_on_failure_false():
     _ = load_dotenv()
     notte = NotteClient()
-    with notte.Session(browser_type="chrome", viewport_height=1080, viewport_width=1920) as page:
+    with notte.Session(proxies=False, browser_type="chrome", viewport_height=1080, viewport_width=1920) as page:
         n_articles = 10
         _ = page.execute(type="goto", url="http://stonewoodcapital.com/news/")
         result = page.scrape(

--- a/tests/integration/sdk/test_sessions.py
+++ b/tests/integration/sdk/test_sessions.py
@@ -9,7 +9,7 @@ _ = load_dotenv()
 def test_start_close_session():
     client = NotteClient()
 
-    response = client.sessions.start()
+    response = client.sessions.start(proxies=False)
     assert response.status == "active"
     response = client.sessions.stop(session_id=response.session_id)
     assert response.status == "closed"
@@ -36,7 +36,7 @@ def test_start_close_session_with_proxy():
 
 def test_start_close_session_with_viewport():
     client = NotteClient()
-    with client.Session(viewport_height=100, viewport_width=100) as session:
+    with client.Session(proxies=False, viewport_height=100, viewport_width=100) as session:
         assert session.session_id is not None
         status = session.status()
         assert status.status == "active"
@@ -58,7 +58,7 @@ def test_replay_session(session_id: str):
 @pytest.mark.parametrize("browser_type", ["chrome", "chromium"])
 def test_start_close_session_with_browser_type(browser_type: BrowserType):
     client = NotteClient()
-    with client.Session(open_viewer=False, browser_type=browser_type) as session:
+    with client.Session(proxies=False, open_viewer=False, browser_type=browser_type) as session:
         assert session.session_id is not None
         status = session.status()
         assert status.status == "active"

--- a/tests/integration/sdk/test_steps.py
+++ b/tests/integration/sdk/test_steps.py
@@ -10,7 +10,7 @@ _ = load_dotenv()
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_new_steps():
     client = NotteClient()
-    with client.Session(open_viewer=False) as session:
+    with client.Session(proxies=False, open_viewer=False) as session:
         _ = session.execute(type="goto", url="https://phantombuster.com/login")
         _ = session.observe()
 
@@ -89,7 +89,7 @@ def test_old_session_format():
 
 def test_agents_in_single_session():
     client = NotteClient()
-    with client.Session(browser_type="chrome", open_viewer=False) as session:
+    with client.Session(proxies=False, browser_type="chrome", open_viewer=False) as session:
         agent1 = client.Agent(session=session, max_steps=1)
         _ = agent1.run(task="go to linkedin", url="https://www.linkedin.com")
 

--- a/tests/integration/sdk/test_vault.py
+++ b/tests/integration/sdk/test_vault.py
@@ -138,7 +138,7 @@ def test_vault_in_remote_agent():
 
     client = NotteClient()
     # Create a new secure vault
-    with client.Vault() as vault, client.Session(open_viewer=False) as session:
+    with client.Vault() as vault, client.Session(proxies=False, open_viewer=False) as session:
         # Add your credentials securely
         _ = vault.add_credentials(
             url="https://github.com/",

--- a/tests/sdk/test_replay_frames.py
+++ b/tests/sdk/test_replay_frames.py
@@ -25,7 +25,7 @@ def test_sdk_screenshots():
             assert decoded == "JFIF"
 
     ## remote
-    with client.Session(open_viewer=False) as session:
+    with client.Session(proxies=False, open_viewer=False) as session:
         _ = session.execute(dict(type="goto", url="https://linkedin.com"))
         obs = session.observe()
 

--- a/tests/sdk/test_validator.py
+++ b/tests/sdk/test_validator.py
@@ -19,7 +19,7 @@ def test_validator_message_received():
 
     client = NotteClient()
 
-    with client.Session() as session:
+    with client.Session(proxies=False) as session:
         agent = client.Agent(session=session, max_steps=3)
         # Ask for invalid price first (-1), expect agent to recover with valid price (2)
         valid = agent.run(


### PR DESCRIPTION
## Why

`SessionStartRequest.proxies` now defaults to `true` (#914). The pytest suite runs against the live API with a real key, so every remote session it starts without an explicit value now goes out over a proxy - paid bandwidth on every run, and a behaviour change for tests that never asked for one.

## What

`proxies=False` on the 37 remote session starts that relied on the default, across `tests/integration/sdk/` and two live tests in `tests/sdk/`.

Deliberately untouched:

- **Local sessions.** `notte.Session()` resolves to `notte_browser.session.NotteSession`, and `LocalSessionStartRequest` already defaults `proxies` to `false`. Note that several files rebind `notte = NotteClient()` inside the test function, which makes those calls remote - those are included.
- **`tests/sdk/test_client.py`.** Every start there is behind `patch("requests.post")`, and `test_proxies_default_to_enabled_but_can_be_disabled` asserts the new default.
- **Sessions that exercise proxies on purpose** keep their explicit values (`test_sessions.py::test_start_close_session_with_proxy`, `test_proxy_settings.py`).

## Two gaps left open

Both need a product call rather than a test edit, so they are not in this PR:

1. **`NotteClient.scrape`** starts its own session (`self.Session(open_viewer=False, perception_type="fast")`) and `ScrapeRequestDict` carries no session fields, so a caller cannot opt out. The four `client.scrape(...)` calls in `test_scraping.py` are still proxied, as is every user calling `scrape`.
2. **Docs snippets.** `docs/src/testers/*.py` is the source that generates the published `.mdx`, and the third `snippets-python-tests` job executes them live. Pinning `proxies=False` there would put it in the public docs, which may or may not be what you want the docs to show now that the default has changed.

## Verification

`ruff format --check` and `ruff check` clean. `basedpyright` reports no new findings - the errors it does report are unresolved imports from a stale local venv and reproduce on unmodified files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791113795&installation_model_id=8247&pr_number=942&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F942&signature=7f29c10f70b9370ca3c253981f84b445a54d1465b407fd9481ef25aa12814876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated SDK integration and validation tests to run sessions without proxy handling.
  - Improved test consistency across file storage, agents, cookies, profiles, scraping, sessions, vaults, and other SDK workflows.
  - Preserved existing assertions and behavior while making test environments more deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->