### PR TITLE
fix(sdk): preserve explicit function runtime overrides

### DIFF
--- a/docs/src/concepts/search.mdx
+++ b/docs/src/concepts/search.mdx
@@ -9,7 +9,7 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 Search looks up the public web and returns ranked results, a sourced answer, or structured output. Use it when you need links and context before you [Fetch](/concepts/scraping) a page.
 
-The REST endpoint is `POST /search`. Full schema: [Search Web](/api-reference/search/search-web).
+The REST endpoint is `POST /search`. See the [request parameters](#parameters) below.
 
 ## Quick start
 

--- a/docs/src/sdk-reference/misc/getfunctionresponse.mdx
+++ b/docs/src/sdk-reference/misc/getfunctionresponse.mdx
@@ -7,6 +7,9 @@ description: ""
 
 ## Fields
 
+<ParamField path="default_runtime" type="Literal['standard', 'extended']" default="standard">
+</ParamField>
+
 <ParamField path="function_id" type="str" required>
   The ID of the function
 </ParamField>

--- a/docs/src/sdk-reference/misc/nottefunction.mdx
+++ b/docs/src/sdk-reference/misc/nottefunction.mdx
@@ -111,7 +111,7 @@ Get presigned URLs for the workflow run replay
 ### run
 
 ```python
-run(version: str | None = None, local: bool = False, restricted: bool = True, timeout: int | None = None, stream: bool = True, raise_on_failure: bool = True, function_run_id: str | None = None, workflow_run_id: str | None = None, log_callback: Callable[[str], None] | None = None, runtime: FunctionRuntime = "standard", input_variables: dict[str, Any] | None = None, variables: Any) -> FunctionRunResponse
+run(version: str | None = None, local: bool = False, restricted: bool = True, timeout: int | None = None, stream: bool = True, raise_on_failure: bool = True, function_run_id: str | None = None, workflow_run_id: str | None = None, log_callback: Callable[[str], None] | None = None, runtime: FunctionRuntime | None = None, input_variables: dict[str, Any] | None = None, variables: Any) -> FunctionRunResponse
 ```
 
 Run the function code using the specified version and variables

--- a/docs/src/sdk-reference/nottefunction/run.mdx
+++ b/docs/src/sdk-reference/nottefunction/run.mdx
@@ -49,7 +49,7 @@ function.run(variable1="value1", variable2="value2")
 <ParamField path="log_callback" type="UnionType[Callable[[str], None], None]" default="None">
 </ParamField>
 
-<ParamField path="runtime" type="Literal['standard', 'extended']" default="standard">
+<ParamField path="runtime" type="Literal['standard', 'extended'] | None" default="None">
 </ParamField>
 
 <ParamField path="input_variables" type="UnionType[Dict[str, Any], None]" default="None">

--- a/docs/src/sdk-reference/nottefunction/run.mdx
+++ b/docs/src/sdk-reference/nottefunction/run.mdx
@@ -7,7 +7,8 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 <AgentMdNotice />
 
 If no version is provided, the latest version is used.
-Pass runtime="extended" for longer cloud execution; "standard" is the default.
+Omit runtime to use the saved function default. Pass runtime="extended"
+for longer cloud execution, or runtime="standard" to override that default.
 Use `input_variables={"runtime": value}` for script inputs whose names match
 SDK options; these are merged with keyword inputs, rejecting duplicates.
 

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -491,9 +491,7 @@ class WorkflowsClient(BaseClient):
         headers["Content-Type"] = "application/json"
         headers = self.headers(headers=headers)
         url = self.request_path(endpoint)
-        req_data = request.model_dump_json(
-            exclude_none=True, exclude={"runtime"} if request.runtime == "standard" else None
-        )
+        req_data = request.model_dump_json(exclude_none=True)
         timeout = timeout or self.WORKFLOW_RUN_TIMEOUT
 
         if not request.stream:
@@ -792,7 +790,7 @@ class RemoteWorkflow:
         function_run_id: str | None = None,
         workflow_run_id: str | None = None,
         log_callback: Callable[[str], None] | None = None,
-        runtime: FunctionRuntime = "standard",
+        runtime: FunctionRuntime | None = None,
         input_variables: dict[str, Any] | None = None,
         **variables: Any,
     ) -> FunctionRunResponse:
@@ -800,7 +798,8 @@ class RemoteWorkflow:
         Run the function code using the specified version and variables.
 
         If no version is provided, the latest version is used.
-        Pass runtime="extended" for longer cloud execution; "standard" is the default.
+        Omit runtime to use the saved function default. Pass runtime="extended"
+        for longer cloud execution, or runtime="standard" to override that default.
         Use `input_variables={"runtime": value}` for script inputs whose names match
         SDK options; these are merged with keyword inputs, rejecting duplicates.
 
@@ -811,12 +810,12 @@ class RemoteWorkflow:
 
         > Make sure that the correct variables are provided based on the python file previously uploaded. Otherwise, the workflow will fail.
         """
-        runtime = TypeAdapter[FunctionRuntime](FunctionRuntime).validate_python(runtime)
+        runtime = TypeAdapter[FunctionRuntime | None](FunctionRuntime | None).validate_python(runtime)
         if input_variables is not None:
             if duplicates := input_variables.keys() & variables.keys():
                 raise ValueError(f"Duplicate input variables: {sorted(duplicates)}")
             variables = {**input_variables, **variables}
-        if local and runtime != "standard":
+        if local and runtime == "extended":
             raise ValueError("extended runtime is only available for cloud runs")
         if workflow_run_id is not None:
             warnings.warn(

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -2297,7 +2297,7 @@ class RunFunctionRequestDict(TypedDict, total=False):
     function_id: str
     variables: dict[str, Any]
     stream: bool
-    runtime: FunctionRuntime
+    runtime: FunctionRuntime | None
 
 
 class RunFunctionRequest(SdkRequest):
@@ -2307,8 +2307,8 @@ class RunFunctionRequest(SdkRequest):
     ]
     variables: Annotated[dict[str, Any], Field(description="The variables to run the workflow with")]
     runtime: Annotated[
-        FunctionRuntime, Field(description="standard uses Lambda; extended allows longer cloud execution")
-    ] = "standard"
+        FunctionRuntime | None, Field(description="Override the saved function runtime; omit to inherit its default")
+    ] = None
     stream: Annotated[bool, Field(description="Whether to stream logs, or only return final response")] = True
 
 
@@ -2336,6 +2336,7 @@ class ForkFunctionRequest(SdkRequest):
 
 
 class GetFunctionResponse(SdkResponse):
+    default_runtime: FunctionRuntime = "standard"
     function_id: Annotated[
         str, Field(description="The ID of the function", validation_alias=AliasChoices("workflow_id", "function_id"))
     ]
@@ -2434,8 +2435,8 @@ class StartFunctionRunRequest(SdkRequest):
     ] = None
     variables: Annotated[dict[str, Any] | None, Field(description="The variables to run the function with")] = None
     runtime: Annotated[
-        FunctionRuntime, Field(description="standard uses Lambda; extended allows longer cloud execution")
-    ] = "standard"
+        FunctionRuntime | None, Field(description="Override the saved function runtime; omit to inherit its default")
+    ] = None
     stream: Annotated[bool, Field(description="Whether to stream logs, or only return final response")] = False
 
     @computed_field

--- a/tests/sdk/test_function_runtime.py
+++ b/tests/sdk/test_function_runtime.py
@@ -2,7 +2,7 @@
 
 import json
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from notte_sdk.endpoints import workflows
@@ -10,7 +10,7 @@ from notte_sdk.endpoints.workflows import RemoteWorkflow, WorkflowsClient
 from notte_sdk.types import RunFunctionRequest, StartFunctionRunRequest
 
 
-@pytest.mark.parametrize("runtime", ["standard", "extended"])
+@pytest.mark.parametrize("runtime", [None, "standard", "extended"])
 def test_high_level_run_forwards_runtime(runtime):
     response = SimpleNamespace(status="closed", session_id=None)
     client = SimpleNamespace(run=Mock(return_value=response))
@@ -21,8 +21,9 @@ def test_high_level_run_forwards_runtime(runtime):
     assert client.run.call_args.kwargs["variables"] == {"wait_seconds": 960}
 
 
-@pytest.mark.parametrize("runtime", ["standard", "extended"])
-def test_transport_preserves_selection(monkeypatch, runtime):
+@pytest.mark.parametrize("runtime", [None, "standard", "extended"])
+@pytest.mark.parametrize("stream", [False, True])
+def test_transport_preserves_selection(monkeypatch, runtime, stream):
     endpoint = SimpleNamespace(with_request=lambda request: request)
     client = SimpleNamespace(
         token="test",
@@ -31,7 +32,7 @@ def test_transport_preserves_selection(monkeypatch, runtime):
         _start_workflow_run_endpoint=lambda **kwargs: endpoint,
         WORKFLOW_RUN_TIMEOUT=900,
     )
-    post = Mock(
+    post = MagicMock(
         return_value=SimpleNamespace(
             json=lambda: {
                 "function_id": "function",
@@ -42,15 +43,22 @@ def test_transport_preserves_selection(monkeypatch, runtime):
             }
         )
     )
+    post.return_value = MagicMock(json=post.return_value.json)
+    post.return_value.__enter__.return_value = post.return_value
+    post.return_value.iter_lines.return_value = [
+        ("data: " + json.dumps({"type": "result", "message": json.dumps(post.return_value.json())})).encode()
+    ]
     monkeypatch.setattr(workflows.requests, "post", post)
     WorkflowsClient.run(
-        client, "run", function_id="function", variables={"wait_seconds": 960}, stream=False, runtime=runtime
+        client, "run", function_id="function", variables={"wait_seconds": 960}, stream=stream, runtime=runtime
     )
     body = json.loads(post.call_args.kwargs["data"])
-    assert body.get("runtime", "standard") == runtime
+    assert body.get("runtime") == runtime
     assert body["variables"] == {"wait_seconds": 960}
-    if runtime == "standard":
-        assert "runtime" not in body  # Compatible with older APIs and Lambda images.
+    if runtime is None:
+        assert "runtime" not in body
+    else:
+        assert body["runtime"] == runtime
 
 
 def test_invalid_or_local_extended_rejected_before_creating_run():
@@ -62,9 +70,9 @@ def test_invalid_or_local_extended_rejected_before_creating_run():
     function.client.create_run.assert_not_called()
 
 
-def test_models_default_to_standard():
-    assert RunFunctionRequest(function_id="function", variables={}).runtime == "standard"
-    assert StartFunctionRunRequest(function_id="function").runtime == "standard"
+def test_models_leave_runtime_unset():
+    assert RunFunctionRequest(function_id="function", variables={}).runtime is None
+    assert StartFunctionRunRequest(function_id="function").runtime is None
 
 
 def test_script_inputs_can_use_reserved_sdk_option_names():


### PR DESCRIPTION
Let `Function.run()` inherit the saved function runtime when the argument is omitted. Explicit `runtime="standard"` and `runtime="extended"` are preserved in both streaming and JSON requests. Expose `default_runtime` in function metadata and update the reference docs.

Validation: 15 focused SDK tests pass; Ruff and focused type checks pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791556682&installation_model_id=8247&pr_number=955&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F955&signature=e6dfa6b59f898743017543a1a581b40b2814b0c0fcc740c699b121a5b083e3e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Runtime selection is now optional when running saved functions.
  - Omitting the runtime uses the function’s saved default.
  - Explicitly selecting `extended` enables longer cloud execution, while `standard` overrides the saved default.
  - Function details now expose the saved default runtime.

- **Documentation**
  - Updated SDK reference documentation to explain optional runtime selection and override behavior.
  - Updated search documentation to link directly to the request parameters schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->