### PR TITLE
fix: publish PyPI releases with uv

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -53,7 +53,6 @@ jobs:
         run: >-
           uv publish
           --check-url https://pypi.org/simple
-          --token "$UV_PUBLISH_TOKEN"
           dist/*
 
       - name: Wait for PyPI indexing

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -36,17 +36,25 @@ jobs:
             python-version-file: ".python-version"
             cache: ${{ env.CACHE_TYPE }}
 
+      - name: Build Python distributions
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: bash build.sh "$RELEASE_TAG"
+
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
 
-      - name: Build and Publish to PyPI
+      - name: Publish to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: bash build.sh "$RELEASE_TAG" publish
+        run: >-
+          uv publish
+          --check-url https://pypi.org/simple
+          --token "$UV_PUBLISH_TOKEN"
+          dist/*
 
       - name: Wait for PyPI indexing
         run: |

--- a/build.sh
+++ b/build.sh
@@ -50,5 +50,8 @@ done
 publish=$2
 if [ "$publish" == "publish" ]; then
     echo "Publishing packages"
-    uv run twine upload --skip-existing --repository pypi dist/* -u __token__ -p $UV_PUBLISH_TOKEN
+    uv publish \
+        --check-url https://pypi.org/simple \
+        --token "$UV_PUBLISH_TOKEN" \
+        dist/*
 fi

--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,5 @@ if [ "$publish" == "publish" ]; then
     echo "Publishing packages"
     uv publish \
         --check-url https://pypi.org/simple \
-        --token "$UV_PUBLISH_TOKEN" \
         dist/*
 fi

--- a/tests/scripts/test_release_publish.py
+++ b/tests/scripts/test_release_publish.py
@@ -2,20 +2,19 @@ from pathlib import Path
 
 import yaml
 
-
 ROOT = Path(__file__).parents[2]
 
 
 def test_release_workflow_builds_before_uploading_and_publishing() -> None:
-    workflow = yaml.safe_load(
-        (ROOT / ".github/workflows/pypi-release.yml").read_text()
-    )
+    workflow = yaml.safe_load((ROOT / ".github/workflows/pypi-release.yml").read_text())
     steps = workflow["jobs"]["build"]["steps"]
     names = [step.get("name") for step in steps]
 
-    assert names.index("Build Python distributions") < names.index(
-        "Store the distribution packages"
-    ) < names.index("Publish to PyPI")
+    assert (
+        names.index("Build Python distributions")
+        < names.index("Store the distribution packages")
+        < names.index("Publish to PyPI")
+    )
 
     publish = next(step for step in steps if step.get("name") == "Publish to PyPI")
     command = publish["run"]

--- a/tests/scripts/test_release_publish.py
+++ b/tests/scripts/test_release_publish.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).parents[2]
+
+
+def test_release_workflow_builds_before_uploading_and_publishing() -> None:
+    workflow = yaml.safe_load(
+        (ROOT / ".github/workflows/pypi-release.yml").read_text()
+    )
+    steps = workflow["jobs"]["build"]["steps"]
+    names = [step.get("name") for step in steps]
+
+    assert names.index("Build Python distributions") < names.index(
+        "Store the distribution packages"
+    ) < names.index("Publish to PyPI")
+
+    publish = next(step for step in steps if step.get("name") == "Publish to PyPI")
+    command = publish["run"]
+    assert "uv publish" in command
+    assert "--check-url https://pypi.org/simple" in command
+    assert "twine" not in command
+    assert "--token" not in command
+    assert publish["env"] == {"UV_PUBLISH_TOKEN": "${{ secrets.UV_PUBLISH_TOKEN }}"}
+
+
+def test_manual_release_uses_uv_environment_credentials() -> None:
+    build_script = (ROOT / "build.sh").read_text()
+
+    assert "uv publish" in build_script
+    assert "--check-url https://pypi.org/simple" in build_script
+    assert "twine upload" not in build_script
+    assert "--token" not in build_script


### PR DESCRIPTION
## Summary

- replace Twine with `uv publish` for release uploads
- build distributions before uploading the release artifact
- preserve duplicate-file handling through the PyPI simple-index check
- update the manual `build.sh <version> publish` path as well

## Context

Releases v1.8.32 through v1.8.39 all failed before reaching PyPI because Twine, running with the locked `packaging==25.0`, rejects the generated Core Metadata 2.5 distributions. PyPI therefore remains on 1.8.31.

## Validation

- `bash -n build.sh`
- parsed `.github/workflows/pypi-release.yml` with PyYAML
- built all 14 v1.8.40 wheel/sdist artifacts
- `uv publish --dry-run --check-url https://pypi.org/simple dist/*` validated every artifact successfully

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791477387&installation_model_id=8247&pr_number=952&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F952&signature=a10e6914dcba20332a6c3252c90e054787e7f4cdf42a0083e1dc55631d9ab641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Package releases now build distributions and publish them as separate steps.
  * Publishing uses the standard PyPI publishing flow with availability checks.
  * Release sequencing now ensures packages are built and stored before publication.

* **Tests**
  * Added automated validation for release workflow ordering and PyPI publishing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->