### PR TITLE
docs: refresh generated llms.txt

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -301,7 +301,10 @@ The SDK docs below are for generated-code editing and reference. They are not th
 
 ## Sessions
 
+- [DELETE Delete Session File](https://docs.notte.cc/api-reference/sessions/delete-session-file.md)
+- [GET Download Session File](https://docs.notte.cc/api-reference/sessions/download-session-file.md)
 - [GET Get Session Script](https://docs.notte.cc/api-reference/sessions/get-session-script.md)
+- [GET List Session Files](https://docs.notte.cc/api-reference/sessions/list-session-files.md)
 - [GET List Sessions](https://docs.notte.cc/api-reference/sessions/list-sessions.md)
 - [POST Page Execute](https://docs.notte.cc/api-reference/sessions/page-execute.md)
 - [POST Page Observe](https://docs.notte.cc/api-reference/sessions/page-observe.md)
@@ -316,15 +319,7 @@ The SDK docs below are for generated-code editing and reference. They are not th
 - [POST Session Start](https://docs.notte.cc/api-reference/sessions/session-start.md)
 - [GET Session Status](https://docs.notte.cc/api-reference/sessions/session-status.md)
 - [DELETE Session Stop](https://docs.notte.cc/api-reference/sessions/session-stop.md)
-
-## Storage
-
-- [GET File Download](https://docs.notte.cc/api-reference/storage/file-download.md)
-- [GET File Download Uploaded File](https://docs.notte.cc/api-reference/storage/file-download-uploaded-file.md)
-- [GET File List Downloads](https://docs.notte.cc/api-reference/storage/file-list-downloads.md)
-- [GET File List Uploads](https://docs.notte.cc/api-reference/storage/file-list-uploads.md)
-- [POST File Upload](https://docs.notte.cc/api-reference/storage/file-upload.md)
-- [POST File Upload Downloaded File](https://docs.notte.cc/api-reference/storage/file-upload-downloaded-file.md)
+- [POST Upload Session File](https://docs.notte.cc/api-reference/sessions/upload-session-file.md)
 
 ## Usage
 


### PR DESCRIPTION
Automated daily regeneration of `docs/src/llms.txt` via `make docs-llms`, which builds the API section from the live OpenAPI spec.

Updated 2026-09-05 (UTC): +4 -9

No hand edits. The run fails instead of committing if the spec cannot be fetched or comes back incomplete.

Opened by .github/workflows/refresh-llms.yml. Merges automatically once the required checks pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791178555&installation_model_id=8247&pr_number=945&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F945&signature=ba23db9275ded73c778cbc316560fe7307f8fef0b6276a7d81bbce91ef5a013e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->