### PR TITLE
Add wait_until to the goto action

### DIFF
--- a/docs/src/features/sessions/browser-controls.mdx
+++ b/docs/src/features/sessions/browser-controls.mdx
@@ -50,6 +50,7 @@ Navigate to a URL.
 
 **Parameters:**
 - `url` (str): The URL to navigate to
+- `wait_until` (str, optional): Navigation event to wait for: `load` (default), `domcontentloaded`, `commit` or `networkidle`. `commit` and `domcontentloaded` skip the post-load settle wait, which makes them the cheap choice when the page is only needed as an origin for `session.fetch()`
 
 **Use for:** Opening pages, navigating between pages
 

--- a/docs/src/sdk-reference/misc/gotoaction.mdx
+++ b/docs/src/sdk-reference/misc/gotoaction.mdx
@@ -6,9 +6,17 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 <AgentMdNotice />
 
+`wait_until` picks the navigation event to wait for, as in Playwright: `load`
+(the default) waits for the page and its subresources, `domcontentloaded` for
+the HTML to be parsed, `commit` for the first response bytes, `networkidle`
+for the network to go quiet. `commit` and `domcontentloaded` also skip the
+settle wait that follows a load, which makes them the cheap choice when the
+page is only needed as an origin for `session.fetch()`.
+
 **Example:**
 ```python
 session.execute(type="goto", url="https://www.google.com")
+session.execute(type="goto", url="https://www.google.com", wait_until="commit")
 ```
 
 ## Fields
@@ -23,6 +31,9 @@ session.execute(type="goto", url="https://www.google.com")
 </ParamField>
 
 <ParamField path="url" type="str" required>
+</ParamField>
+
+<ParamField path="wait_until" type="Literal['commit', 'domcontentloaded', 'load', 'networkidle'] | None">
 </ParamField>
 
 

--- a/packages/notte-browser/src/notte_browser/controller.py
+++ b/packages/notte-browser/src/notte_browser/controller.py
@@ -216,8 +216,8 @@ class BrowserController:
 
             case CaptchaSolveAction(captcha_type=_):
                 _ = await CaptchaHandler.handle_captchas(window, action)
-            case GotoAction(url=url):
-                await window.goto(url)
+            case GotoAction(url=url, wait_until=wait_until):
+                await window.goto(url, wait_until=wait_until)
             case GotoNewTabAction(url=url):
                 new_page = await window.page.context.new_page()
                 window.page = new_page

--- a/packages/notte-browser/src/notte_browser/window.py
+++ b/packages/notte-browser/src/notte_browser/window.py
@@ -48,6 +48,8 @@ from notte_browser.errors import (
 )
 from notte_browser.playwright_async_api import CDPSession, Locator, Page, Response
 
+WaitUntil = Literal["commit", "domcontentloaded", "load", "networkidle"]
+
 
 class BrowserWindowOptions(BaseModel):
     headless: bool
@@ -584,7 +586,11 @@ class BrowserWindow(BaseModel):
             return await self.snapshot(screenshot=screenshot, retries=retries - 1, selector=selector)
 
     async def goto_and_wait(
-        self, url: str | None = None, tries: int = 3, operation: Literal["back", "forward"] | None = None
+        self,
+        url: str | None = None,
+        tries: int = 3,
+        operation: Literal["back", "forward"] | None = None,
+        wait_until: WaitUntil | None = None,
     ) -> None:
         def is_default_page():
             return self.page.url == "about:blank" and not url == "about:blank"
@@ -602,7 +608,7 @@ class BrowserWindow(BaseModel):
                 match operation:
                     case None:
                         assert url is not None, "URL is required for goto"
-                        _ = await self.page.goto(url, timeout=config.timeout_goto_ms)
+                        _ = await self.page.goto(url, timeout=config.timeout_goto_ms, wait_until=wait_until)
                     case "back":
                         _ = await self.page.go_back(timeout=config.timeout_goto_ms)
                     case "forward":
@@ -628,8 +634,9 @@ class BrowserWindow(BaseModel):
                 raise PageLoadingError(url=url or self.page.url) from e
 
             # extra wait to make sure that css animations can start
-            # to make extra element visible
-            await self.short_wait()
+            # to make extra element visible; pointless before the DOM exists
+            if wait_until not in ("commit", "domcontentloaded"):
+                await self.short_wait()
 
             if not is_default_page() or tries < 0:
                 break
@@ -637,7 +644,7 @@ class BrowserWindow(BaseModel):
         if is_default_page():
             raise PageLoadingError(url=url or self.page.url)
 
-    async def goto(self, url: str, tries: int = 3) -> None:
+    async def goto(self, url: str, tries: int = 3, wait_until: WaitUntil | None = None) -> None:
         if url == self.page.url:
             return
         prefixes = ("http://", "https://")
@@ -649,7 +656,7 @@ class BrowserWindow(BaseModel):
         if not is_valid_url(url, check_reachability=False):
             raise InvalidURLError(url=url)
 
-        await self.goto_and_wait(url=url, tries=tries, operation=None)
+        await self.goto_and_wait(url=url, tries=tries, operation=None, wait_until=wait_until)
 
     async def set_cookies(self, cookies: list[CookieDict] | None = None, cookie_path: str | Path | None = None) -> None:
         if cookies is None and cookie_path is not None:

--- a/packages/notte-core/src/notte_core/actions/actions.py
+++ b/packages/notte-core/src/notte_core/actions/actions.py
@@ -285,15 +285,24 @@ class GotoAction(BrowserAction):
     """
     Goto to a URL (in current tab).
 
+    `wait_until` picks the navigation event to wait for, as in Playwright: `load`
+    (the default) waits for the page and its subresources, `domcontentloaded` for
+    the HTML to be parsed, `commit` for the first response bytes, `networkidle`
+    for the network to go quiet. `commit` and `domcontentloaded` also skip the
+    settle wait that follows a load, which makes them the cheap choice when the
+    page is only needed as an origin for `session.fetch()`.
+
     **Example:**
     ```python
     session.execute(type="goto", url="https://www.google.com")
+    session.execute(type="goto", url="https://www.google.com", wait_until="commit")
     ```
     """
 
     type: Literal["goto"] = "goto"  # pyright: ignore [reportIncompatibleVariableOverride]
     description: str = "Goto to a URL (in current tab)"
     url: str
+    wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] | None = None
 
     # Allow 'id' to be a field name
     model_config = {"extra": "forbid", "protected_namespaces": ()}  # type: ignore[reportUnknownMemberType]

--- a/packages/notte-core/src/notte_core/actions/actions.py
+++ b/packages/notte-core/src/notte_core/actions/actions.py
@@ -309,6 +309,12 @@ class GotoAction(BrowserAction):
 
     __pydantic_fields_set__ = {"url"}  # type: ignore[reportUnknownMemberType]
 
+    @classmethod
+    @override
+    def non_agent_fields(cls) -> set[str]:
+        # a latency knob for scripts, not a decision the agent should be making
+        return super().non_agent_fields() | {"wait_until"}
+
     @override
     def execution_message(self) -> str:
         return f"Navigated to '{self.url}' in current tab"

--- a/packages/notte-core/src/notte_core/actions/actions.py
+++ b/packages/notte-core/src/notte_core/actions/actions.py
@@ -6,9 +6,9 @@ import re
 import warnings
 from abc import ABCMeta, abstractmethod
 from functools import reduce
-from typing import Annotated, Any, ClassVar, Literal, get_args
+from typing import Annotated, Any, ClassVar, Literal, cast, get_args
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, field_validator, model_serializer, model_validator
 from typing_extensions import override
 
 from notte_core.browser.dom_tree import NodeSelectors
@@ -314,6 +314,20 @@ class GotoAction(BrowserAction):
     def non_agent_fields(cls) -> set[str]:
         # a latency knob for scripts, not a decision the agent should be making
         return super().non_agent_fields() | {"wait_until"}
+
+    @model_serializer(mode="wrap")
+    def _omit_unset_wait_until(self, handler: SerializerFunctionWrapHandler) -> Any:
+        # Actions are echoed back in API responses and every action model forbids
+        # unknown fields, so a `"wait_until": null` from a newer API would make an
+        # older SDK reject the whole response. Leave the key out unless it is set;
+        # the wire shape of a plain goto then stays exactly what it was.
+        data = handler(self)
+        if not isinstance(data, dict):
+            return data
+        typed = cast(dict[str, Any], data)
+        if typed.get("wait_until") is None:
+            _ = typed.pop("wait_until", None)
+        return typed
 
     @override
     def execution_message(self) -> str:

--- a/packages/notte-core/src/notte_core/actions/typedicts.py
+++ b/packages/notte-core/src/notte_core/actions/typedicts.py
@@ -116,6 +116,7 @@ class FormFillActionDict(TypedDict, total=False):
 class GotoActionDict(TypedDict):
     type: Literal["goto"]
     url: str
+    wait_until: NotRequired[Literal["commit", "domcontentloaded", "load", "networkidle"]]
 
 
 class GotoNewTabActionDict(TypedDict):

--- a/tests/browser/test_goto_settle_wait.py
+++ b/tests/browser/test_goto_settle_wait.py
@@ -1,0 +1,67 @@
+"""`goto_and_wait` skips the post-load settle wait when the caller asked for `commit` or `domcontentloaded`."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from notte_browser.window import BrowserWindow
+
+
+class FakePage:
+    def __init__(self) -> None:
+        self.url = "about:blank"
+        self.goto_calls: list[dict[str, Any]] = []
+
+    def once(self, event: str, handler: Any) -> None:
+        pass
+
+    def on(self, event: str, handler: Any) -> None:
+        pass
+
+    def set_default_timeout(self, timeout: float) -> None:
+        pass
+
+    async def goto(self, url: str, **kwargs: Any) -> None:
+        self.goto_calls.append({"url": url, **kwargs})
+        self.url = url
+
+
+def window_with(page: FakePage, monkeypatch: pytest.MonkeyPatch) -> tuple[BrowserWindow, list[str]]:
+    waits: list[str] = []
+
+    async def short_wait(self: BrowserWindow) -> None:
+        waits.append("short")
+
+    async def long_wait(self: BrowserWindow) -> None:
+        waits.append("long")
+
+    monkeypatch.setattr(BrowserWindow, "short_wait", short_wait)
+    monkeypatch.setattr(BrowserWindow, "long_wait", long_wait)
+    # the real property falls back to other tabs when the page is closed; only navigation is under test
+    monkeypatch.setattr(BrowserWindow, "page", property(lambda self: self.resource.page))
+    window = BrowserWindow.model_construct(resource=SimpleNamespace(page=page))
+    return window, waits
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wait_until", [None, "load", "networkidle"])
+async def test_full_loads_keep_the_settle_wait(monkeypatch: pytest.MonkeyPatch, wait_until: str | None) -> None:
+    page = FakePage()
+    window, waits = window_with(page, monkeypatch)
+
+    await window.goto_and_wait(url="https://example.com/", wait_until=wait_until)  # type: ignore[arg-type]
+
+    assert page.goto_calls[0]["wait_until"] == wait_until
+    assert waits == ["short"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wait_until", ["commit", "domcontentloaded"])
+async def test_cheap_loads_skip_the_settle_wait(monkeypatch: pytest.MonkeyPatch, wait_until: str) -> None:
+    page = FakePage()
+    window, waits = window_with(page, monkeypatch)
+
+    await window.goto_and_wait(url="https://example.com/", wait_until=wait_until)  # type: ignore[arg-type]
+
+    assert page.goto_calls[0]["wait_until"] == wait_until
+    assert waits == []

--- a/tests/mock/mock_browser.py
+++ b/tests/mock/mock_browser.py
@@ -166,9 +166,10 @@ class MockBrowserDriver(AsyncResource):
         """Mock browser screenshot"""
         return Observation.empty().screenshot.raw
 
-    async def goto(self, url: str) -> BrowserSnapshot:
+    async def goto(self, url: str, wait_until: str | None = None) -> BrowserSnapshot:
         """Mock navigation action"""
         self.url = url
+        self.wait_until = wait_until
         snapshot = BrowserSnapshot(
             metadata=SnapshotMetadata(
                 title="mock",

--- a/tests/test_goto_wait_until.py
+++ b/tests/test_goto_wait_until.py
@@ -1,18 +1,49 @@
 """`goto` accepts a `wait_until` navigation event and omits it from the wire when unset."""
 
+import datetime as dt
+from typing import Literal
+
 import pytest
 from notte_browser.session import NotteSession
 from notte_core.actions import GotoAction
 from notte_core.actions.typedicts import action_dict_to_base_action
-from pydantic import ValidationError
+from notte_core.browser.observation import ExecutionResult
+from pydantic import BaseModel, ValidationError
 
 
 def test_goto_action_defaults_to_no_wait_until_and_omits_it_when_dumped() -> None:
     action = GotoAction(url="https://example.com")
 
     assert action.wait_until is None
-    # older API builds reject unknown fields, so an unset value must not be sent
+    # older API builds reject unknown fields, so an unset value must not be sent,
+    # and not only under exclude_none: API responses are dumped with defaults included
     assert "wait_until" not in action.model_dump(exclude_none=True)
+    assert "wait_until" not in action.model_dump()
+    assert "wait_until" not in action.model_dump(mode="json", by_alias=True)
+    assert GotoAction(url="https://example.com", wait_until="commit").model_dump()["wait_until"] == "commit"
+
+
+class _GotoBeforeWaitUntil(BaseModel):
+    """The goto action as every SDK released before this field parses it."""
+
+    type: Literal["goto"] = "goto"
+    url: str
+    model_config = {"extra": "forbid"}
+
+
+def test_an_echoed_goto_still_parses_on_an_older_sdk() -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+    result = ExecutionResult(
+        action=GotoAction(url="https://example.com"), success=True, message="ok", started_at=now, ended_at=now
+    )
+
+    # what FastAPI serialises for the response model: defaults included, nothing excluded
+    echoed = result.model_dump(mode="json", by_alias=True)["action"]
+
+    parsed = _GotoBeforeWaitUntil.model_validate(
+        {k: v for k, v in echoed.items() if k in ("type", "url", "wait_until")}
+    )
+    assert parsed.url == "https://example.com"
 
 
 def test_goto_action_accepts_the_playwright_events_only() -> None:

--- a/tests/test_goto_wait_until.py
+++ b/tests/test_goto_wait_until.py
@@ -27,6 +27,12 @@ def test_goto_action_accepts_the_playwright_events_only() -> None:
         _ = GotoAction(url="https://example.com", wait_until="eventually")  # type: ignore[arg-type]
 
 
+def test_wait_until_stays_out_of_the_agent_schema() -> None:
+    # the agent prompt renders each action's schema minus non_agent_fields; keep the knob out of it
+    assert "wait_until" in GotoAction.non_agent_fields()
+    assert "wait_until" not in GotoAction(url="https://example.com", wait_until="commit").model_dump_agent()
+
+
 @pytest.mark.asyncio
 async def test_goto_with_commit_is_enough_for_a_same_origin_fetch() -> None:
     async with NotteSession(headless=True) as session:

--- a/tests/test_goto_wait_until.py
+++ b/tests/test_goto_wait_until.py
@@ -1,0 +1,39 @@
+"""`goto` accepts a `wait_until` navigation event and omits it from the wire when unset."""
+
+import pytest
+from notte_browser.session import NotteSession
+from notte_core.actions import GotoAction
+from notte_core.actions.typedicts import action_dict_to_base_action
+from pydantic import ValidationError
+
+
+def test_goto_action_defaults_to_no_wait_until_and_omits_it_when_dumped() -> None:
+    action = GotoAction(url="https://example.com")
+
+    assert action.wait_until is None
+    # older API builds reject unknown fields, so an unset value must not be sent
+    assert "wait_until" not in action.model_dump(exclude_none=True)
+
+
+def test_goto_action_accepts_the_playwright_events_only() -> None:
+    assert GotoAction(url="https://example.com", wait_until="commit").wait_until == "commit"
+    assert (
+        action_dict_to_base_action(
+            {"type": "goto", "url": "https://example.com", "wait_until": "domcontentloaded"}
+        ).wait_until
+        == "domcontentloaded"
+    )  # type: ignore[attr-defined]
+    with pytest.raises(ValidationError):
+        _ = GotoAction(url="https://example.com", wait_until="eventually")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_goto_with_commit_is_enough_for_a_same_origin_fetch() -> None:
+    async with NotteSession(headless=True) as session:
+        result = await session.aexecute(type="goto", url="https://www.example.com/", wait_until="commit")
+        assert result.success
+
+        response = await session.afetch("/")
+
+        assert response.status_code == 200
+        assert "Example Domain" in response.text


### PR DESCRIPTION
`goto` always waited for Playwright's `load` event and then a short settle wait, even when the page is only needed as an origin for `session.fetch()`. This adds an optional `wait_until` on the action with the Playwright vocabulary: `load` (default, unchanged), `domcontentloaded`, `commit`, `networkidle`.

```python
session.execute(type="goto", url="https://www.example.com/", wait_until="commit")
data = session.fetch("/api/items").json()
```

- `commit` and `domcontentloaded` also skip the post-load settle wait, since there is nothing to let animate yet.
- Unset values are not sent on the wire, so existing API builds keep accepting the action.
- Measured through a session's CDP on real sites, `commit` cuts the navigation from 2.5 to 6 s down to about 1.3 s; the saving is largest on heavy pages.

Tests: model validation and wire omission, plus a headless browser test that `goto` with `commit` followed by a same-origin `fetch` returns the page.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791279780&installation_model_id=8247&pr_number=946&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F946&signature=0a0d780ac8c49492e0cefd106ab94feb1ac308e4da2bcd773780e5563421dc3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional navigation wait setting for browser navigation actions.
  * Supports waiting for `commit`, `domcontentloaded`, `load`, or `networkidle` events.
  * Added guidance and examples for choosing navigation timing, including faster options before subsequent fetches.

* **Bug Fixes**
  * Improved handling of early navigation states by avoiding unnecessary settling delays.

* **Tests**
  * Added coverage for supported values, validation, defaults, serialization, and same-origin fetches after navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->