### PR TITLE
fix: preserve goto action output schema

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,6 +9,10 @@ You can contribute to Notte by submitting a PR or by reporting an issue.
 3. Make your changes
 4. Submit a PR
 
+Changes to Pydantic models used by the API must follow the
+[backward-compatibility guide](backward-compatibility.md), including checks for
+both validation and serialization schemas.
+
 ## Reporting an Issue
 
 1. Check if the issue already exists

--- a/docs/backward-compatibility.md
+++ b/docs/backward-compatibility.md
@@ -1,0 +1,74 @@
+# Backward compatibility
+
+Notte models cross several independently deployed boundaries: the Python SDK,
+the hosted API, stored trajectories, and generated clients. A change that is
+valid inside one Python process can still break an older client or corrupt the
+OpenAPI contract.
+
+## Adding an optional field
+
+Prefer an optional field with a `None` default:
+
+```python
+wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] | None = None
+```
+
+Omit `None` values at the wire boundary rather than changing the model's global
+serializer:
+
+- SDK requests should use `model_dump(exclude_none=True)` or
+  `model_dump_json(exclude_none=True)`.
+- FastAPI response routes should use `response_model_exclude_none=True`.
+- Stored or manually assembled response payloads should apply the same rule
+  before they leave the service.
+
+This lets a new API return an object that older strict clients still accept.
+Sending a newly introduced field with a non-null value still requires a server
+version that supports that feature.
+
+## Keep serialization schemas concrete
+
+Pydantic uses a custom serializer's declared return type when it builds the
+serialization JSON schema. In particular, this pattern is dangerous for models
+that appear in FastAPI responses:
+
+```python
+@model_serializer(mode="wrap")
+def serialize(self, handler: SerializerFunctionWrapHandler) -> Any:
+    ...
+```
+
+The runtime JSON may look correct while the serialization schema becomes `{}`.
+FastAPI can then publish a correct `Model-Input` schema and an unconstrained
+`Model-Output` schema. Discriminated unions make this worse: generated clients
+expect every mapped object to contain the discriminator, but `{}` contains no
+fields at all.
+
+Avoid model-wide serializers for omission rules. If a custom serializer is
+unavoidable, give it an accurate output type and test the serialization schema,
+not only the runtime payload.
+
+## Required regression tests
+
+For a model used by the API, cover both schema modes:
+
+```python
+for mode in ("validation", "serialization"):
+    schema = Model.model_json_schema(mode=mode)
+    assert schema["type"] == "object"
+    assert "discriminator_field" in schema["properties"]
+```
+
+When the model belongs to a discriminated union, also inspect the generated
+FastAPI OpenAPI document and verify that its input and output component schemas
+remain concrete. Runtime serialization tests alone do not catch schema-only
+regressions.
+
+## Rollout checklist
+
+1. Add the optional model field and schema regression tests.
+2. Confirm SDK requests omit unset optional values at the HTTP boundary.
+3. Confirm API responses omit unset optional values at every public route.
+4. Update the API's pinned Notte dependency and deploy to staging.
+5. Inspect the staging OpenAPI schema and regenerate every generated client.
+6. Deploy production before relying on the new field in released clients.

--- a/packages/notte-core/src/notte_core/actions/actions.py
+++ b/packages/notte-core/src/notte_core/actions/actions.py
@@ -6,9 +6,9 @@ import re
 import warnings
 from abc import ABCMeta, abstractmethod
 from functools import reduce
-from typing import Annotated, Any, ClassVar, Literal, cast, get_args
+from typing import Annotated, Any, ClassVar, Literal, get_args
 
-from pydantic import BaseModel, Field, SerializerFunctionWrapHandler, field_validator, model_serializer, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing_extensions import override
 
 from notte_core.browser.dom_tree import NodeSelectors
@@ -314,20 +314,6 @@ class GotoAction(BrowserAction):
     def non_agent_fields(cls) -> set[str]:
         # a latency knob for scripts, not a decision the agent should be making
         return super().non_agent_fields() | {"wait_until"}
-
-    @model_serializer(mode="wrap")
-    def _omit_unset_wait_until(self, handler: SerializerFunctionWrapHandler) -> Any:
-        # Actions are echoed back in API responses and every action model forbids
-        # unknown fields, so a `"wait_until": null` from a newer API would make an
-        # older SDK reject the whole response. Leave the key out unless it is set;
-        # the wire shape of a plain goto then stays exactly what it was.
-        data = handler(self)
-        if not isinstance(data, dict):
-            return data
-        typed = cast(dict[str, Any], data)
-        if typed.get("wait_until") is None:
-            _ = typed.pop("wait_until", None)
-        return typed
 
     @override
     def execution_message(self) -> str:

--- a/tests/test_goto_wait_until.py
+++ b/tests/test_goto_wait_until.py
@@ -5,22 +5,29 @@ from typing import Literal
 
 import pytest
 from notte_browser.session import NotteSession
-from notte_core.actions import GotoAction
+from notte_core.actions import ActionUnion, GotoAction
 from notte_core.actions.typedicts import action_dict_to_base_action
 from notte_core.browser.observation import ExecutionResult
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 
-def test_goto_action_defaults_to_no_wait_until_and_omits_it_when_dumped() -> None:
+def test_goto_action_defaults_to_no_wait_until_and_wire_dump_omits_it() -> None:
     action = GotoAction(url="https://example.com")
 
     assert action.wait_until is None
-    # older API builds reject unknown fields, so an unset value must not be sent,
-    # and not only under exclude_none: API responses are dumped with defaults included
+    # SDK requests and API responses use exclude_none at their wire boundaries.
     assert "wait_until" not in action.model_dump(exclude_none=True)
-    assert "wait_until" not in action.model_dump()
-    assert "wait_until" not in action.model_dump(mode="json", by_alias=True)
     assert GotoAction(url="https://example.com", wait_until="commit").model_dump()["wait_until"] == "commit"
+
+
+def test_goto_action_union_serialization_schema_remains_concrete() -> None:
+    schema = TypeAdapter(ActionUnion).json_schema(mode="serialization")
+    goto_schema = schema["$defs"]["GotoAction"]
+
+    assert schema["discriminator"]["mapping"]["goto"] == "#/$defs/GotoAction"
+    assert goto_schema["type"] == "object"
+    assert {"type", "url", "wait_until"} <= goto_schema["properties"].keys()
+    assert goto_schema["properties"]["type"]["const"] == "goto"
 
 
 class _GotoBeforeWaitUntil(BaseModel):
@@ -37,8 +44,8 @@ def test_an_echoed_goto_still_parses_on_an_older_sdk() -> None:
         action=GotoAction(url="https://example.com"), success=True, message="ok", started_at=now, ended_at=now
     )
 
-    # what FastAPI serialises for the response model: defaults included, nothing excluded
-    echoed = result.model_dump(mode="json", by_alias=True)["action"]
+    # API response routes exclude None-valued model fields at the wire boundary.
+    echoed = result.model_dump(mode="json", by_alias=True, exclude_none=True)["action"]
 
     parsed = _GotoBeforeWaitUntil.model_validate(
         {k: v for k, v in echoed.items() if k in ("type", "url", "wait_until")}


### PR DESCRIPTION
## Summary

- remove the `GotoAction` model serializer whose `Any` return type reduced its Pydantic serialization schema to `{}`
- keep unset `wait_until` compatibility at the SDK/API wire boundaries via `exclude_none`
- add a discriminated-union serialization-schema regression test
- document backward-compatible model and OpenAPI changes for maintainers

This fixes the malformed `GotoAction-Output` schema consumed by nottelabs/notte-cli#96. After merge, `notte-api` should bump its pinned Notte revision and deploy staging before regenerating that client.

## Validation

- `pytest tests/test_goto_wait_until.py -q` (6 passed)
- pre-commit hooks on all changed files (ruff, formatting, basedpyright, secrets and repository checks)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791384820&installation_model_id=8247&pr_number=949&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F949&signature=a2c7595ec48abb05029bd9012a5b527f8c7d9078720fe7c2c9e63892664964db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added backward-compatibility guidance for API model changes, including validation and serialization schema checks.
  * Added rollout recommendations for introducing optional fields safely.

* **Bug Fixes**
  * Updated action serialization so unset optional values are omitted at the API boundary while explicitly configured values remain available.
  * Improved schema handling to preserve concrete action definitions and compatibility with older SDK versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->