### PR TITLE
Allow per-run selection of extended function runtime

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -3,6 +3,8 @@ import os
 import sys
 from pathlib import Path
 
+from sphinx.application import Sphinx
+
 sys.path.insert(0, os.path.abspath(".."))  # Add parent directory to Python path
 sys.path.insert(0, os.path.abspath("../.."))  # Add parent directory to Python path
 
@@ -49,16 +51,16 @@ autodoc_class_signature = "mixed"
 
 # sphinx-mintlify renders defaults of string type aliases without their quotes.
 # Keep the public function signature valid Python after each regeneration.
-def preserve_function_runtime_default(app, exception):
+def preserve_function_runtime_default(app: Sphinx, exception: Exception | None) -> None:
     if exception is not None:
         return
     reference = Path(app.confdir).parent / "src/sdk-reference/misc/nottefunction.mdx"
     if reference.exists():
         content = reference.read_text()
-        reference.write_text(
+        _ = reference.write_text(
             content.replace("runtime: FunctionRuntime = standard", 'runtime: FunctionRuntime = "standard"')
         )
 
 
-def setup(app):
-    app.connect("build-finished", preserve_function_runtime_default)
+def setup(app: Sphinx) -> None:
+    _ = app.connect("build-finished", preserve_function_runtime_default)

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,6 +1,7 @@
 # Configuration file for the Sphinx documentation builder.
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(".."))  # Add parent directory to Python path
 sys.path.insert(0, os.path.abspath("../.."))  # Add parent directory to Python path
@@ -44,3 +45,20 @@ builders = {"mintlify": "sphinx_mintlify.MintlifyBuilder"}
 autodoc_member_order = "bysource"
 autodoc_typehints = "description"
 autodoc_class_signature = "mixed"
+
+
+# sphinx-mintlify renders defaults of string type aliases without their quotes.
+# Keep the public function signature valid Python after each regeneration.
+def preserve_function_runtime_default(app, exception):
+    if exception is not None:
+        return
+    reference = Path(app.confdir).parent / "src/sdk-reference/misc/nottefunction.mdx"
+    if reference.exists():
+        content = reference.read_text()
+        reference.write_text(
+            content.replace("runtime: FunctionRuntime = standard", 'runtime: FunctionRuntime = "standard"')
+        )
+
+
+def setup(app):
+    app.connect("build-finished", preserve_function_runtime_default)

--- a/docs/src/sdk-reference/misc/nottefunction.mdx
+++ b/docs/src/sdk-reference/misc/nottefunction.mdx
@@ -111,7 +111,7 @@ Get presigned URLs for the workflow run replay
 ### run
 
 ```python
-run(version: str | None = None, local: bool = False, restricted: bool = True, timeout: int | None = None, stream: bool = True, raise_on_failure: bool = True, function_run_id: str | None = None, workflow_run_id: str | None = None, log_callback: Callable[[str], None] | None = None, variables: Any) -> FunctionRunResponse
+run(version: str | None = None, local: bool = False, restricted: bool = True, timeout: int | None = None, stream: bool = True, raise_on_failure: bool = True, function_run_id: str | None = None, workflow_run_id: str | None = None, log_callback: Callable[[str], None] | None = None, runtime: FunctionRuntime = standard, input_variables: dict[str, Any] | None = None, variables: Any) -> FunctionRunResponse
 ```
 
 Run the function code using the specified version and variables

--- a/docs/src/sdk-reference/misc/nottefunction.mdx
+++ b/docs/src/sdk-reference/misc/nottefunction.mdx
@@ -111,7 +111,7 @@ Get presigned URLs for the workflow run replay
 ### run
 
 ```python
-run(version: str | None = None, local: bool = False, restricted: bool = True, timeout: int | None = None, stream: bool = True, raise_on_failure: bool = True, function_run_id: str | None = None, workflow_run_id: str | None = None, log_callback: Callable[[str], None] | None = None, runtime: FunctionRuntime = standard, input_variables: dict[str, Any] | None = None, variables: Any) -> FunctionRunResponse
+run(version: str | None = None, local: bool = False, restricted: bool = True, timeout: int | None = None, stream: bool = True, raise_on_failure: bool = True, function_run_id: str | None = None, workflow_run_id: str | None = None, log_callback: Callable[[str], None] | None = None, runtime: FunctionRuntime = "standard", input_variables: dict[str, Any] | None = None, variables: Any) -> FunctionRunResponse
 ```
 
 Run the function code using the specified version and variables

--- a/docs/src/sdk-reference/nottefunction/run.mdx
+++ b/docs/src/sdk-reference/nottefunction/run.mdx
@@ -7,6 +7,9 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 <AgentMdNotice />
 
 If no version is provided, the latest version is used.
+Pass runtime="extended" for longer cloud execution; "standard" is the default.
+Use `input_variables={"runtime": value}` for script inputs whose names match
+SDK options; these are merged with keyword inputs, rejecting duplicates.
 
 ```python
 function = notte.Function("<your-function-id>")
@@ -43,6 +46,12 @@ function.run(variable1="value1", variable2="value2")
 </ParamField>
 
 <ParamField path="log_callback" type="UnionType[Callable[[str], None], None]" default="None">
+</ParamField>
+
+<ParamField path="runtime" type="Literal['standard', 'extended']" default="standard">
+</ParamField>
+
+<ParamField path="input_variables" type="UnionType[Dict[str, Any], None]" default="None">
 </ParamField>
 
 <ParamField path="variables" type="Any" required>

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -13,6 +13,7 @@ from notte_core.common.logging import logger
 from notte_core.common.telemetry import track_usage
 from notte_core.errors.base import NotteBaseError
 from notte_core.utils.encryption import Encryption
+from pydantic import TypeAdapter
 from typing_extensions import deprecated
 
 from notte_sdk.endpoints.base import BaseClient, NotteEndpoint
@@ -792,6 +793,7 @@ class RemoteWorkflow:
         workflow_run_id: str | None = None,
         log_callback: Callable[[str], None] | None = None,
         runtime: FunctionRuntime = "standard",
+        input_variables: dict[str, Any] | None = None,
         **variables: Any,
     ) -> FunctionRunResponse:
         """
@@ -799,6 +801,8 @@ class RemoteWorkflow:
 
         If no version is provided, the latest version is used.
         Pass runtime="extended" for longer cloud execution; "standard" is the default.
+        Use `input_variables={"runtime": value}` for script inputs whose names match
+        SDK options; these are merged with keyword inputs, rejecting duplicates.
 
         ```python
         function = notte.Function("<your-function-id>")
@@ -807,8 +811,11 @@ class RemoteWorkflow:
 
         > Make sure that the correct variables are provided based on the python file previously uploaded. Otherwise, the workflow will fail.
         """
-        if runtime not in ("standard", "extended"):
-            raise ValueError("runtime must be 'standard' or 'extended'")
+        runtime = TypeAdapter(FunctionRuntime).validate_python(runtime)
+        if input_variables is not None:
+            if duplicates := input_variables.keys() & variables.keys():
+                raise ValueError(f"Duplicate input variables: {sorted(duplicates)}")
+            variables = {**input_variables, **variables}
         if local and runtime != "standard":
             raise ValueError("extended runtime is only available for cloud runs")
         if workflow_run_id is not None:

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -25,6 +25,7 @@ from notte_sdk.types import (
     DeleteFunctionResponse,
     ForkFunctionRequest,
     FunctionRunResponse,
+    FunctionRuntime,
     FunctionRunUpdateRequest,
     FunctionRunUpdateRequestDict,
     GetFunctionRequest,
@@ -479,6 +480,7 @@ class WorkflowsClient(BaseClient):
             function_run_id=function_run_id,
             variables=_request.variables,
             stream=_request.stream,
+            runtime=_request.runtime,
         )
         endpoint = self._start_workflow_run_endpoint(
             function_id=request.function_id, run_id=function_run_id
@@ -488,7 +490,9 @@ class WorkflowsClient(BaseClient):
         headers["Content-Type"] = "application/json"
         headers = self.headers(headers=headers)
         url = self.request_path(endpoint)
-        req_data = request.model_dump_json(exclude_none=True)
+        req_data = request.model_dump_json(
+            exclude_none=True, exclude={"runtime"} if request.runtime == "standard" else None
+        )
         timeout = timeout or self.WORKFLOW_RUN_TIMEOUT
 
         if not request.stream:
@@ -787,12 +791,14 @@ class RemoteWorkflow:
         function_run_id: str | None = None,
         workflow_run_id: str | None = None,
         log_callback: Callable[[str], None] | None = None,
+        runtime: FunctionRuntime = "standard",
         **variables: Any,
     ) -> FunctionRunResponse:
         """
         Run the function code using the specified version and variables.
 
         If no version is provided, the latest version is used.
+        Pass runtime="extended" for longer cloud execution; "standard" is the default.
 
         ```python
         function = notte.Function("<your-function-id>")
@@ -801,6 +807,10 @@ class RemoteWorkflow:
 
         > Make sure that the correct variables are provided based on the python file previously uploaded. Otherwise, the workflow will fail.
         """
+        if runtime not in ("standard", "extended"):
+            raise ValueError("runtime must be 'standard' or 'extended'")
+        if local and runtime != "standard":
+            raise ValueError("extended runtime is only available for cloud runs")
         if workflow_run_id is not None:
             warnings.warn(
                 "'workflow_run_id' is deprecated, use 'function_run_id' instead",
@@ -862,6 +872,7 @@ class RemoteWorkflow:
             function_id=self.response.function_id,
             function_run_id=function_run_id,
             stream=stream,
+            runtime=runtime,
             timeout=timeout,
             variables=variables,
         )

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -872,7 +872,9 @@ class RemoteWorkflow:
                 function_run_id=function_run_id,
                 session_id=log_capture.session_id,
                 result=result,
-                status=status,
+                # Persistence uses closed for both outcomes; the execution
+                # response must retain the verdict for cloud callers.
+                status="failed" if exception is not None else status,
             )
         # run on cloud
         res = self.client.run(

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -811,7 +811,7 @@ class RemoteWorkflow:
 
         > Make sure that the correct variables are provided based on the python file previously uploaded. Otherwise, the workflow will fail.
         """
-        runtime = TypeAdapter(FunctionRuntime).validate_python(runtime)
+        runtime = TypeAdapter[FunctionRuntime](FunctionRuntime).validate_python(runtime)
         if input_variables is not None:
             if duplicates := input_variables.keys() & variables.keys():
                 raise ValueError(f"Duplicate input variables: {sorted(duplicates)}")

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -2283,6 +2283,9 @@ class ListFunctionsRequestDict(ListRequestDict, total=False):
     pass
 
 
+FunctionRuntime = Literal["standard", "extended"]
+
+
 class RunFunctionRequestDict(TypedDict, total=False):
     """Request dictionary for running a function.
 
@@ -2294,6 +2297,7 @@ class RunFunctionRequestDict(TypedDict, total=False):
     function_id: str
     variables: dict[str, Any]
     stream: bool
+    runtime: FunctionRuntime
 
 
 class RunFunctionRequest(SdkRequest):
@@ -2302,6 +2306,9 @@ class RunFunctionRequest(SdkRequest):
         Field(description="The ID of the function to run", validation_alias=AliasChoices("workflow_id", "function_id")),
     ]
     variables: Annotated[dict[str, Any], Field(description="The variables to run the workflow with")]
+    runtime: Annotated[
+        FunctionRuntime, Field(description="standard uses Lambda; extended allows longer cloud execution")
+    ] = "standard"
     stream: Annotated[bool, Field(description="Whether to stream logs, or only return final response")] = True
 
 
@@ -2426,6 +2433,9 @@ class StartFunctionRunRequest(SdkRequest):
         ),
     ] = None
     variables: Annotated[dict[str, Any] | None, Field(description="The variables to run the function with")] = None
+    runtime: Annotated[
+        FunctionRuntime, Field(description="standard uses Lambda; extended allows longer cloud execution")
+    ] = "standard"
     stream: Annotated[bool, Field(description="Whether to stream logs, or only return final response")] = False
 
     @computed_field

--- a/tests/integration/sdk/test_workflow_runs.py
+++ b/tests/integration/sdk/test_workflow_runs.py
@@ -308,7 +308,7 @@ class TestRemoteFunctionRuns:
     @patch("notte_sdk.endpoints.workflows.SecureScriptRunner")
     @patch("notte_sdk.endpoints.workflows.LogCapture")
     def test_remote_workflow_run_local_failure_closes_run(self, mock_log_capture, mock_script_runner):
-        """Test local function failures close the run instead of marking it failed."""
+        """Return a failed response while persisting the closed billing state."""
         workflows_client = MagicMock()
         workflows_client.get.return_value.function_id = "test-function-id"
         root_client = MagicMock()
@@ -325,7 +325,7 @@ class TestRemoteFunctionRuns:
         with patch.object(workflow, "download", return_value="def run():\n    raise RuntimeError('boom')"):
             result = workflow.run(local=True, function_run_id="test-run-id", raise_on_failure=False)
 
-        assert result.status == "closed"
+        assert result.status == "failed"
         assert result.result == "boom"
         workflows_client.update_run.assert_called_once()
         assert workflows_client.update_run.call_args.kwargs["status"] == "closed"

--- a/tests/sdk/test_function_runtime.py
+++ b/tests/sdk/test_function_runtime.py
@@ -57,7 +57,7 @@ def test_invalid_or_local_extended_rejected_before_creating_run():
     function = SimpleNamespace(client=SimpleNamespace(create_run=Mock()))
     with pytest.raises(ValueError, match="cloud"):
         RemoteWorkflow.run(function, local=True, runtime="extended")
-    with pytest.raises(ValueError, match="runtime must"):
+    with pytest.raises(ValueError, match="standard.*extended"):
         RemoteWorkflow.run(function, runtime="invalid")
     function.client.create_run.assert_not_called()
 
@@ -65,3 +65,25 @@ def test_invalid_or_local_extended_rejected_before_creating_run():
 def test_models_default_to_standard():
     assert RunFunctionRequest(function_id="function", variables={}).runtime == "standard"
     assert StartFunctionRunRequest(function_id="function").runtime == "standard"
+
+
+def test_script_inputs_can_use_reserved_sdk_option_names():
+    response = SimpleNamespace(status="closed", session_id=None)
+    client = SimpleNamespace(run=Mock(return_value=response))
+    function = SimpleNamespace(client=client, response=SimpleNamespace(function_id="function"))
+    RemoteWorkflow.run(
+        function,
+        function_run_id="run",
+        runtime="extended",
+        input_variables={"runtime": "python", "version": 3},
+        wait_seconds=960,
+    )
+    assert client.run.call_args.kwargs["variables"] == {"runtime": "python", "version": 3, "wait_seconds": 960}
+    assert client.run.call_args.kwargs["runtime"] == "extended"
+
+
+def test_duplicate_inputs_rejected_before_creating_run():
+    function = SimpleNamespace(client=SimpleNamespace(create_run=Mock()))
+    with pytest.raises(ValueError, match="Duplicate input"):
+        RemoteWorkflow.run(function, input_variables={"wait_seconds": 1}, wait_seconds=2)
+    function.client.create_run.assert_not_called()

--- a/tests/sdk/test_function_runtime.py
+++ b/tests/sdk/test_function_runtime.py
@@ -87,3 +87,22 @@ def test_duplicate_inputs_rejected_before_creating_run():
     with pytest.raises(ValueError, match="Duplicate input"):
         RemoteWorkflow.run(function, input_variables={"wait_seconds": 1}, wait_seconds=2)
     function.client.create_run.assert_not_called()
+
+
+@pytest.mark.parametrize("raise_on_failure", [True, False])
+def test_local_failure_persists_closed_but_reports_failure(monkeypatch, raise_on_failure):
+    failure = RuntimeError("intentional test failure")
+    runner = SimpleNamespace(run_script=Mock(side_effect=failure))
+    monkeypatch.setattr(workflows, "SecureScriptRunner", lambda **kwargs: runner)
+    client = SimpleNamespace(update_run=Mock())
+    function = SimpleNamespace(
+        client=client, function_id="function", root_client=object(), download=lambda **kwargs: "code"
+    )
+    if raise_on_failure:
+        with pytest.raises(RuntimeError, match="intentional test failure"):
+            RemoteWorkflow.run(function, function_run_id="run", local=True, raise_on_failure=True)
+    else:
+        result = RemoteWorkflow.run(function, function_run_id="run", local=True, raise_on_failure=False)
+        assert result.status == "failed" and result.result == "intentional test failure"
+    assert client.update_run.call_args.kwargs["status"] == "closed"
+    assert client.update_run.call_args.kwargs["result"] == "intentional test failure"

--- a/tests/sdk/test_function_runtime.py
+++ b/tests/sdk/test_function_runtime.py
@@ -1,0 +1,67 @@
+"""Runtime selection travels outside script variables and survives request conversion."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from notte_sdk.endpoints import workflows
+from notte_sdk.endpoints.workflows import RemoteWorkflow, WorkflowsClient
+from notte_sdk.types import RunFunctionRequest, StartFunctionRunRequest
+
+
+@pytest.mark.parametrize("runtime", ["standard", "extended"])
+def test_high_level_run_forwards_runtime(runtime):
+    response = SimpleNamespace(status="closed", session_id=None)
+    client = SimpleNamespace(run=Mock(return_value=response))
+    function = SimpleNamespace(client=client, response=SimpleNamespace(function_id="function"))
+    result = RemoteWorkflow.run(function, function_run_id="run", runtime=runtime, wait_seconds=960)
+    assert result is response
+    assert client.run.call_args.kwargs["runtime"] == runtime
+    assert client.run.call_args.kwargs["variables"] == {"wait_seconds": 960}
+
+
+@pytest.mark.parametrize("runtime", ["standard", "extended"])
+def test_transport_preserves_selection(monkeypatch, runtime):
+    endpoint = SimpleNamespace(with_request=lambda request: request)
+    client = SimpleNamespace(
+        token="test",
+        headers=lambda headers: headers,
+        request_path=lambda endpoint: "https://example.com",
+        _start_workflow_run_endpoint=lambda **kwargs: endpoint,
+        WORKFLOW_RUN_TIMEOUT=900,
+    )
+    post = Mock(
+        return_value=SimpleNamespace(
+            json=lambda: {
+                "function_id": "function",
+                "function_run_id": "run",
+                "status": "closed",
+                "session_id": None,
+                "result": {"ok": True},
+            }
+        )
+    )
+    monkeypatch.setattr(workflows.requests, "post", post)
+    WorkflowsClient.run(
+        client, "run", function_id="function", variables={"wait_seconds": 960}, stream=False, runtime=runtime
+    )
+    body = json.loads(post.call_args.kwargs["data"])
+    assert body.get("runtime", "standard") == runtime
+    assert body["variables"] == {"wait_seconds": 960}
+    if runtime == "standard":
+        assert "runtime" not in body  # Compatible with older APIs and Lambda images.
+
+
+def test_invalid_or_local_extended_rejected_before_creating_run():
+    function = SimpleNamespace(client=SimpleNamespace(create_run=Mock()))
+    with pytest.raises(ValueError, match="cloud"):
+        RemoteWorkflow.run(function, local=True, runtime="extended")
+    with pytest.raises(ValueError, match="runtime must"):
+        RemoteWorkflow.run(function, runtime="invalid")
+    function.client.create_run.assert_not_called()
+
+
+def test_models_default_to_standard():
+    assert RunFunctionRequest(function_id="function", variables={}).runtime == "standard"
+    assert StartFunctionRunRequest(function_id="function").runtime == "standard"


### PR DESCRIPTION
Adds `fn.run(runtime="extended", ...)` to select longer cloud execution per invocation; `standard` remains the default. The option stays outside script variables and is omitted on the wire for standard calls to preserve compatibility with existing APIs. `input_variables={"runtime": "script value"}` handles reserved input names; duplicate inputs, invalid runtime choices and local extended runs fail before creating a run.

Fixes a failure discovered during the live pilot: local script exceptions now return `status="failed"`, while the persisted run remains `closed` for existing billing semantics. The default cloud SDK call raises for that failed response.

Companion API/AgentCore pilot: https://github.com/nottelabs/monorepo/pull/2620. Ten focused SDK tests pass, type checks pass, and preview calls verified both routes, reserved inputs, persisted failures and default exceptions. The final full SDK suite passed: 937 tests, 32 skipped. Documentation regeneration and type checks also pass. Greptile: 5/5 with zero unresolved review threads.
