### PR TITLE
fix(browser): avoid retaining screenshots after evaluate_js

### DIFF
--- a/packages/notte-browser/src/notte_browser/session.py
+++ b/packages/notte-browser/src/notte_browser/session.py
@@ -893,8 +893,12 @@ class NotteSession(AsyncResource, SyncResource):
         )
         await self.trajectory.append(execution_result)
 
-        # add screenshot to trajectory (after the execution)
-        if self._window is not None:
+        # Add a screenshot after visual browser actions. EvaluateJsAction is a
+        # data-returning primitive (commonly used for repeated fetches), and
+        # retaining a full JPEG for every call makes session memory grow linearly
+        # even when the page never changes. Callers that need a frame after
+        # evaluate_js can still request one explicitly with ascreenshot().
+        if self._window is not None and not isinstance(resolved_action, EvaluateJsAction):
             try:
                 _ = await self.ascreenshot()
             except Exception as e:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -468,6 +468,21 @@ async def test_evaluate_js_success_path_is_unchanged(code: str, expected_markdow
         assert result.data.markdown == expected_markdown
 
 
+@pytest.mark.asyncio
+async def test_evaluate_js_does_not_retain_automatic_screenshots() -> None:
+    async with NotteSession(headless=True) as session:
+        await session.window.page.set_content("<p>hello</p>")
+
+        for _ in range(3):
+            result = await session.aexecute(type="evaluate_js", code="document.body.textContent")
+            assert result.success is True
+
+        assert list(session.trajectory.screenshots()) == []
+
+        explicit_screenshot = await session.ascreenshot()
+        assert list(session.trajectory.screenshots()) == [explicit_screenshot]
+
+
 # ============================================
 # actions that fail by returning (no exception)
 # ============================================


### PR DESCRIPTION
## Summary

- stop taking automatic trajectory screenshots after `evaluate_js`
- preserve explicit screenshots and screenshots after visual browser actions
- add a regression test covering repeated evaluations

## Why

A production memory investigation found repeated browser-side fetches through `evaluate_js` retained a full JPEG after every call. Memray attributed about 121 MB of one run's peak to screenshot validation, and the live session graph showed trajectory objects as a major retained owner. The affected marketplace function does not visually mutate the page, so these frames are redundant and make session memory grow linearly.

The API-side redundant response validation/full-payload logging fix is tracked in nottelabs/monorepo#2596.

## Test plan

- `uv run pytest tests/test_session.py -q -k 'evaluate_js_success_path_is_unchanged or evaluate_js_does_not_retain_automatic_screenshots'` (6 passed)
- `uv run ruff check packages/notte-browser/src/notte_browser/session.py tests/test_session.py`
- `uv run ruff format --check packages/notte-browser/src/notte_browser/session.py tests/test_session.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - JavaScript evaluation actions no longer automatically add screenshots to the session history.
  - Screenshots from other browser actions continue to be captured as before.
  - Explicit screenshot requests remain recorded correctly.

- **Tests**
  - Added coverage to verify screenshot behavior for repeated JavaScript evaluations and explicit screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->