### PR TITLE
docs: document cloud file uploads from URLs

### DIFF
--- a/docs/src/concepts/file-storage.mdx
+++ b/docs/src/concepts/file-storage.mdx
@@ -4,6 +4,7 @@ description: Upload and download files for your automations
 ---
 import Quickstart from '/snippets/file-storage/quickstart.mdx';
 import UploadingFiles from '/snippets/file-storage/uploading_files.mdx';
+import UrlUpload from '/snippets/file-storage/url_upload.mdx';
 import DownloadingFiles from '/snippets/file-storage/downloading_files.mdx';
 import ForceOverwrite from '/snippets/file-storage/force_overwrite.mdx';
 import UsingWithAgents from '/snippets/file-storage/using_with_agents.mdx';
@@ -65,18 +66,13 @@ In a cloud session, pass a public HTTP(S) file URL, including a signed URL, to
 selector or observed ID. Notte downloads and attaches the file without navigating
 away from the form or requiring a separate `session.storage.upload()` call.
 
-```python
-session.execute(
-    type="upload_file",
-    selector='input[type="file"]',
-    file_path="https://example.com/document.pdf",
-)
-```
+<UrlUpload />
 
 The download runs on the API server and does not use browser cookies, browser proxy
 settings, or custom authentication headers. URLs must resolve to public addresses;
 redirects are checked too. Downloads have a 120-second overall limit, up to five
-redirects, and the server's configured session file size limit. Temporary files are
+redirects, and the server's configured per-file and aggregate temporary-upload size
+limits. Temporary files are
 removed when the session is cleaned up and are not added to its persistent file
 catalog.
 

--- a/docs/src/concepts/file-storage.mdx
+++ b/docs/src/concepts/file-storage.mdx
@@ -58,6 +58,32 @@ Upload files from your local machine to make them available in sessions:
   team at [support@notte.cc](mailto:support@notte.cc).
 </Note>
 
+### Attaching a URL directly to a form
+
+In a cloud session, pass a public HTTP(S) file URL, including a signed URL, to
+`session.execute(type="upload_file", file_path=...)` along with the upload element's
+selector or observed ID. Notte downloads and attaches the file without navigating
+away from the form or requiring a separate `session.storage.upload()` call.
+
+```python
+session.execute(
+    type="upload_file",
+    selector='input[type="file"]',
+    file_path="https://example.com/document.pdf",
+)
+```
+
+The download runs on the API server and does not use browser cookies, browser proxy
+settings, or custom authentication headers. URLs must resolve to public addresses;
+redirects are checked too. Downloads have a 120-second overall limit, up to five
+redirects, and the server's configured session file size limit. Temporary files are
+removed when the session is cleaned up and are not added to its persistent file
+catalog.
+
+This requires cloud backend support, with no SDK update. Standalone local sessions
+retain their existing storage/path behavior. `storage.upload()` still accepts local
+files; URL support belongs to the browser's `upload_file` action.
+
 ## Downloading Files
 
 Download files that agents retrieved from websites:

--- a/docs/src/features/sessions/browser-controls.mdx
+++ b/docs/src/features/sessions/browser-controls.mdx
@@ -259,7 +259,13 @@ Upload a file to a file input.
 **Parameters:**
 - `selector` (str): CSS selector for the file input
 - `id` (str): Element ID
-- `file_path` (str): Path to the file to upload
+- `file_path` (str): In cloud sessions, a stored filename or a public HTTP(S) file URL, including signed URLs.
+
+URL files download on the API server without navigating away from the form. They do
+not use browser cookies, browser proxy settings, or custom authentication headers,
+and are not added to the persistent session file catalog. The cloud backend must
+support URL uploads; no SDK update is required. Standalone local sessions keep
+their existing storage/path behavior.
 
 **Use for:** Uploading documents, images, any file input
 

--- a/docs/src/sdk-reference/misc/uploadfileaction.mdx
+++ b/docs/src/sdk-reference/misc/uploadfileaction.mdx
@@ -8,10 +8,27 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 Use with any upload file element, including button, input, a, span, div. CRITICAL: Use only this for file upload, do not use click.
 
+In cloud sessions, `file_path` accepts a session file's filename or a public HTTP(S)
+file URL, including signed URLs. URL files are downloaded on the API server and
+attached without navigating away from the form. Downloads do not use browser
+cookies, browser proxy settings, or custom authentication headers. They are
+temporary and are not added to the session's persistent file catalog.
+
+URL support requires the cloud backend feature; it does not require an SDK update.
+Standalone local sessions retain their existing storage/path behavior and do not
+gain URL downloading. To use a local file with a cloud session, first upload it
+with `session.storage.upload()` and pass the returned filename.
+
 **Example:**
 ```python
-session.execute(type="upload_file", id="file-input", file_path="/path/to/document.pdf")
-session.execute(type="upload_file", id="image-upload", file_path="./image.jpg")
+# Cloud session: attach an existing session file by filename.
+session.execute(type="upload_file", selector='input[type="file"]', file_path="document.pdf")
+# Cloud session: download and attach a public or signed HTTP(S) URL.
+session.execute(
+    type="upload_file",
+    selector='input[type="file"]',
+    file_path="https://example.com/document.pdf",
+)
 ```
 
 ## Fields

--- a/docs/src/snippets/browser-controls/upload_file.mdx
+++ b/docs/src/snippets/browser-controls/upload_file.mdx
@@ -9,9 +9,14 @@ client = NotteClient()
 with client.Session() as session:
     session.execute(type="goto", url="https://example.com/upload")
 
-    # Upload from local file
-    session.execute(type="upload_file", selector="input[type='file']", file_path="/path/to/document.pdf")
+    # Upload a local file to the cloud session, then attach it by filename.
+    uploaded = session.storage.upload("/path/to/document.pdf")
+    session.execute(type="upload_file", selector="input[type='file']", file_path=uploaded.filename)
 
-    # Upload with ID
-    session.execute(type="upload_file", id="file-upload", file_path="/path/to/image.jpg")
+    # Or attach a public HTTP(S) file URL directly. Signed URLs also work.
+    session.execute(
+        type="upload_file",
+        selector="input[type='file']",
+        file_path="https://example.com/document.pdf",
+    )
 ```

--- a/docs/src/snippets/file-storage/url_upload.mdx
+++ b/docs/src/snippets/file-storage/url_upload.mdx
@@ -7,10 +7,10 @@ from notte_sdk import NotteClient
 client = NotteClient()
 
 with client.Session() as session:
-    session.execute(type="goto", url="https://example.com/upload")
+    session.execute(type="goto", url="https://test-resources-lovat.vercel.app/upload_fixture.html")
     session.execute(
         type="upload_file",
         selector='input[type="file"]',
-        file_path="https://example.com/document.pdf",
+        file_path="https://test-resources-lovat.vercel.app/text1.txt",
     )
 ```

--- a/docs/src/snippets/file-storage/url_upload.mdx
+++ b/docs/src/snippets/file-storage/url_upload.mdx
@@ -1,0 +1,16 @@
+{/* Auto-generated mdx file. Do not edit! */}
+{/* @sniptest testers/file-storage/url_upload.py */}
+
+```python url_upload.py
+from notte_sdk import NotteClient
+
+client = NotteClient()
+
+with client.Session() as session:
+    session.execute(type="goto", url="https://example.com/upload")
+    session.execute(
+        type="upload_file",
+        selector='input[type="file"]',
+        file_path="https://example.com/document.pdf",
+    )
+```

--- a/docs/src/testers/browser-controls/upload_file.py
+++ b/docs/src/testers/browser-controls/upload_file.py
@@ -6,8 +6,13 @@ client = NotteClient()
 with client.Session() as session:
     session.execute(type="goto", url="https://example.com/upload")
 
-    # Upload from local file
-    session.execute(type="upload_file", selector="input[type='file']", file_path="/path/to/document.pdf")
+    # Upload a local file to the cloud session, then attach it by filename.
+    uploaded = session.storage.upload("/path/to/document.pdf")
+    session.execute(type="upload_file", selector="input[type='file']", file_path=uploaded.filename)
 
-    # Upload with ID
-    session.execute(type="upload_file", id="file-upload", file_path="/path/to/image.jpg")
+    # Or attach a public HTTP(S) file URL directly. Signed URLs also work.
+    session.execute(
+        type="upload_file",
+        selector="input[type='file']",
+        file_path="https://example.com/document.pdf",
+    )

--- a/docs/src/testers/file-storage/url_upload.py
+++ b/docs/src/testers/file-storage/url_upload.py
@@ -4,9 +4,9 @@ from notte_sdk import NotteClient
 client = NotteClient()
 
 with client.Session() as session:
-    session.execute(type="goto", url="https://example.com/upload")
+    session.execute(type="goto", url="https://test-resources-lovat.vercel.app/upload_fixture.html")
     session.execute(
         type="upload_file",
         selector='input[type="file"]',
-        file_path="https://example.com/document.pdf",
+        file_path="https://test-resources-lovat.vercel.app/text1.txt",
     )

--- a/docs/src/testers/file-storage/url_upload.py
+++ b/docs/src/testers/file-storage/url_upload.py
@@ -1,0 +1,12 @@
+# @sniptest filename=url_upload.py
+from notte_sdk import NotteClient
+
+client = NotteClient()
+
+with client.Session() as session:
+    session.execute(type="goto", url="https://example.com/upload")
+    session.execute(
+        type="upload_file",
+        selector='input[type="file"]',
+        file_path="https://example.com/document.pdf",
+    )

--- a/packages/notte-core/src/notte_core/actions/actions.py
+++ b/packages/notte-core/src/notte_core/actions/actions.py
@@ -1327,10 +1327,27 @@ class UploadFileAction(InteractionAction):
     """
     Upload file to interactive element with file path. Use with any upload file element, including button, input, a, span, div. CRITICAL: Use only this for file upload, do not use click.
 
+    In cloud sessions, `file_path` accepts a session file's filename or a public HTTP(S)
+    file URL, including signed URLs. URL files are downloaded on the API server and
+    attached without navigating away from the form. Downloads do not use browser
+    cookies, browser proxy settings, or custom authentication headers. They are
+    temporary and are not added to the session's persistent file catalog.
+
+    URL support requires the cloud backend feature; it does not require an SDK update.
+    Standalone local sessions retain their existing storage/path behavior and do not
+    gain URL downloading. To use a local file with a cloud session, first upload it
+    with `session.storage.upload()` and pass the returned filename.
+
     **Example:**
     ```python
-    session.execute(type="upload_file", id="file-input", file_path="/path/to/document.pdf")
-    session.execute(type="upload_file", id="image-upload", file_path="./image.jpg")
+    # Cloud session: attach an existing session file by filename.
+    session.execute(type="upload_file", selector='input[type="file"]', file_path="document.pdf")
+    # Cloud session: download and attach a public or signed HTTP(S) URL.
+    session.execute(
+        type="upload_file",
+        selector='input[type="file"]',
+        file_path="https://example.com/document.pdf",
+    )
     ```
     """
 

--- a/packages/notte-core/src/notte_core/actions/typedicts.py
+++ b/packages/notte-core/src/notte_core/actions/typedicts.py
@@ -288,6 +288,8 @@ class SelectDropdownOptionActionDict(TypedDict, total=False):
 
 
 class UploadFileActionDict(TypedDict, total=False):
+    """Attach a storage file; cloud sessions also accept HTTP(S) URLs in file_path."""
+
     type: Required[Literal["upload_file"]]
     id: NotRequired[str]
     selector: NotRequired[NodeSelector]


### PR DESCRIPTION
Cloud sessions can accept a public or signed HTTP(S) URL in `upload_file.file_path` once the companion backend change is deployed. Document that behavior in the browser controls guide, file storage guide, action reference, and source docstrings; regenerate the upload snippet and correct its local-file example to stage the file in session storage first.

The SDK implementation and request schema are unchanged. Existing SDK clients can use the feature after backend rollout; standalone local sessions retain their current storage/path behavior. The docs explain temporary storage and the absence of browser cookies, proxy settings, and custom authentication headers.

Validation: full SDK CI on ca8b2f36 passed (944 tests passed, 32 skipped); docs syntax, type-check, and execution CI all passed. All 447 local docs snippet tests passed in syntax mode after moving the inline URL example into a generated snippet. Documentation navigation and SDK method-reference checks passed; example syntax and generated snippet match; AST comparison confirms source changes are docstrings only. Ruff passed with the two existing TRY004 findings excluded.

Companion backend PR: https://github.com/nottelabs/monorepo/pull/2699. Coordinate publication with its rollout; this documentation does not enable URL downloads by itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented support for attaching public or signed HTTP(S) file URLs directly to uploads in cloud sessions.
  - Clarified that URL files are downloaded server-side, remain temporary, and do not use browser credentials or custom headers.
  - Added guidance for uploading local files to cloud storage and attaching them by filename.
  - Documented URL requirements, upload limits, cleanup behavior, and cloud-only support.
  - Updated examples and test fixtures to reflect cloud and local session behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->