### PR TITLE
feat(sdk): add Function.create_run and simplify async invocation docs

### DIFF
--- a/docs/src/docs.json
+++ b/docs/src/docs.json
@@ -307,6 +307,7 @@
                     "collapsed": true,
                     "pages": [
                       "sdk-reference/manual/workflow",
+                      "sdk-reference/nottefunction/create_run",
                       "sdk-reference/nottefunction/run",
                       "sdk-reference/nottefunction/update",
                       "sdk-reference/nottefunction/delete",

--- a/docs/src/features/functions/invocations.mdx
+++ b/docs/src/features/functions/invocations.mdx
@@ -17,6 +17,7 @@ import StreamSdk from "/snippets/functions/invocations/stream_sdk.mdx";
 import StreamHttp from "/snippets/functions/invocations/stream_http.mdx";
 import StreamResponse from "/snippets/functions/invocations/stream_response.mdx";
 import AsyncCreateStart from "/snippets/functions/invocations/async_create_start.mdx";
+import AsyncRun from "/snippets/functions/invocations/async_run.mdx";
 import CheckRunStatus from "/snippets/functions/invocations/check_run_status.mdx";
 import StopRunning from "/snippets/functions/invocations/stop_running.mdx";
 import WebhookHandler from "/snippets/functions/invocations/webhook_handler.mdx";
@@ -110,11 +111,30 @@ Response streams:
 
 ### Create and Start Separately
 
-For long-running functions:
+Use `function.create_run()` when you need a run ID before execution begins.
+It creates the run record only. Pass that ID to `function.run(function_run_id=...)`
+to execute it; omitting the ID creates a different run. If creating a local run,
+pass `local=True` to both calls.
 
 <AsyncCreateStart />
 
+### Run Without Blocking the Event Loop
+
+`function.run()` is synchronous and waits for completion. `stream=True` (the default)
+prints live logs; `stream=False` receives the final JSON response without live logs.
+Disabling streaming does not make standard-runtime execution non-blocking.
+
+Use `asyncio.to_thread()` to keep your application's event loop available:
+
+<AsyncRun />
+
+Keep the application running until the task finishes. This runs the synchronous
+SDK call in a local thread; it does not create a detached server-side job.
+
 ### Check Run Status
+
+`function.get_run(run_id)` fetches the current status and result without waiting
+for execution to finish. From async code, use `await asyncio.to_thread(function.get_run, run_id)`.
 
 <CheckRunStatus />
 

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -420,6 +420,7 @@ The SDK docs below are for generated-code editing and reference. They are not th
 #### Function
 
 - [Get started](https://docs.notte.cc/sdk-reference/manual/workflow.md): Create, manage, and execute automated web functions
+- [create_run](https://docs.notte.cc/sdk-reference/nottefunction/create_run.md): Create a run record without starting execution
 - [run](https://docs.notte.cc/sdk-reference/nottefunction/run.md): Run the function code using the specified version and variables
 - [update](https://docs.notte.cc/sdk-reference/nottefunction/update.md): Update the workflow with a new code version
 - [delete](https://docs.notte.cc/sdk-reference/nottefunction/delete.md): Delete the workflow from the notte console

--- a/docs/src/sdk-reference/misc/createfunctionrunresponse.mdx
+++ b/docs/src/sdk-reference/misc/createfunctionrunresponse.mdx
@@ -1,0 +1,27 @@
+---
+title: "CreateFunctionRunResponse"
+description: ""
+---
+
+
+
+## Fields
+
+<ParamField path="function_id" type="str" required>
+  The ID of the function
+</ParamField>
+
+<ParamField path="function_run_id" type="str" required>
+  The ID of the function run
+</ParamField>
+
+<ParamField path="created_at" type="datetime" required>
+</ParamField>
+
+<ParamField path="status" type="Literal['created']" default="created">
+</ParamField>
+
+
+## Module
+
+`notte_sdk.types`

--- a/docs/src/sdk-reference/misc/nottefunction.mdx
+++ b/docs/src/sdk-reference/misc/nottefunction.mdx
@@ -10,6 +10,20 @@ This is a wrapper around RemoteWorkflow that uses function_id terminology
 
 ## Methods
 
+### create_run
+
+```python
+create_run(local: bool = False) -> CreateFunctionRunResponse
+```
+
+Create a run record without starting execution
+
+**Returns:**
+
+<Visibility for="humans">[`CreateFunctionRunResponse`](/sdk-reference/misc/createfunctionrunresponse)</Visibility><Visibility for="agents">[`CreateFunctionRunResponse`](/sdk-reference/misc/createfunctionrunresponse.md)</Visibility>
+
+---
+
 ### delete
 
 ```python

--- a/docs/src/sdk-reference/nottefunction/create_run.mdx
+++ b/docs/src/sdk-reference/nottefunction/create_run.mdx
@@ -1,0 +1,30 @@
+---
+title: "create_run"
+description: "Create a run record without starting execution"
+---
+import AgentMdNotice from '/partials/agent-md-notice.mdx';
+
+<AgentMdNotice />
+
+Returns the run ID before execution begins. Pass it explicitly to
+`run(function_run_id=...)` to execute this run; `run()` without an ID
+creates a new run. Use the same `local` value when creating and running.
+
+```python
+function = notte.Function("<your-function-id>")
+created = function.create_run()
+result = function.run(function_run_id=created.function_run_id, url="https://example.com")
+```
+
+`run()` still waits for completion. Creating a run does not launch a
+background job or change which run `run()` uses by default
+
+
+## Parameters
+
+<ParamField path="local" type="bool" default="False">
+</ParamField>
+
+## Returns
+
+<Visibility for="humans">[`CreateFunctionRunResponse`](/sdk-reference/misc/createfunctionrunresponse)</Visibility><Visibility for="agents">[`CreateFunctionRunResponse`](/sdk-reference/misc/createfunctionrunresponse.md)</Visibility>

--- a/docs/src/sdk-reference/nottefunction/index.mdx
+++ b/docs/src/sdk-reference/nottefunction/index.mdx
@@ -33,6 +33,24 @@ This is a wrapper around RemoteWorkflow that uses function_id terminology.
   </Visibility>
   <Visibility for="humans">
     <Card
+      title="create_run"
+      icon="function"
+      href="/sdk-reference/nottefunction/create_run"
+    >
+      Create a run record without starting execution
+    </Card>
+  </Visibility>
+  <Visibility for="agents">
+    <Card
+      title="create_run"
+      icon="function"
+      href="/sdk-reference/nottefunction/create_run.md"
+    >
+      Create a run record without starting execution
+    </Card>
+  </Visibility>
+  <Visibility for="humans">
+    <Card
       title="delete"
       icon="function"
       href="/sdk-reference/nottefunction/delete"

--- a/docs/src/sdk-reference/nottefunction/run.mdx
+++ b/docs/src/sdk-reference/nottefunction/run.mdx
@@ -7,6 +7,9 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 <AgentMdNotice />
 
 If no version is provided, the latest version is used.
+This call waits for completion; streaming controls live log delivery.
+For a Function, call `create_run()` first to obtain a run ID before execution,
+then pass it as `function_run_id`. Omitting the ID creates a new run.
 Omit runtime to use the saved function default. Pass runtime="extended"
 for longer cloud execution, or runtime="standard" to override that default.
 Use `input_variables={"runtime": value}` for script inputs whose names match

--- a/docs/src/sdk-reference/nottefunction/run.mdx
+++ b/docs/src/sdk-reference/nottefunction/run.mdx
@@ -8,8 +8,9 @@ import AgentMdNotice from '/partials/agent-md-notice.mdx';
 
 If no version is provided, the latest version is used.
 This call waits for completion; streaming controls live log delivery.
-For a Function, call `create_run()` first to obtain a run ID before execution,
-then pass it as `function_run_id`. Omitting the ID creates a new run.
+For a Function, optionally call `create_run()` only if you need the run ID
+before execution, then pass it as `function_run_id`. When `function_run_id`
+is omitted, `run()` automatically creates a new run.
 Omit runtime to use the saved function default. Pass runtime="extended"
 for longer cloud execution, or runtime="standard" to override that default.
 Use `input_variables={"runtime": value}` for script inputs whose names match

--- a/docs/src/snippets/functions/invocations/async_create_start.mdx
+++ b/docs/src/snippets/functions/invocations/async_create_start.mdx
@@ -5,12 +5,13 @@
 from notte_sdk import NotteClient
 
 client = NotteClient()
-# Create a run (returns immediately)
-run_response = client.functions.create_run("function_abc123", local=False)
+function = client.Function("function_abc123")
+# Create a run record without starting execution.
+created = function.create_run()
 
-run_id = run_response.workflow_run_id
+run_id = created.function_run_id
 print(f"Run created: {run_id}")
 
-# Start the run
-client.functions.run(run_id, function_id="function_abc123", variables={"url": "https://example.com"})
+# Execute that run and wait for its result.
+result = function.run(function_run_id=run_id, url="https://example.com")
 ```

--- a/docs/src/snippets/functions/invocations/async_run.mdx
+++ b/docs/src/snippets/functions/invocations/async_run.mdx
@@ -1,0 +1,28 @@
+{/* Auto-generated mdx file. Do not edit! */}
+{/* @sniptest testers/functions/invocations/async_run.py */}
+
+```python async_run.py
+import asyncio
+
+from notte_sdk import NotteClient
+
+
+async def main():
+    function = NotteClient().Function("function_abc123")
+    created = await asyncio.to_thread(function.create_run)
+    pending = asyncio.create_task(
+        asyncio.to_thread(
+            function.run,
+            function_run_id=created.function_run_id,
+            url="https://example.com",
+        )
+    )
+
+    # Other async work can run while execution is in progress.
+    print(f"Run ID: {created.function_run_id}")
+    result = await pending
+    print(result.result)
+
+
+asyncio.run(main())
+```

--- a/docs/src/snippets/functions/invocations/check_run_status.mdx
+++ b/docs/src/snippets/functions/invocations/check_run_status.mdx
@@ -2,8 +2,7 @@
 {/* @sniptest testers/functions/invocations/check_run_status.py */}
 
 ```python check_run_status.py
-# Check run status
-run_status = client.functions.get_run("function_abc123", run_id)
+run_status = function.get_run(run_id)
 
 print(f"Status: {run_status.status}")  # "active", "closed", "failed"
 print(f"Result: {run_status.result}")

--- a/docs/src/snippets/functions/invocations/stop_running.mdx
+++ b/docs/src/snippets/functions/invocations/stop_running.mdx
@@ -2,6 +2,5 @@
 {/* @sniptest testers/functions/invocations/stop_running.py */}
 
 ```python stop_running.py
-# Stop a long-running function
-client.functions.stop_run("function_abc123", run_id)
+function.stop_run(run_id)
 ```

--- a/docs/src/testers/functions/invocations/async_create_start.py
+++ b/docs/src/testers/functions/invocations/async_create_start.py
@@ -2,11 +2,12 @@
 from notte_sdk import NotteClient
 
 client = NotteClient()
-# Create a run (returns immediately)
-run_response = client.functions.create_run("function_abc123", local=False)
+function = client.Function("function_abc123")
+# Create a run record without starting execution.
+created = function.create_run()
 
-run_id = run_response.workflow_run_id
+run_id = created.function_run_id
 print(f"Run created: {run_id}")
 
-# Start the run
-client.functions.run(run_id, function_id="function_abc123", variables={"url": "https://example.com"})
+# Execute that run and wait for its result.
+result = function.run(function_run_id=run_id, url="https://example.com")

--- a/docs/src/testers/functions/invocations/async_run.py
+++ b/docs/src/testers/functions/invocations/async_run.py
@@ -1,0 +1,24 @@
+# @sniptest filename=async_run.py
+import asyncio
+
+from notte_sdk import NotteClient
+
+
+async def main():
+    function = NotteClient().Function("function_abc123")
+    created = await asyncio.to_thread(function.create_run)
+    pending = asyncio.create_task(
+        asyncio.to_thread(
+            function.run,
+            function_run_id=created.function_run_id,
+            url="https://example.com",
+        )
+    )
+
+    # Other async work can run while execution is in progress.
+    print(f"Run ID: {created.function_run_id}")
+    result = await pending
+    print(result.result)
+
+
+asyncio.run(main())

--- a/docs/src/testers/functions/invocations/check_run_status.py
+++ b/docs/src/testers/functions/invocations/check_run_status.py
@@ -1,12 +1,13 @@
 # @sniptest filename=check_run_status.py
-# @sniptest show=6-12
+# @sniptest show=8-13
 from notte_sdk import NotteClient
 
 client = NotteClient()
+function = client.Function("function_abc123")
 run_id = "run_xyz789"
 
 # Check run status
-run_status = client.functions.get_run("function_abc123", run_id)
+run_status = function.get_run(run_id)
 
 print(f"Status: {run_status.status}")  # "active", "closed", "failed"
 print(f"Result: {run_status.result}")

--- a/docs/src/testers/functions/invocations/stop_running.py
+++ b/docs/src/testers/functions/invocations/stop_running.py
@@ -1,9 +1,10 @@
 # @sniptest filename=stop_running.py
-# @sniptest show=6-8
+# @sniptest show=8-10
 from notte_sdk import NotteClient
 
 client = NotteClient()
+function = client.Function("function_abc123")
 run_id = "run_xyz789"
 
 # Stop a long-running function
-client.functions.stop_run("function_abc123", run_id)
+function.stop_run(run_id)

--- a/packages/notte-sdk/src/notte_sdk/endpoints/functions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/functions.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Unpack, overload
 from typing_extensions import override
 
 from notte_sdk.endpoints.workflows import RemoteWorkflow
-from notte_sdk.types import CreateFunctionRequestDict
+from notte_sdk.types import CreateFunctionRequestDict, CreateFunctionRunResponse
 
 if TYPE_CHECKING:
     from notte_sdk.client import NotteClient
@@ -42,6 +42,25 @@ class NotteFunction(RemoteWorkflow):
         else:
             # Call with keyword arguments to match second overload
             super().__init__(_client=_client, **data)  # pyright: ignore[reportDeprecated]
+
+    def create_run(self, local: bool = False) -> CreateFunctionRunResponse:
+        """
+        Create a run record without starting execution.
+
+        Returns the run ID before execution begins. Pass it explicitly to
+        `run(function_run_id=...)` to execute this run; `run()` without an ID
+        creates a new run. Use the same `local` value when creating and running.
+
+        ```python
+        function = notte.Function("<your-function-id>")
+        created = function.create_run()
+        result = function.run(function_run_id=created.function_run_id, url="https://example.com")
+        ```
+
+        `run()` still waits for completion. Creating a run does not launch a
+        background job or change which run `run()` uses by default.
+        """
+        return self.client.create_run(self._function_id, local=local)
 
     @override
     def fork(self) -> "NotteFunction":

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -799,8 +799,9 @@ class RemoteWorkflow:
 
         If no version is provided, the latest version is used.
         This call waits for completion; streaming controls live log delivery.
-        For a Function, call `create_run()` first to obtain a run ID before execution,
-        then pass it as `function_run_id`. Omitting the ID creates a new run.
+        For a Function, optionally call `create_run()` only if you need the run ID
+        before execution, then pass it as `function_run_id`. When `function_run_id`
+        is omitted, `run()` automatically creates a new run.
         Omit runtime to use the saved function default. Pass runtime="extended"
         for longer cloud execution, or runtime="standard" to override that default.
         Use `input_variables={"runtime": value}` for script inputs whose names match

--- a/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/workflows.py
@@ -798,6 +798,9 @@ class RemoteWorkflow:
         Run the function code using the specified version and variables.
 
         If no version is provided, the latest version is used.
+        This call waits for completion; streaming controls live log delivery.
+        For a Function, call `create_run()` first to obtain a run ID before execution,
+        then pass it as `function_run_id`. Omitting the ID creates a new run.
         Omit runtime to use the saved function default. Pass runtime="extended"
         for longer cloud execution, or runtime="standard" to override that default.
         Use `input_variables={"runtime": value}` for script inputs whose names match

--- a/tests/integration/sdk/test_functions.py
+++ b/tests/integration/sdk/test_functions.py
@@ -1,0 +1,58 @@
+import json
+from collections.abc import Generator
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from dotenv import load_dotenv
+from notte_sdk import NotteClient
+from notte_sdk.endpoints.functions import NotteFunction
+
+
+@pytest.fixture
+def function(tmp_path: Path) -> Generator[NotteFunction, None, None]:
+    """Deploy an isolated function that needs no browser or external website."""
+    _ = load_dotenv()
+    client = NotteClient()
+    source = tmp_path / "echo_function.py"
+    source.write_text('def run(value: str) -> dict:\n    return {"echo": value}\n')
+    fn = client.Function(path=str(source))
+    try:
+        yield fn
+    finally:
+        fn.delete()
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_create_run_then_execute_and_retrieve(function: NotteFunction, stream: bool) -> None:
+    """Exercise create_run -> run -> get_run through the live API, without mocks."""
+    created = function.create_run()
+    run_id = created.function_run_id
+    try:
+        assert created.function_id == function.function_id
+        assert created.status == "created"
+        assert run_id
+
+        # Creation alone must leave the run unexecuted.
+        before = function.get_run(run_id)
+        assert before.function_run_id == run_id
+        assert before.result is None
+        assert before.local is False
+
+        value = str(uuid4())
+        result = function.run(function_run_id=run_id, stream=stream, value=value)
+        assert result.function_run_id == run_id
+        assert result.function_id == function.function_id
+        assert result.status == "closed"
+        assert result.result == {"echo": value}
+
+        persisted = function.get_run(run_id)
+        assert persisted.function_run_id == run_id
+        assert persisted.status == "closed"
+        assert persisted.variables == {"value": value}
+        assert persisted.result is not None
+        assert json.loads(persisted.result) == {"echo": value}
+    finally:
+        # Close an unstarted or interrupted run if an earlier assertion failed.
+        if function.get_run(run_id).status == "active":
+            function.stop_run(run_id)

--- a/tests/sdk/test_function_create_run.py
+++ b/tests/sdk/test_function_create_run.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from notte_sdk import NotteClient
+from notte_sdk.types import CreateFunctionRunResponse, FunctionRunResponse
+
+
+@pytest.mark.parametrize("local", [False, True])
+def test_create_run_does_not_execute_or_fetch_function(local: bool) -> None:
+    client = NotteClient(api_key="test-api-key", server_url="https://api.notte.cc")
+    function = client.Function("function-123")
+    created = CreateFunctionRunResponse(
+        function_id="function-123", function_run_id="run-123", created_at=datetime.now(timezone.utc)
+    )
+    with (
+        patch.object(client.functions, "create_run", return_value=created) as create,
+        patch.object(client.functions, "get") as get,
+        patch.object(client.functions, "run") as run,
+    ):
+        response = function.create_run(local=True) if local else function.create_run()
+
+    assert response is created
+    create.assert_called_once_with("function-123", local=local)
+    get.assert_not_called()
+    run.assert_not_called()
+    assert function._function_run_id is None
+
+
+def test_created_run_can_be_executed_without_creating_another() -> None:
+    client = NotteClient(api_key="test-api-key", server_url="https://api.notte.cc")
+    function = client.Function("function-123")
+    created = CreateFunctionRunResponse(
+        function_id="function-123", function_run_id="run-123", created_at=datetime.now(timezone.utc)
+    )
+    completed = FunctionRunResponse(
+        function_id="function-123", function_run_id="run-123", session_id=None, status="closed", result={"ok": True}
+    )
+    with (
+        patch.object(client.functions, "create_run", return_value=created) as create,
+        patch.object(client.functions, "get") as get,
+        patch.object(client.functions, "run", return_value=completed) as run,
+    ):
+        get.return_value.function_id = "function-123"
+        response = function.create_run()
+        result = function.run(function_run_id=response.function_run_id, url="https://example.com")
+
+    assert result is completed
+    create.assert_called_once_with("function-123", local=False)
+    assert run.call_args.kwargs["function_run_id"] == "run-123"
+    assert run.call_args.kwargs["variables"] == {"url": "https://example.com"}
+
+
+def test_create_run_propagates_api_errors() -> None:
+    client = NotteClient(api_key="test-api-key", server_url="https://api.notte.cc")
+    function = client.Function("function-123")
+    with patch.object(client.functions, "create_run", side_effect=ValueError("Function unavailable")):
+        with pytest.raises(ValueError, match="Function unavailable"):
+            function.create_run()


### PR DESCRIPTION
## Summary

Getting a function run ID before execution currently requires dropping down to `client.functions.create_run(function_id)`. Add `function.create_run(local=False)` so creation, execution, status retrieval, and stopping can all use the same function object.

```python
function = client.Function("your-function-id")
created = function.create_run()
result = function.run(function_run_id=created.function_run_id, url="https://example.com")
status = function.get_run(created.function_run_id)
```

The method only creates a run record. It does not start execution, fetch function metadata, or implicitly select the next run; callers pass the returned ID explicitly to `run()`.

Update the async invocation guide, generated snippets, and SDK reference to use this API. Clarify that streaming controls live logs and that standard execution still waits for completion; show `asyncio.to_thread()` for keeping an event loop available. Preserve the runtime and input-variable documentation already on main.

## Validation

- Based on freshly fetched `origin/main` (`792e3b6b`).
- Six focused SDK tests passed against this worktree: creation without execution/metadata fetch, local flag propagation, executing the pre-created ID without creating another run, error propagation, and existing endpoint checks.
- Ruff and `git diff --check` passed.
- Live API integration tests passed: `tests/integration/sdk/test_functions.py` — 2 passed in 7.93s (`stream=True` and `stream=False`), with test-function cleanup completed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791710018&installation_model_id=8247&pr_number=962&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F962&signature=049bf73f3daaa52873861f1962d2299481e34c6ceb1b69191a48c2ece06306e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create a function run record and receive its run ID before execution.
  - Start a specific run using its ID.
  - Run functions asynchronously without blocking other work while monitoring status and stopping runs.

- **Documentation**
  - Added SDK reference pages and navigation for run creation and response details.
  - Updated invocation guidance and examples to use the object-oriented SDK interface.
  - Documented log streaming, optional run creation, and run status checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Live integration coverage

Added `tests/integration/sdk/test_functions.py` with streaming enabled/disabled cases. Each deploys an isolated echo function, calls `function.create_run()`, checks that no result exists yet, executes that exact ID, and verifies the persisted status, input variables, and output via `function.get_run()`. Cleanup stops any still-active run and deletes the test function.

Both live API cases passed locally (2 passed in 7.93s), using the Notte credential from the local monorepo Node SDK environment. Both tests completed cleanup. The four focused create-run unit tests and all commit checks also pass.
