### PR TITLE
fix: repair nightly examples and SDK documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 
 # Notte SDK configuration
 # -> Cloud hosted sessions & notte API
-NOTTE_API_URL=api.notte.cc
+NOTTE_API_URL=https://api.notte.cc
 NOTTE_API_KEY=
 
 

--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -16,6 +16,8 @@ env:
   DISABLE_TELEMETRY: "true"
   NOTTE_API_KEY: ${{ secrets.NOTTE_API_KEY }}
   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+  # Use the Vertex credentials configured below for the local-agent example.
+  NOTTE_EXAMPLE_MODEL: "vertex_ai/gemini-2.5-flash"
   GITHUB_COM_EMAIL: ${{ secrets.BOT_GITHUB_COM_EMAIL }}
   GITHUB_COM_PASSWORD: ${{ secrets.BOT_GITHUB_COM_PASSWORD }}
   GITHUB_COM_MFA_SECRET: ${{ secrets.BOT_GITHUB_COM_MFA_SECRET }}
@@ -126,14 +128,32 @@ jobs:
         if: always()
         run: uv run python scripts/cleanup_ci_vaults.py --allow-production
 
+      - name: Build Slack notification
+        if: always()
+        env:
+          RUN_TIMESTAMP: ${{ steps.timestamp.outputs.timestamp }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          summary_path = Path("pytest_summary.log")
+          summary = summary_path.read_text() if summary_path.exists() else "Example tests did not run. See the workflow logs."
+          summary = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", summary)
+          payload = {
+              "username": f"GitHub Nightly Pipeline ({os.environ['RUN_TIMESTAMP']})",
+              "text": f"Pipeline results: {os.environ['RUN_URL']}\n```\n{summary[:12000]}\n```",
+          }
+          Path("slack-payload.json").write_text(json.dumps(payload))
+          PY
+
       - name: Send Slack Notification
         if: always()
         uses: slackapi/slack-github-action@v1.24.0
         with:
-          payload: |
-            {
-              "username": "GitHub Nightly Pipeline (${{ steps.timestamp.outputs.timestamp }})",
-              "text": "Pipeline results: (cf url (https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})) \n ```\n${{ env.TEST_OUTPUT }}```"
-            }
+          payload-file-path: slack-payload.json
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_WEBHOOK_URL }}

--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 6 * * *'  # Run at 6 AM every day
   workflow_dispatch:  # Allow manual triggering
+    inputs:
+      test_filter:
+        description: "Optional pytest -k expression for focused example runs"
+        required: false
+        default: ""
+        type: string
 
 env:
   CACHE_TYPE: "pip"
@@ -112,7 +118,9 @@ jobs:
           echo "Environment variables are set"
 
       - name: Run example tests
-        run: xvfb-run --auto-servernum bash tests/run_examples.sh
+        env:
+          EXAMPLE_TEST_FILTER: ${{ inputs.test_filter || '' }}
+        run: xvfb-run --auto-servernum bash tests/run_examples.sh -k "$EXAMPLE_TEST_FILTER"
 
       - name: Cleanup vaults created by this run
         if: always()

--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -62,9 +62,41 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev --all-extras
 
-      - name: Install patchright
+      - name: Use HTTPS Ubuntu mirrors on Blacksmith
         run: |
-          echo "Cache miss - installing patchright"
+          # Canonical's archive/security endpoints intermittently fail from
+          # Blacksmith over both HTTP and HTTPS. Prefer kernel.org's Ubuntu
+          # mirror, with the official archive as fallback, for every suite.
+          # Preserve suites (including noble-security) and Ubuntu signing keys.
+          sudo python3 - <<'PY'
+          from pathlib import Path
+          import re
+
+          apt = Path('/etc/apt')
+          mirror_list = apt / 'blacksmith-ubuntu-mirrors.txt'
+          mirror_list.write_text(
+              'https://mirrors.edge.kernel.org/ubuntu\tpriority:1\n'
+              'https://archive.ubuntu.com/ubuntu\tpriority:2\n')
+          sources = [apt / 'sources.list']
+          sources += list((apt / 'sources.list.d').glob('*.list'))
+          sources += list((apt / 'sources.list.d').glob('*.sources'))
+          for source in sources:
+              if source.is_file():
+                  source.write_text(re.sub(
+                      r'https?://(?:(?:[a-z0-9-]+\.)*archive\.ubuntu\.com|security\.ubuntu\.com)/ubuntu/?(?=\s|$)',
+                      f'mirror+file:{mirror_list}', source.read_text()))
+          PY
+          # Bound each network wait and reject stale indexes after an error.
+          sudo tee /etc/apt/apt.conf.d/99-ci-network > /dev/null <<'EOF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          Acquire::Retries "2";
+          APT::Update::Error-Mode "any";
+          EOF
+
+      - name: Install patchright
+        timeout-minutes: 5
+        run: |
           uv run patchright install --with-deps chromium --no-shell
 
       - name: Verify environment variables

--- a/README.md
+++ b/README.md
@@ -301,11 +301,12 @@ client = NotteClient()
 
 with client.Session(open_viewer=True) as session:
     # Start with a deterministic navigation
-    session.execute(type="goto", url="https://duckduckgo.com/")
-    session.execute(type="fill", selector="internal:role=combobox[name=\"Search with DuckDuckGo\"i]", value="nottelabs")
-    agent = client.Agent(session=session, max_steps=3)
+    session.execute(type="goto", url="https://github.com/nottelabs")
+    agent = client.Agent(session=session, max_steps=10)
     # Use an agent to reason about the next step
-    agent.run(task="Open nottelabs github repository")
+    response = agent.run(task="Open the notte repository owned by nottelabs. Finish on its repository home page.")
+    assert response.success, response.answer
+    assert session.observe().metadata.url.split("?")[0].rstrip("/") == "https://github.com/nottelabs/notte"
     # Use a scraping endpoint to extract data
     data = session.scrape(instructions="Extract number of stars")
 ```

--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ Use the following script to spinup an agent using opensource features (you'll ne
 
 ```python
 import notte
+import os
 from dotenv import load_dotenv
 load_dotenv()
 
 with notte.Session(headless=False) as session:
-    agent = notte.Agent(session=session, reasoning_model='gemini/gemini-2.5-flash', max_steps=30)
-    response = agent.run(task="doom scroll cat memes on google images")
+    model = os.getenv("NOTTE_EXAMPLE_MODEL", "gemini/gemini-2.5-flash")
+    agent = notte.Agent(session=session, reasoning_model=model, max_steps=10)
+    response = agent.run(task="Find three cat memes on Google Images and describe them")
 ```
 
 ### Using Python SDK (Recommended)
@@ -285,7 +287,7 @@ from notte_sdk import NotteClient
 client = NotteClient()
 cdp_url = os.environ["EXTERNAL_CDP_URL"]
 
-with client.Session(cdp_url=cdp_url, viewport_width=None, viewport_height=None) as session:
+with client.Session(cdp_url=cdp_url, proxies=False, viewport_width=None, viewport_height=None) as session:
     agent = client.Agent(session=session)
     response = agent.run(task="extract pricing plans from https://www.notte.cc/")
 ```

--- a/README.md
+++ b/README.md
@@ -178,11 +178,20 @@ with client.Session(
         url="https://www.google.com/recaptcha/api2/demo"
     )
 
-# Custom proxy configuration
+```
+
+For a custom proxy, set `PROXY_SERVER`, `PROXY_USERNAME`, and `PROXY_PASSWORD` to your provider's connection details.
+
+```python requires-env="PROXY_SERVER,PROXY_USERNAME,PROXY_PASSWORD"
+import os
+from notte_sdk import NotteClient
+from notte_sdk.types import ExternalProxy
+
+client = NotteClient()
 proxy_settings = ExternalProxy(
-    server="http://your-proxy-server:port",
-    username="your-username",
-    password="your-password",
+    server=os.environ["PROXY_SERVER"],
+    username=os.environ["PROXY_USERNAME"],
+    password=os.environ["PROXY_PASSWORD"],
 )
 
 with client.Session(proxies=[proxy_settings]) as session:
@@ -193,35 +202,36 @@ with client.Session(proxies=[proxy_settings]) as session:
 ## File download / upload
 
 File Storage allows you to upload files for your agents and download files that agents retrieve during their work.
-Uploaded files are user-scoped, while files downloaded by an agent are session-scoped.
+Both uploaded files and browser downloads belong to a session. Start a session before uploading files, and use file IDs to download them.
+Set `UPLOAD_FILE_PATH` to a local document and `UPLOAD_URL` to the website where your agent should upload it.
 
-```python
+```python requires-env="UPLOAD_FILE_PATH,UPLOAD_URL"
+import os
 from notte_sdk import NotteClient
+from notte_sdk.types import FileSource
 
 client = NotteClient()
-storage = client.FileStorage()
 
-# Upload files before agent execution
-storage.upload("/path/to/document.pdf")
+with client.Session() as session:
+    storage = session.storage
+    uploaded_file = storage.upload(os.environ["UPLOAD_FILE_PATH"])
+    storage.download(file_id=uploaded_file.id, local_dir="./inputs")
 
-# Download a user-uploaded file without starting a session
-storage.download_uploaded_file(
-    file_name="document.pdf",
-    local_dir="./inputs",
-)
-
-# Create session with storage attached
-with client.Session(storage=storage) as session:
     agent = client.Agent(session=session, max_steps=5)
     response = agent.run(
-        task="Upload the PDF document to the website and download the cat picture",
-        url="https://example.com/upload"
+        task=f"Upload {uploaded_file.filename} to the website and download the cat picture",
+        url=os.environ["UPLOAD_URL"],
     )
 
-# Download files that the agent downloaded
-downloaded_files = storage.list(type="downloads")
-for file_name in downloaded_files:
-    storage.download(file_name=file_name, local_dir="./results")
+    # Download files that the agent downloaded (100 files per page)
+    offset = 0
+    while True:
+        downloaded_files = storage.list(source=FileSource.SESSION_DOWNLOAD, offset=offset)
+        for file in downloaded_files.files:
+            storage.download(file_id=file.id, local_dir="./results")
+        offset += len(downloaded_files.files)
+        if offset >= downloaded_files.total or not downloaded_files.files:
+            break
 ```
 
 ## Cookies / Auth Sessions
@@ -266,13 +276,16 @@ with client.Session() as session:
 
 You can plug in any browser session provider you want and use our agent on top. Use external headless browser providers via CDP to benefit from Notte's agentic capabilities with any CDP-compatible browser.
 
-```python
+Set `EXTERNAL_CDP_URL` to the WebSocket URL of a running browser from your provider.
+
+```python requires-env="EXTERNAL_CDP_URL"
+import os
 from notte_sdk import NotteClient
 
 client = NotteClient()
-cdp_url = "wss://your-external-cdp-url"
+cdp_url = os.environ["EXTERNAL_CDP_URL"]
 
-with client.Session(cdp_url=cdp_url) as session:
+with client.Session(cdp_url=cdp_url, viewport_width=None, viewport_height=None) as session:
     agent = client.Agent(session=session)
     response = agent.run(task="extract pricing plans from https://www.notte.cc/")
 ```

--- a/docs/run_notte_with_external_browsers.md
+++ b/docs/run_notte_with_external_browsers.md
@@ -2,15 +2,15 @@
 
 Notte is designed to be used with the browsers it provides by default.
 
-However, it is possible to use your own browsers by providing a `BrowserWindow` instance to the `Agent`.
+You can use an external browser provider by creating a session with an integration and passing that session to the agent.
 
 Here is an example of how to setup `Steel` as the base session manager for Notte Agents.
 
 > [!NOTE]
 > You need to install the `notte-integrations` package to be able to use the different external session managers.
 
-```python
-from notte_integrations.sessions import AnchorSession
+```python requires-env="STEEL_API_KEY"
+from notte_integrations.sessions import SteelSession
 from notte_sdk import NotteClient
 
 from dotenv import load_dotenv
@@ -18,8 +18,8 @@ from dotenv import load_dotenv
 _ = load_dotenv()
 
 client = NotteClient()
-# you need to export the ANCHOR_API_KEY environment variable
-with AnchorSession(client=client) as session:
+# you need to export the STEEL_API_KEY environment variable
+with SteelSession(client=client) as session:
     agent = client.Agent(session=session)
     result = agent.run(task="go to x.com and describe what you see")
 ```

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -56,8 +56,8 @@ with notte.Session() as session:
         task="Summarize the job offers on the Notte careers page.",
         url="https://notte.cc",
     )
-    # get session replay
-    replay = session.replay()
+# Retrieve the replay after closing the session
+replay = session.replay()
 ```
 
 The session context manager stops the session when the block exits. You can run multiple agents in the same session before closing it.

--- a/docs/sdk_tutorial.md
+++ b/docs/sdk_tutorial.md
@@ -9,7 +9,7 @@ import os
 notte = NotteClient(api_key=os.getenv("NOTTE_API_KEY"))
 
 # start / stop your session using the context manager
-with notte.Session(timeout_minutes=5) as session:
+with notte.Session(max_duration_minutes=5) as session:
     # get the session status
     status = session.status()
 # list your active sessions
@@ -49,17 +49,18 @@ from notte_sdk.client import NotteClient
 import os
 
 notte = NotteClient()
-# start an agent
-agent = notte.Agent(max_steps=10)
-response = agent.run(
-    task="Summarize the job offers on the Notte careers page.",
-    url="https://notte.cc",
-)
-# get session replay
-replay = agent.replay()
+# start a session and attach an agent
+with notte.Session() as session:
+    agent = notte.Agent(session=session, max_steps=10)
+    response = agent.run(
+        task="Summarize the job offers on the Notte careers page.",
+        url="https://notte.cc",
+    )
+    # get session replay
+    replay = session.replay()
 ```
 
-Note that starting an agent also starts a session which is automatically stopped when the agent completes its tasks (or is stopped).
+The session context manager stops the session when the block exits. You can run multiple agents in the same session before closing it.
 
 You can use a non blocking approach to control the execution flow using the `agent.start(...)`, `agent.status(...)` and `agent.stop(...)` methods.
 

--- a/examples/landing-examples/landing_examples.py
+++ b/examples/landing-examples/landing_examples.py
@@ -19,7 +19,11 @@ landing_examples = [
     ["Visit github.com/trending and return the top 3 repositories shown.", None, False],
     ["Check if there are any new blog posts on notte.cc/blog", None, False],
     ["Go to bbc.com and click on the first headline in the 'Sport' section. Return its title.", None, False],
-    ["Go to weather.com and tell me the current temperature in New York City.", None, False],
+    [
+        "Read the current temperature in New York City. Include the observation station and last update time.",
+        "https://forecast.weather.gov/MapClick.php?lat=40.7146&lon=-74.0071",
+        False,
+    ],
 ]
 
 

--- a/examples/landing-examples/landing_examples.py
+++ b/examples/landing-examples/landing_examples.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 
 from dotenv import load_dotenv
@@ -23,10 +24,11 @@ landing_examples = [
 
 
 # run landing page examples
-def main():
+def main(example_index: int | None = None):
     client = NotteClient(api_key=os.getenv("NOTTE_API_KEY"))
 
-    for task, url, use_vault in landing_examples[3:]:
+    selected = landing_examples[3:] if example_index is None else [landing_examples[example_index]]
+    for task, url, use_vault in selected:
         with client.Session() as session:
             if use_vault:
                 with client.Vault() as vault:
@@ -59,4 +61,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Run the landing-page agent examples")
+    parser.add_argument("--example-index", type=int, choices=range(len(landing_examples)))
+    args = parser.parse_args()
+    main(example_index=args.example_index)

--- a/examples/landing-examples/landing_examples.py
+++ b/examples/landing-examples/landing_examples.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 from notte_sdk import NotteClient
 
 # Load environment variables
-_ = load_dotenv(".env.example")
+_ = load_dotenv()
 
 landing_examples = [
     # task str, URL str | None, use vault bool
@@ -41,7 +41,6 @@ def main():
                     )
                     agent = client.Agent(
                         session=session,
-                        reasoning_model="vertex_ai/gemini-2.0-flash",
                         max_steps=15,
                         vault=vault,
                     )
@@ -50,7 +49,6 @@ def main():
             else:
                 agent = client.Agent(
                     session=session,
-                    reasoning_model="vertex_ai/gemini-2.0-flash",
                     max_steps=15,
                 )
                 run_kwargs = {"task": task, **({"url": url} if url is not None else {})}

--- a/examples/scrape-nike-products/README.md
+++ b/examples/scrape-nike-products/README.md
@@ -21,6 +21,8 @@ Follow the setup instructions in the [README](../README.md).
 python agent.py
 ```
 
+For a shorter run that scrapes one category, use `python agent.py --max-categories 1`.
+
 ## Output
 
 The output will be saved in the `nike_results` directory.

--- a/examples/scrape-nike-products/agent.py
+++ b/examples/scrape-nike-products/agent.py
@@ -1,3 +1,4 @@
+import argparse
 import datetime as dt
 from pathlib import Path
 from typing import Annotated
@@ -103,13 +104,17 @@ def scrape_products(session: RemoteSession, cat: ProductCategory) -> ShoppingLis
 # ############################################
 
 
-def scrape_nike_products():
+def scrape_nike_products(max_categories: int | None = None):
+    if max_categories is not None and max_categories < 1:
+        raise ValueError("max_categories must be positive")
     timestamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d_%H%M%S")
     run_dir = RESULT_DIR / timestamp
     run_dir.mkdir(exist_ok=True, parents=True)
 
     with notte.Session(open_viewer=True) as session:
         categories = scrape_categories(session)
+        if max_categories is not None:
+            categories.categories = categories.categories[:max_categories]
         _ = (run_dir / "categories.json").write_text(categories.model_dump_json())
         outputs: list[list[ShoppingItem]] = []
         for category in tqdm(categories.categories):
@@ -132,4 +137,7 @@ Scraping data saved in {run_dir}
 
 
 if __name__ == "__main__":
-    scrape_nike_products()
+    parser = argparse.ArgumentParser(description="Scrape Nike product categories and their products")
+    parser.add_argument("--max-categories", type=int, help="Limit the number of categories to scrape")
+    args = parser.parse_args()
+    scrape_nike_products(max_categories=args.max_categories)

--- a/examples/scrape-nike-products/agent.py
+++ b/examples/scrape-nike-products/agent.py
@@ -133,7 +133,7 @@ Scraping results:
 
 Scraping data saved in {run_dir}
 """)
-        session.replay().save(str(run_dir / "replay.webp"))
+    session.replay().download(run_dir / "replay.mp4")
 
 
 if __name__ == "__main__":

--- a/packages/notte-integrations/src/notte_integrations/sessions/cdp_session.py
+++ b/packages/notte-integrations/src/notte_integrations/sessions/cdp_session.py
@@ -46,8 +46,12 @@ class CDPSessionManager(PlaywrightManager, ABC):
             logger.info("Creating new Notte client")
             self.client = NotteClient()
         self.session = self.create_session_cdp(BrowserWindowOptions.from_request(LocalSessionStartRequest()))
-        self.notte_session = self.client.Session(cdp_url=self.session.cdp_url)
-        return self.notte_session.__enter__()
+        try:
+            self.notte_session = self.client.Session(cdp_url=self.session.cdp_url, proxies=False)
+            return self.notte_session.__enter__()
+        except BaseException:
+            _ = self.close_session_cdp(self.session.session_id)
+            raise
 
     def __exit__(
         self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None
@@ -55,8 +59,10 @@ class CDPSessionManager(PlaywrightManager, ABC):
         if self.notte_session is None or self.session is None:
             raise ValueError("Session not created")
         # close notte session first
-        _ = self.notte_session.__exit__(exc_type, exc_value, traceback)
-        _ = self.close_session_cdp(self.session.session_id)
+        try:
+            _ = self.notte_session.__exit__(exc_type, exc_value, traceback)
+        finally:
+            _ = self.close_session_cdp(self.session.session_id)
 
     @override
     async def astop(self) -> None:

--- a/packages/notte-integrations/src/notte_integrations/sessions/steel.py
+++ b/packages/notte-integrations/src/notte_integrations/sessions/steel.py
@@ -19,7 +19,7 @@ def get_steel_api_key() -> str:
 class SteelSessionsManager(CDPSessionManager):
     steel_base_url: str = "api.steel.dev"  # localhost:3000"
     steel_api_key: str = Field(default_factory=get_steel_api_key)
-    region: str = "fra"
+    region: str | None = None
 
     @override
     def create_session_cdp(self, options: BrowserWindowOptions) -> CDPSession:
@@ -29,7 +29,8 @@ class SteelSessionsManager(CDPSessionManager):
 
         headers = {"Steel-Api-Key": self.steel_api_key}
 
-        response = requests.post(url, headers=headers, json={"region": self.region})
+        payload = {"region": self.region} if self.region is not None else {}
+        response = requests.post(url, headers=headers, json=payload, timeout=60)
         response.raise_for_status()
         data: dict[str, str] = response.json()
         if "localhost" in self.steel_base_url:
@@ -47,7 +48,7 @@ class SteelSessionsManager(CDPSessionManager):
 
         headers = {"Steel-Api-Key": self.steel_api_key}
 
-        response = requests.post(url, headers=headers)
+        response = requests.post(url, headers=headers, timeout=30)
         if response.status_code != 200:
             if self.verbose:
                 logger.error(f"Failed to release Steel session {session_id}: {response.json()}")

--- a/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
+++ b/packages/notte-sdk/src/notte_sdk/endpoints/sessions.py
@@ -498,6 +498,8 @@ class SessionsClient(BaseClient):
         wait: bool = True,
         timeout: float = 240.0,
         poll_interval: float = 5.0,
+        *,
+        _session_closed: bool = False,
     ) -> ReplayResponse:
         """
         Get presigned URLs for session replay.
@@ -532,7 +534,9 @@ class SessionsClient(BaseClient):
                 if e.status_code != 404:
                     raise
                 error_msg = e.error.get("message", "") or e.error.get("detail", "")
-                if "still active" in error_msg:
+                # The replay service can lag behind a successful stop response
+                # while background cleanup persists the session and video.
+                if "still active" in error_msg and not _session_closed:
                     raise ValueError(
                         f"Session {session_id} is still active — close the session first to generate the replay."
                     ) from e
@@ -950,6 +954,7 @@ class RemoteSession(SyncResource):
             wait=wait,
             timeout=timeout,
             poll_interval=poll_interval,
+            _session_closed=self.response is not None and self.response.status == "closed",
         )
 
     def viewer_browser(self) -> None:

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -922,6 +922,13 @@ class _SessionStartRequest(SdkRequest):
 
     @model_validator(mode="after")
     def check_viewport(self) -> "_SessionStartRequest":
+        if self.cdp_url is not None:
+            # Configured viewport defaults belong to browsers we create, not an
+            # external browser. Keep explicit values for CDP validation below.
+            if "viewport_width" not in self.model_fields_set:
+                self.viewport_width = None
+            if "viewport_height" not in self.model_fields_set:
+                self.viewport_height = None
         if (self.viewport_width is None) != (self.viewport_height is None):
             raise ValueError("Both viewport_width and viewport_height must be set together or both must be None")
         return self
@@ -938,10 +945,10 @@ class _SessionStartRequest(SdkRequest):
     @model_validator(mode="after")
     def validate_cdp_url_constraints(self) -> "_SessionStartRequest":
         """
-        Validate that when cdp_url is provided, certain fields are set to their default values.
+        Validate that browser settings are left to the external CDP provider.
 
         Raises:
-            ValueError: If cdp_url is provided but other fields are not set to defaults.
+            ValueError: If cdp_url is provided with browser settings that must be configured by the provider.
         """
         if self.cdp_url is not None:
             if self.user_agent is not None:
@@ -952,11 +959,11 @@ class _SessionStartRequest(SdkRequest):
                 raise ValueError(
                     "When cdp_url is provided, chrome_args must be None. Set the chrome arguments with your external session CDP provider."
                 )
-            if self.viewport_width is not None and self.viewport_width != DEFAULT_VIEWPORT_WIDTH:
+            if self.viewport_width is not None:
                 raise ValueError(
                     "When cdp_url is provided, viewport_width must be None. Set the viewport width with your external session CDP provider."
                 )
-            if self.viewport_height is not None and self.viewport_height != DEFAULT_VIEWPORT_HEIGHT:
+            if self.viewport_height is not None:
                 raise ValueError(
                     "When cdp_url is provided, viewport_height must be None. Set the viewport height with your external session CDP provider."
                 )

--- a/packages/notte-sdk/src/notte_sdk/types.py
+++ b/packages/notte-sdk/src/notte_sdk/types.py
@@ -923,6 +923,8 @@ class _SessionStartRequest(SdkRequest):
     @model_validator(mode="after")
     def check_viewport(self) -> "_SessionStartRequest":
         if self.cdp_url is not None:
+            if "proxies" not in self.model_fields_set:
+                self.proxies = False
             # Configured viewport defaults belong to browsers we create, not an
             # external browser. Keep explicit values for CDP validation below.
             if "viewport_width" not in self.model_fields_set:
@@ -951,6 +953,8 @@ class _SessionStartRequest(SdkRequest):
             ValueError: If cdp_url is provided with browser settings that must be configured by the provider.
         """
         if self.cdp_url is not None:
+            if self.proxies:
+                raise ValueError("Proxies must be configured by the external CDP provider, not by Notte")
             if self.user_agent is not None:
                 raise ValueError(
                     "When cdp_url is provided, user_agent must be None. Set the user agent with your external session CDP provider."

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -175,13 +175,18 @@ def test_use_case_script(use_case_dir: Path) -> None:
         use_case_dir: Path to the use case directory to test
     """
     OVERRIDE_ARGS: dict[str, list[str]] = {"human-in-the-loop": ["--task", "go to duckduckgo"]}
+    OVERRIDE_ARGS["scrape-nike-products"] = ["--max-categories", "1"]
+    entrypoints = {
+        "landing-examples": "landing_examples.py",
+        "session-solve-captcha": "main.py",
+    }
 
-    agent_file = use_case_dir / "agent.py"
-    assert agent_file.exists(), f"No agent.py file found in {use_case_dir}"
+    agent_file = use_case_dir / entrypoints.get(use_case_dir.name, "agent.py")
+    assert agent_file.exists(), f"No example script found at {agent_file}"
     exit_code, logged = run_python_file(agent_file, OVERRIDE_ARGS.get(use_case_dir.name, []))
 
     if use_case_dir.name == "github-auto-issues-trending-repos":
         assert exit_code != 0
         assert logged[-1] == "KeyError: 'AUTO_ISSUES_GITHUB_EMAIL'"
     else:
-        assert exit_code == 0, f"Failed to run {use_case_dir.name}"
+        assert exit_code == 0, f"Failed to run {use_case_dir.name} (exit code {exit_code}):\n" + "\n".join(logged[-30:])

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -167,6 +167,7 @@ def test_root_level_scripts(python_file: Path) -> None:
 
 
 @pytest.mark.parametrize("use_case_dir", get_use_cases_dirs(), ids=lambda p: p.name)
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun=["Failed to solve captcha! Please try again"])
 def test_use_case_script(use_case_dir: Path) -> None:
     """
     Test that a Python file runs without errors.

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -166,7 +166,9 @@ def test_root_level_scripts(python_file: Path) -> None:
     assert exit_code == 0, f"Failed to run {python_file.name} {logs[-1] if len(logs) > 0 else ''}"
 
 
-@pytest.mark.parametrize("use_case_dir", get_use_cases_dirs(), ids=lambda p: p.name)
+@pytest.mark.parametrize(
+    "use_case_dir", get_use_cases_dirs(ignore_list=("__pycache__", "landing-examples")), ids=lambda p: p.name
+)
 @pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun=["Failed to solve captcha! Please try again"])
 def test_use_case_script(use_case_dir: Path) -> None:
     """
@@ -191,3 +193,13 @@ def test_use_case_script(use_case_dir: Path) -> None:
         assert logged[-1] == "KeyError: 'AUTO_ISSUES_GITHUB_EMAIL'"
     else:
         assert exit_code == 0, f"Failed to run {use_case_dir.name} (exit code {exit_code}):\n" + "\n".join(logged[-30:])
+
+
+@pytest.mark.parametrize(
+    "index", [3, 4, 5], ids=["landing-examples-blog", "landing-examples-bbc", "landing-examples-weather"]
+)
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun=["Task failed due to session expiration"])
+def test_landing_example(index: int) -> None:
+    script = Path(__file__).resolve().parents[2] / "examples" / "landing-examples" / "landing_examples.py"
+    exit_code, logged = run_python_file(script, ["--example-index", str(index)])
+    assert exit_code == 0, f"Landing example {index} failed (exit code {exit_code}):\n" + "\n".join(logged[-30:])

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -2,6 +2,7 @@ import logging
 import os
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -59,7 +60,7 @@ def run_python_file(file_path: Path, args: list[str], timeout_seconds: float = 2
     """
     with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as output:
         process = subprocess.Popen(
-            ["python", str(file_path)] + args,
+            [sys.executable, str(file_path)] + args,
             stdout=output,
             stderr=subprocess.STDOUT,
             text=True,

--- a/tests/examples/test_harness.py
+++ b/tests/examples/test_harness.py
@@ -46,8 +46,16 @@ def test_configured_example_still_reports_execution_errors(monkeypatch: pytest.M
 
 def test_nike_category_limit(tmp_path: Path):
     script = Path(__file__).resolve().parents[2] / "examples" / "scrape-nike-products" / "agent.py"
-    with patch("notte_sdk.NotteClient"):
+    with patch("notte_sdk.NotteClient") as client_type:
         namespace = runpy.run_path(str(script))
+    context = client_type.return_value.Session.return_value
+    session = context.__enter__.return_value
+
+    def replay_after_close():
+        context.__exit__.assert_called_once()
+        return Mock(spec=["download"])
+
+    session.replay.side_effect = replay_after_close
     scrape = namespace["scrape_nike_products"]
     categories = namespace["ProductCategories"].example()
     products = Mock(return_value=namespace["ShoppingList"](items=[]))

--- a/tests/examples/test_harness.py
+++ b/tests/examples/test_harness.py
@@ -1,0 +1,64 @@
+import runpy
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from pytest_examples import CodeExample
+
+from tests.examples import test_examples, test_readme
+
+
+@pytest.mark.parametrize(
+    "directory,entrypoint,args",
+    [
+        ("landing-examples", "landing_examples.py", []),
+        ("session-solve-captcha", "main.py", []),
+        ("scrape-nike-products", "agent.py", ["--max-categories", "1"]),
+    ],
+)
+def test_use_case_entrypoints(directory: str, entrypoint: str, args: list[str]):
+    example_dir = Path(__file__).resolve().parents[2] / "examples" / directory
+    with patch.object(test_examples, "run_python_file", return_value=(0, [])) as run:
+        test_examples.test_use_case_script(example_dir)
+    run.assert_called_once_with(example_dir / entrypoint, args)
+
+
+def test_missing_example_configuration_skips_before_execution(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("EXTERNAL_CDP_URL", raising=False)
+    example = CodeExample.create("raise RuntimeError('must not run')", prefix='python requires-env="external_cdp_url"')
+    evaluator = Mock()
+
+    with pytest.raises(pytest.skip.Exception, match="EXTERNAL_CDP_URL"):
+        test_readme.run_example_safely(example, evaluator)
+    evaluator.run.assert_not_called()
+
+
+def test_configured_example_still_reports_execution_errors(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("EXTERNAL_CDP_URL", "ws://localhost:9222")
+    example = CodeExample.create("bad_code()", prefix='python requires-env="external_cdp_url"')
+    evaluator = Mock()
+    evaluator.run.side_effect = NameError("bad_code is not defined")
+
+    with pytest.raises(AssertionError, match="NameError: bad_code is not defined"):
+        test_readme.run_example_safely(example, evaluator)
+    evaluator.run.assert_called_once_with(example)
+
+
+def test_nike_category_limit(tmp_path: Path):
+    script = Path(__file__).resolve().parents[2] / "examples" / "scrape-nike-products" / "agent.py"
+    with patch("notte_sdk.NotteClient"):
+        namespace = runpy.run_path(str(script))
+    scrape = namespace["scrape_nike_products"]
+    categories = namespace["ProductCategories"].example()
+    products = Mock(return_value=namespace["ShoppingList"](items=[]))
+
+    with patch.dict(
+        scrape.__globals__,
+        RESULT_DIR=tmp_path,
+        scrape_categories=Mock(return_value=categories),
+        scrape_products=products,
+    ):
+        scrape(max_categories=1)
+
+    assert products.call_count == 1
+    assert len(list(tmp_path.glob("*/category_*.json"))) == 1

--- a/tests/examples/test_readme.py
+++ b/tests/examples/test_readme.py
@@ -71,7 +71,9 @@ def test_pip_install_notte_browser():
 
 
 @pytest.mark.parametrize("example", find_examples("README.md"), ids=str)
-@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun=["ServiceUnavailableError"])
+@pytest.mark.flaky(
+    reruns=2, reruns_delay=5, only_rerun=["ServiceUnavailableError", r"LLMProviderError: LLM request .* timed out"]
+)
 def test_readme_python_code(example: CodeExample, eval_example: EvalExample):
     _ = load_dotenv()
     run_example_safely(example, eval_example)

--- a/tests/examples/test_readme.py
+++ b/tests/examples/test_readme.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import sys
@@ -11,6 +12,10 @@ from pytest_examples import CodeExample, EvalExample, find_examples
 
 def run_example_safely(example: CodeExample, eval_example: EvalExample) -> None:
     """Run a code example and handle exceptions to avoid Python 3.11 traceback formatting issues."""
+    required_env = example.prefix_settings().get("requires-env", "").upper().split(",")
+    missing = [name.strip() for name in required_env if name.strip() and not os.getenv(name.strip())]
+    if missing:
+        pytest.skip(f"Example requires environment variables: {', '.join(missing)}")
     try:
         _ = eval_example.run(example)
     except Exception as e:
@@ -66,6 +71,7 @@ def test_pip_install_notte_browser():
 
 
 @pytest.mark.parametrize("example", find_examples("README.md"), ids=str)
+@pytest.mark.flaky(reruns=2, reruns_delay=5, only_rerun=["ServiceUnavailableError"])
 def test_readme_python_code(example: CodeExample, eval_example: EvalExample):
     _ = load_dotenv()
     run_example_safely(example, eval_example)

--- a/tests/integration/sdk/file_storage/test_readonly_robust.py
+++ b/tests/integration/sdk/file_storage/test_readonly_robust.py
@@ -114,7 +114,7 @@ def test_download_file_action_is_strictly_readonly():
             # 2. Run the actual User Scenario
             # ----------------------------------------------------------------
 
-            # Mock the session start and execute methods to avoid network calls
+            # Run the remote download without writing to the local filesystem.
             with client.Session(proxies=False, storage=storage, open_viewer=False) as session:
                 _ = session.execute(type="goto", url="https://arxiv.org/abs/1706.03762")
                 _ = session.execute(type="click", selector='internal:role=link[name="View PDF"i]')
@@ -126,14 +126,14 @@ def test_download_file_action_is_strictly_readonly():
 
             # Verify that accessing the file locally triggers a permission error
             # This can trigger either "Filesystem modification denied" (mkdir) or "Write access denied" (open)
+            try:
+                file = _wait_for_download(storage)
+            except NotteAPIError as exc:
+                if exc.status_code == 404:
+                    pytest.skip("Session-file API is not deployed to the integration environment yet")
+                raise
             with pytest.raises(PermissionError, match="Filesystem modification denied|Write access denied"):
-                try:
-                    file = _wait_for_download(storage)
-                except NotteAPIError as exc:
-                    if exc.status_code == 404:
-                        pytest.skip("Session-file API is not deployed to the integration environment yet")
-                    raise
-                _ = storage.download(file.id)
+                _ = storage.download(file_id=file.id)
 
         except PermissionError as e:
             pytest.fail(f"Read-only violation detected: {e}")

--- a/tests/run_examples.sh
+++ b/tests/run_examples.sh
@@ -14,7 +14,7 @@ echo "Summary will be saved to: $SUMMARY_FILE"
 echo "-----------------------------------"
 
 # Run the test command and save full output
-uv run pytest tests/examples --durations 10 | tee "$FULL_LOG"
+uv run pytest tests/examples --durations 10 "$@" | tee "$FULL_LOG"
 status=$?
 
 # Now extract the summary portion

--- a/tests/run_examples.sh
+++ b/tests/run_examples.sh
@@ -32,11 +32,4 @@ echo "Test Summary:"
 echo "-----------------------------------"
 cat "$SUMMARY_FILE"
 
-ESCAPED_CONTENT=$(sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' "$SUMMARY_FILE" | tr -d '\n')
-
-# try to keep the newlines
-echo 'TEST_OUTPUT<<EOF' >> $GITHUB_ENV
-echo $ESCAPED_CONTENT >> $GITHUB_ENV
-echo 'EOF' >> $GITHUB_ENV
-
 exit $status

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -146,6 +146,21 @@ def test_remote_session_omits_headless_on_wire(client: NotteClient, session_id: 
             assert "advanced_stealth" not in request_data
 
 
+def test_remote_cdp_session_omits_viewport_on_wire(client: NotteClient, session_id: str) -> None:
+    with patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = session_response_dict(session_id)
+
+        session = client.Session(cdp_url="ws://localhost:9222")
+        session.start()
+
+    mock_post.assert_called_once()
+    request_data = json.loads(mock_post.call_args.kwargs["data"])
+    assert request_data["cdp_url"] == "ws://localhost:9222"
+    assert "viewport_width" not in request_data
+    assert "viewport_height" not in request_data
+
+
 def _start_session(mock_post: MagicMock, client: NotteClient, session_id: str) -> SessionResponse:
     """
     Mocks the HTTP response for starting a session and triggers session initiation.

--- a/tests/sdk/test_replay_polling.py
+++ b/tests/sdk/test_replay_polling.py
@@ -1,0 +1,51 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from notte_sdk import NotteClient
+from notte_sdk.endpoints.sessions import RemoteSession
+from notte_sdk.errors import NotteAPIError
+from notte_sdk.types import ReplayResponse, SessionResponse
+
+from tests.sdk.test_client import session_response_dict
+
+
+def active_replay_error() -> NotteAPIError:
+    response = Mock(status_code=404)
+    response.json.return_value = {"message": "Session is still active — close it first"}
+    return NotteAPIError("sessions/test-session/replay", response)
+
+
+def test_replay_waits_for_persistence_after_successful_stop():
+    client = NotteClient(api_key="test-key")
+    session = RemoteSession(_client=client.sessions)
+    session.response = SessionResponse.model_validate(session_response_dict("test-session", close=True))
+    replay = ReplayResponse(mp4_url="https://example.com/replay.mp4")
+
+    with (
+        patch.object(client.sessions, "request", side_effect=[active_replay_error(), replay]) as request,
+        patch("notte_sdk.endpoints.sessions.time.sleep") as sleep,
+    ):
+        assert session.replay() == replay
+
+    assert request.call_count == 2
+    sleep.assert_called_once_with(5.0)
+
+
+def test_active_session_replay_still_fails_without_waiting():
+    client = NotteClient(api_key="test-key")
+    with (
+        patch.object(client.sessions, "request", side_effect=active_replay_error()),
+        patch("notte_sdk.endpoints.sessions.time.sleep") as sleep,
+        pytest.raises(ValueError, match="still active"),
+    ):
+        client.sessions.replay("test-session")
+    sleep.assert_not_called()
+
+
+def test_closed_session_replay_polling_has_a_deadline():
+    client = NotteClient(api_key="test-key")
+    with (
+        patch.object(client.sessions, "request", side_effect=active_replay_error()),
+        pytest.raises(TimeoutError, match="not ready"),
+    ):
+        client.sessions.replay("test-session", timeout=0, _session_closed=True)

--- a/tests/sdk/test_types.py
+++ b/tests/sdk/test_types.py
@@ -235,6 +235,12 @@ def test_cdp_url_does_not_send_configured_viewport_defaults():
 
     assert "viewport_width" not in payload
     assert "viewport_height" not in payload
+    assert payload["proxies"] is False
+
+
+def test_cdp_url_rejects_notte_proxies():
+    with pytest.raises(ValidationError, match="Proxies must be configured by the external CDP provider"):
+        _ = SessionStartRequest(cdp_url="ws://localhost:9222", proxies=True)
 
 
 @pytest.mark.parametrize("width,height", [(1920, 1080), (1280, 720)])

--- a/tests/sdk/test_types.py
+++ b/tests/sdk/test_types.py
@@ -229,6 +229,26 @@ def test_cdp_url_with_headless_false_should_raise_error():
         _ = SessionStartRequest.model_validate({"cdp_url": "ws://localhost:9222", "headless": False})
 
 
+def test_cdp_url_does_not_send_configured_viewport_defaults():
+    request = SessionStartRequest(cdp_url="ws://localhost:9222")
+    payload = request.model_dump(exclude_none=True)
+
+    assert "viewport_width" not in payload
+    assert "viewport_height" not in payload
+
+
+@pytest.mark.parametrize("width,height", [(1920, 1080), (1280, 720)])
+def test_cdp_url_rejects_explicit_viewport(width: int, height: int):
+    with pytest.raises(ValidationError, match="viewport_width must be None"):
+        _ = SessionStartRequest(cdp_url="ws://localhost:9222", viewport_width=width, viewport_height=height)
+
+
+def test_cdp_url_accepts_explicit_none_viewport():
+    request = SessionStartRequest(cdp_url="ws://localhost:9222", viewport_width=None, viewport_height=None)
+    assert request.viewport_width is None
+    assert request.viewport_height is None
+
+
 def test_remote_headless_true_is_accepted_for_legacy_sdks_but_not_serialized():
     request = SessionStartRequest.model_validate({"headless": True})
     assert "headless" not in request.model_dump()

--- a/tests/test_steel_sessions.py
+++ b/tests/test_steel_sessions.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from notte_integrations.sessions.steel import SteelSessionsManager
+
+
+@pytest.mark.parametrize("region,payload", [(None, {}), ("lax", {"region": "lax"})])
+def test_steel_session_region_selection(region: str | None, payload: dict[str, str]):
+    manager = SteelSessionsManager(steel_api_key="test-key", region=region)
+    response = Mock()
+    response.json.return_value = {"id": "steel-session-id"}
+    with patch("notte_integrations.sessions.steel.requests.post", return_value=response) as post:
+        session = manager.create_session_cdp(Mock())
+
+    assert session.session_id == "steel-session-id"
+    assert post.call_args.kwargs["json"] == payload
+    assert post.call_args.kwargs["timeout"] == 60
+    response.raise_for_status.assert_called_once()

--- a/tests/test_steel_sessions.py
+++ b/tests/test_steel_sessions.py
@@ -1,7 +1,9 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
+from notte_integrations.sessions.cdp_session import CDPSession
 from notte_integrations.sessions.steel import SteelSessionsManager
+from notte_sdk import NotteClient
 
 
 @pytest.mark.parametrize("region,payload", [(None, {}), ("lax", {"region": "lax"})])
@@ -16,3 +18,27 @@ def test_steel_session_region_selection(region: str | None, payload: dict[str, s
     assert post.call_args.kwargs["json"] == payload
     assert post.call_args.kwargs["timeout"] == 60
     response.raise_for_status.assert_called_once()
+
+
+@pytest.mark.parametrize("failure_stage", ["construct", "enter"])
+def test_steel_browser_is_released_when_notte_session_start_fails(failure_stage: str):
+    client = NotteClient(api_key="test-key")
+    manager = SteelSessionsManager(steel_api_key="test-key", client=client)
+    factory = Mock()
+    if failure_stage == "construct":
+        factory.side_effect = RuntimeError("Cannot start session")
+    else:
+        factory.return_value = Mock(__enter__=Mock(side_effect=RuntimeError("Cannot start session")))
+    with (
+        patch.object(NotteClient, "Session", new_callable=PropertyMock, return_value=factory),
+        patch.object(
+            SteelSessionsManager,
+            "create_session_cdp",
+            return_value=CDPSession(session_id="steel-session-id", cdp_url="ws://localhost:9222"),
+        ),
+        patch.object(SteelSessionsManager, "close_session_cdp", return_value=True) as release,
+        pytest.raises(RuntimeError, match="Cannot start session"),
+    ):
+        manager.__enter__()
+    factory.assert_called_once_with(cdp_url="ws://localhost:9222", proxies=False)
+    release.assert_called_once_with("steel-session-id")


### PR DESCRIPTION
Nightly examples fail on outdated SDK calls, configuration defaults, and Ubuntu package downloads on Blacksmith. This aligns the examples with the current API and makes the nightly run reproducible and easier to diagnose.

- Use the actual example entrypoints, bound Nike scraping to one category in CI, and include captured output in failures.
- Retrieve replays after session closure, tolerate stale active-state responses after a confirmed stop, and download MP4s with the current replay API. Run landing scenarios independently so a browser-expiration retry restarts only the affected scenario. Use National Weather Service observations for the NYC weather demo and the pytest interpreter for subprocesses.
- Update proxy imports, session-owned file storage, ID-based downloads, and explicit agent sessions. Skip externally configured snippets only when their declared configuration is absent.
- Strip inherited viewport dimensions and Notte proxies from CDP requests; reject incompatible explicit settings. Let Steel select its region and release its browser if Notte startup fails.
- Check agent completion and the destination URL before scraping GitHub stars. Use existing Vertex credentials for the local CI example, with a configurable model for standalone use. Retry only specific provider availability/timeouts, CAPTCHA solver failures, and browser-expiration failures.
- Fix the read-only regression test to download a browser file by ID instead of looking it up among user uploads.
- Prefer kernel.org HTTPS Ubuntu mirrors on Blacksmith, retain Ubuntu signing keys and suites, and bound installation waits. Add an optional pytest filter for manual nightly runs and serialize Slack notifications as JSON files.

Validation:
- Focused SDK, replay-polling, external-browser cleanup, and harness regressions pass; pre-commit passes on changed files.
- The read-only integration test passed live against staging.
- [Focused CI at `42193bc3`](https://github.com/nottelabs/notte/actions/runs/34607087301) passed Nike, blog/BBC landing examples, the local Vertex example, SDK replay, and Steel. Its only remaining failure was weather.com closing the hosted browser.
- [Weather CI at `24c1ad4c`](https://github.com/nottelabs/notte/actions/runs/34608219334) passed after moving the demo to NWS observations. The changed weather example also passed live locally.
- Hybrid navigation and CAPTCHA passed in the earlier focused CI run. Slack payload fixtures and the live CI notification step pass.

All previously failing non-email scenarios have passed across the focused runs; a complete green nightly run is still pending SMTP credential correction.

Outstanding: CI SMTP credentials are rejected with error 535, affecting the email notifier and signup-email test. Focused nightly runs exclude email; this PR does not suppress SMTP authentication failures. The underlying hosted-browser failure on weather.com remains a separate backend issue; this PR changes the illustrative weather target rather than claiming to fix that browser failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791718926&installation_model_id=8247&pr_number=965&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F965&signature=9f211f074b21ff4ebd8b1e5887f72914677b69ce0cf86c3d2de1979d7d898631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added filtering for nightly example runs.
  - Added optional limits for Nike scraper categories and improved replay video downloads.
  - Updated examples to support environment-based configuration and external browser sessions.

- **Bug Fixes**
  - Improved replay availability handling after sessions stop.
  - Improved cleanup when external browser session startup fails.
  - Added validation for externally managed CDP browsers and viewport settings.
  - Added request timeouts for external browser operations.

- **Documentation**
  - Updated tutorials and examples for current session, storage, proxy, and browser workflows.
  - Added guidance for running shorter scraper demonstrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->