### PR TITLE
Fix closed-session replay and isolate Node integration fixtures

### DIFF
--- a/node-sdk/src/session.ts
+++ b/node-sdk/src/session.ts
@@ -365,14 +365,16 @@ export class Session {
    * Get session replay data
    */
   async replay(): Promise<any> {
-    if (!this.sessionId) {
+    // Replays are generated after stop(), which clears the active session ID.
+    const sessionId = this.sessionId ?? this.response?.session_id;
+    if (!sessionId) {
       throw new Error('Session not started');
     }
 
     const response = await sessionReplay({
       client: this.client.getClient(),
       path: {
-        session_id: this.sessionId
+        session_id: sessionId
       }
     });
 

--- a/node-sdk/src/session.ts
+++ b/node-sdk/src/session.ts
@@ -1,6 +1,7 @@
 import { NotteClient } from '@/client';
 import type {
   SessionResponse,
+  ReplayResponse,
   ApiSessionStartRequest,
   Cookie,
   ExecutionResponse,
@@ -364,7 +365,7 @@ export class Session {
   /**
    * Get session replay data
    */
-  async replay(): Promise<any> {
+  async replay(): Promise<ReplayResponse> {
     // Replays are generated after stop(), which clears the active session ID.
     const sessionId = this.sessionId ?? this.response?.session_id;
     if (!sessionId) {
@@ -382,6 +383,9 @@ export class Session {
       throw new Error(`Failed to get session replay: ${formatError(response.error)}`);
     }
 
+    if (!response.data) {
+      throw new Error('Failed to get session replay: empty response');
+    }
     return response.data;
   }
 

--- a/node-sdk/test/function.integration.test.ts
+++ b/node-sdk/test/function.integration.test.ts
@@ -1,14 +1,27 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { NotteClient } from '@/client';
-import type { FunctionRunStartResult } from '@/functions';
+import { functionCreate, functionDelete } from '@/lib/client/sdk.gen';
 import { config } from 'dotenv';
 config();
 
-describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', () => {
+describe('Function Integration Tests', () => {
 	let client: NotteClient;
+	let functionId: string;
+	beforeAll(async () => {
+		const fixtureClient = new NotteClient();
+		const created = await functionCreate({
+			client: fixtureClient.getClient(),
+			body: { file: new File(['def run(url: str) -> dict:\n    return {"url": url}\n'], 'integration.py', { type: 'text/x-python' }) },
+			throwOnError: true,
+		});
+		functionId = created.data.function_id;
+	});
+	afterAll(async () => {
+		if (functionId) await functionDelete({ client: new NotteClient().getClient(), path: { function_id: functionId }, throwOnError: true });
+	});
 
 	beforeEach(async () => {
 		// Initialize client with API key from environment
@@ -25,7 +38,6 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 
 	describe('Function Creation', () => {
 		it('should create function instance with function_id', () => {
-			const functionId = process.env.NOTTE_FUNCTION_ID!;
 			const fn = client.NotteFunction({
 				function_id: functionId
 			});
@@ -36,7 +48,6 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 		});
 
 		it('should create function instance with function_id and decryption_key', () => {
-			const functionId = process.env.NOTTE_FUNCTION_ID!;
 			const decryptionKey = process.env.NOTTE_FUNCTION_DECRYPTION_KEY || 'test-decryption-key'; // pragma: allowlist secret
 			const fn = client.NotteFunction({
 				function_id: functionId,
@@ -52,7 +63,6 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 
 	describe('Function Run', () => {
 		it('should run a function', { timeout: 300000 }, async () => {
-			const functionId = process.env.NOTTE_FUNCTION_ID!;
 			const fn = client.NotteFunction({
 				function_id: functionId
 			});
@@ -69,7 +79,6 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 
 	describe('Function Metadata', () => {
 		it('should get metadata for a function run', { timeout: 300000 }, async () => {
-			const functionId = process.env.NOTTE_FUNCTION_ID!;
 			const fn = client.NotteFunction({
 				function_id: functionId
 			});
@@ -94,10 +103,8 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 
 	describe('Function Download', () => {
 		it('should get a download url', { timeout: 60000 }, async () => {
-			const functionId = process.env.NOTTE_FUNCTION_ID!;
 			const fn = client.NotteFunction({
 				function_id: functionId,
-				decryption_key: process.env.NOTTE_FUNCTION_DECRYPTION_KEY
 			});
 
 			const url = await fn.getUrl();
@@ -106,10 +113,8 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 		});
 
 		it('should download the function code', { timeout: 60000 }, async () => {
-			const functionId = process.env.NOTTE_FUNCTION_ID!;
 			const fn = client.NotteFunction({
 				function_id: functionId,
-				decryption_key: process.env.NOTTE_FUNCTION_DECRYPTION_KEY
 			});
 
 			const code = await fn.download();
@@ -118,10 +123,8 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 		});
 
 		it('should download the function code to a file', { timeout: 60000 }, async () => {
-			const functionId = process.env.NOTTE_FUNCTION_ID!;
 			const fn = client.NotteFunction({
 				function_id: functionId,
-				decryption_key: process.env.NOTTE_FUNCTION_DECRYPTION_KEY
 			});
 			const target = join(tmpdir(), `notte-function-${Date.now()}.py`);
 
@@ -136,7 +139,7 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 
 		it('should reject a path that is not a python file', async () => {
 			const fn = client.NotteFunction({
-				function_id: process.env.NOTTE_FUNCTION_ID!
+				function_id: functionId
 			});
 
 			await expect(fn.download({ path: 'invalid_file.txt' })).rejects.toThrow(
@@ -147,7 +150,6 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 
 	describe('Function Properties', () => {
 		it('should expose functionId property', () => {
-			const functionId = process.env.NOTTE_FUNCTION_ID!;
 			const fn = client.NotteFunction({
 				function_id: functionId
 			});
@@ -157,7 +159,6 @@ describe.skipIf(!process.env.NOTTE_FUNCTION_ID)('Function Integration Tests', ()
 		});
 
 		it('should expose decryptionKey property when provided', () => {
-			const functionId = process.env.NOTTE_FUNCTION_ID!;
 			const decryptionKey = process.env.NOTTE_FUNCTION_DECRYPTION_KEY || 'test-decryption-key'; // pragma: allowlist secret
 			const fn = client.NotteFunction({
 				function_id: functionId,

--- a/node-sdk/test/personas.integration.test.ts
+++ b/node-sdk/test/personas.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { NotteClient, NottePersona } from '@/index';
 import { Session } from '@/session';
 import { Agent } from '@/agent';
@@ -12,6 +12,18 @@ const API_KEY = process.env.NOTTE_API_KEY;
 
 describe('Persona Integration Tests', () => {
   let client: NotteClient;
+  let fixturePersona: NottePersona | undefined;
+
+  async function existingPersona() {
+    fixturePersona = client.Persona({ create_phone_number: false });
+    await fixturePersona.get();
+    return client.Persona({ persona_id: fixturePersona.personaId });
+  }
+
+  afterEach(async () => {
+    if (fixturePersona) await fixturePersona.delete();
+    fixturePersona = undefined;
+  });
 
   beforeEach(() => {
     if (!API_KEY) {
@@ -96,9 +108,8 @@ describe('Persona Integration Tests', () => {
       }
     });
     it('should get existing persona by ID', async () => {
-      const testPersonaId = process.env.NOTTE_PERSONA_ID;
-      if (!testPersonaId) throw new Error('NOTTE_PERSONA_ID is required for existing-persona tests');
-      const persona = client.Persona({ persona_id: testPersonaId });
+      const persona = await existingPersona();
+      const testPersonaId = fixturePersona!.personaId;
 
       // Initialize the persona
       await persona.get();
@@ -424,39 +435,27 @@ describe('Persona Integration Tests', () => {
 
   describe('Email and SMS Operations', () => {
     it('should read emails with filters', async () => {
-      const testPersonaId = process.env.NOTTE_PERSONA_ID;
-      if (!testPersonaId) throw new Error('NOTTE_PERSONA_ID is required for existing-persona tests');
-      const persona = client.Persona({ persona_id: testPersonaId });
+      const persona = await existingPersona();
 
       // Test reading emails with different filters
       const allEmails = await persona.emails();
-      expect(allEmails.length).toBeGreaterThanOrEqual(1);
+      expect(allEmails).toEqual([]);
 
       // Test with limit
       const limitedEmails = await persona.emails({ limit: 5 });
-      expect(limitedEmails.length).toBeGreaterThanOrEqual(1);
+      expect(limitedEmails).toEqual([]);
 
       // Test with unread only
       const unreadEmails = await persona.emails({ only_unread: true });
       expect(unreadEmails.length).toBeGreaterThanOrEqual(0);
     });
 
-    it('should read SMS with filters', async () => {
-      const testPersonaId = process.env.NOTTE_PERSONA_ID;
-      if (!testPersonaId) throw new Error('NOTTE_PERSONA_ID is required for existing-persona tests');
-      const persona = client.Persona({ persona_id: testPersonaId });
-
-      // Test reading SMS with different filters
-      const allSms = await persona.sms();
-      expect(allSms.length).toBeGreaterThan(0);
-
-      // Test with limit
-      const limitedSms = await persona.sms({ limit: 5 });
-      expect(limitedSms.length).toBeGreaterThan(0);
-
-      // Test with unread only
-      const unreadSms = await persona.sms({ only_unread: true });
-      expect(unreadSms.length).toBeGreaterThanOrEqual(0);
+    it('should reject SMS filters for a persona without a phone', async () => {
+      const persona = await existingPersona();
+      // Do not allocate a billable phone or depend on a shared inbox in CI.
+      for (const filter of [undefined, { limit: 5 }, { only_unread: true }]) {
+        await expect(persona.sms(filter)).rejects.toThrow(/phone/i);
+      }
     });
 
     it('should handle empty email and SMS for new persona', async () => {

--- a/node-sdk/test/session.integration.test.ts
+++ b/node-sdk/test/session.integration.test.ts
@@ -41,10 +41,12 @@ describe('Session Integration Tests', () => {
 		it('should start and stop a session', async () => {
 			const session = client.Session({ proxies: false });
 			await session.start();
-			expect(session.getResponse()?.status).toBe('active');
-			expect(session.getId()).toBeDefined();
-
-			await session.stop();
+			try {
+				expect(session.getResponse()?.status).toBe('active');
+				expect(session.getId()).toBeDefined();
+			} finally {
+				await session.stop();
+			}
 			expect(session.getResponse()?.status).toBe('closed');
 		});
 
@@ -96,20 +98,15 @@ describe('Session Integration Tests', () => {
 
 	describe('Session Replay', () => {
 		it('should replay a session', async () => {
-			const sessionId = process.env.NOTTE_SESSION_ID;
-			if (!sessionId) throw new Error('NOTTE_SESSION_ID is required for replay tests');
-
-			try {
-				const session = client.Session({ proxies: false });
-				session['sessionId'] = sessionId;
-				const response = await session.replay();
-				expect(response).toBeDefined();
-				expect(response.replay).toBeDefined();
-				expect(response.replay.length).toBeGreaterThan(0);
-			} catch (error) {
-				// If the session doesn't exist, that's okay for this test
-				expect(error).toBeDefined();
-			}
+			const session = client.Session({ proxies: false, idle_timeout_minutes: 1 });
+			await session.use(async (session) => {
+				await session.execute({ type: 'goto', url: 'https://example.com' });
+			});
+			// Recordings are finalized only after the browser session is closed.
+			await expect.poll(async () => (await session.replay()).replay.length, {
+				timeout: 60000,
+				interval: 1000,
+			}).toBeGreaterThan(0);
 		});
 	});
 
@@ -277,10 +274,11 @@ describe('Session Integration Tests', () => {
 		it('should handle already active session error', async () => {
 			const session = client.Session({ proxies: false });
 			await session.start();
-
-			await expect(session.start()).rejects.toThrow('Session is already active');
-
-			await session.stop();
+			try {
+				await expect(session.start()).rejects.toThrow('Session is already active');
+			} finally {
+				await session.stop();
+			}
 		});
 	});
 

--- a/node-sdk/test/session.integration.test.ts
+++ b/node-sdk/test/session.integration.test.ts
@@ -97,16 +97,19 @@ describe('Session Integration Tests', () => {
 	});
 
 	describe('Session Replay', () => {
-		it('should replay a session', async () => {
+		it('should replay a session', { timeout: 120000 }, async () => {
 			const session = client.Session({ proxies: false, idle_timeout_minutes: 1 });
 			await session.use(async (session) => {
 				await session.execute({ type: 'goto', url: 'https://example.com' });
 			});
 			// Recordings are finalized only after the browser session is closed.
-			await expect.poll(async () => (await session.replay()).replay.length, {
+			await expect.poll(async () => {
+				const replay = await session.replay();
+				return Boolean(replay.mp4_url || replay.playlist_content);
+			}, {
 				timeout: 60000,
 				interval: 1000,
-			}).toBeGreaterThan(0);
+			}).toBe(true);
 		});
 	});
 

--- a/node-sdk/test/session.test.ts
+++ b/node-sdk/test/session.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, expect, expectTypeOf, vi } from 'vitest';
 import { Session } from '@/session';
 import { NotteClient } from '@/client';
-import { sessionStart, sessionStop } from '@/lib/client/sdk.gen';
+import { sessionStart, sessionStop, sessionReplay } from '@/lib/client/sdk.gen';
 import type {
   SessionOptions,
 } from '@/index';
@@ -61,6 +61,27 @@ describe('Session Unit Tests', () => {
       const options: SessionOptions = { headless };
       expectTypeOf<SessionOptions['headless']>().toEqualTypeOf<boolean | undefined>();
       expect(options.headless).toBe(true);
+    });
+  });
+
+  describe('replay', () => {
+    it('retrieves the last closed session without marking it active', async () => {
+      vi.mocked(sessionStart).mockResolvedValue({ data: { session_id: 'session-replay', status: 'active' } } as any);
+      vi.mocked(sessionStop).mockResolvedValue({ data: { session_id: 'session-replay', status: 'closed' } } as any);
+      vi.mocked(sessionReplay).mockResolvedValue({ data: { replay: 'recording' } } as any);
+      const session = new Session(mockClient);
+      await session.start();
+      await session.stop();
+
+      expect(await session.replay()).toEqual({ replay: 'recording' });
+      expect(sessionReplay).toHaveBeenCalledWith({ client: mockClient.getClient(), path: { session_id: 'session-replay' } });
+      expect(session.getId()).toBeNull();
+      expect(session.isSessionActive()).toBe(false);
+    });
+
+    it('rejects replay when no session has been created', async () => {
+      await expect(new Session(mockClient).replay()).rejects.toThrow('Session not started');
+      expect(sessionReplay).not.toHaveBeenCalled();
     });
   });
 

--- a/node-sdk/test/session.test.ts
+++ b/node-sdk/test/session.test.ts
@@ -4,6 +4,7 @@ import { NotteClient } from '@/client';
 import { sessionStart, sessionStop, sessionReplay } from '@/lib/client/sdk.gen';
 import type {
   SessionOptions,
+  ReplayResponse,
 } from '@/index';
 import { openBrowser } from '@/utils';
 
@@ -65,15 +66,19 @@ describe('Session Unit Tests', () => {
   });
 
   describe('replay', () => {
-    it('retrieves the last closed session without marking it active', async () => {
+    it.each([
+      { mp4_url: 'https://example.com/replay.mp4', expires_at: '2099-01-01T00:00:00Z' },
+      { playlist_content: '#EXTM3U\n#EXT-X-ENDLIST', expires_at: '2099-01-01T00:00:00Z' },
+    ] satisfies ReplayResponse[])('retrieves the last closed session without marking it active (%j)', async replay => {
       vi.mocked(sessionStart).mockResolvedValue({ data: { session_id: 'session-replay', status: 'active' } } as any);
       vi.mocked(sessionStop).mockResolvedValue({ data: { session_id: 'session-replay', status: 'closed' } } as any);
-      vi.mocked(sessionReplay).mockResolvedValue({ data: { replay: 'recording' } } as any);
+      vi.mocked(sessionReplay).mockResolvedValue({ data: replay } as any);
       const session = new Session(mockClient);
       await session.start();
       await session.stop();
 
-      expect(await session.replay()).toEqual({ replay: 'recording' });
+      expectTypeOf<ReturnType<Session['replay']>>().toEqualTypeOf<Promise<ReplayResponse>>();
+      expect(await session.replay()).toEqual(replay);
       expect(sessionReplay).toHaveBeenCalledWith({ client: mockClient.getClient(), path: { session_id: 'session-replay' } });
       expect(session.getId()).toBeNull();
       expect(session.isSessionActive()).toBe(false);
@@ -82,6 +87,14 @@ describe('Session Unit Tests', () => {
     it('rejects replay when no session has been created', async () => {
       await expect(new Session(mockClient).replay()).rejects.toThrow('Session not started');
       expect(sessionReplay).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty replay response', async () => {
+      vi.mocked(sessionStart).mockResolvedValue({ data: { session_id: 'session-replay', status: 'active' } } as any);
+      vi.mocked(sessionReplay).mockResolvedValue({} as any);
+      const session = new Session(mockClient);
+      await session.start();
+      await expect(session.replay()).rejects.toThrow('empty response');
     });
   });
 

--- a/node-sdk/test/vault.integration.test.ts
+++ b/node-sdk/test/vault.integration.test.ts
@@ -66,7 +66,10 @@ describe('Vault Integration Tests', () => {
 			// Verify credentials were added
 			const credentials = await newVault.listCredentials();
 			expect(credentials.length).toBeGreaterThan(0);
-			const githubCreds = credentials.find(c => new URL(c.url).hostname === 'github.com');
+			// The API normalizes credential URLs to a hostname.
+			const githubCreds = credentials.find(c =>
+				new URL(c.url.includes('://') ? c.url : `https://${c.url}`).hostname === 'github.com'
+			);
 			expect(githubCreds).toBeDefined();
 		});
 


### PR DESCRIPTION
## Summary

- Allow typed replay lookup after stop without changing active-session state.
- Test both replay response formats and wait for recording finalization in the live test.
- Replace shared function/persona/session IDs with owned fixtures and cleanup.
- Correct empty inbox, absent phone, and normalized vault hostname assumptions.

Rebased onto main after #967 merged. The diff contains only SDK/test corrections, not the pipeline or documentation migration.

## Validation

- 202 unit tests pass; TypeScript typecheck and build pass after rebase.
- Targeted staging tests passed: replay (1), persona (2), vault (1).
- Full staging integration suite: 128 passed locally and in Node CI; 6 documentation cases skipped here and covered by the separate passing live-example workflow.
- Node CI passes on Node 22 and 24. Greptile: 5/5, zero unresolved threads.
- Python CI remains red: test_signup_email_extraction fails with SMTPAuthenticationError (535 authentication failed). No Python files changed in this PR.
- The five failures in the #967 integration job map to the fixture and hostname corrections here.

## Follow-up

- Success-path SMS coverage needs an explicitly provisioned phone fixture; isolated default persona tests cover the no-phone error path without allocating billable numbers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791720728&installation_model_id=8247&pr_number=966&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F966&signature=29f950b6303ecfb2027ccf8d2022348946baecad6b6c3766fb5ef740014643c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session replay now remains available after a session is stopped.
  - Replay requests provide clearer errors when no session exists or the response is empty.
  - Replay responses now offer improved type information for SDK users.
  - Credential URL handling now works consistently when responses contain hostnames without a URL scheme.

- **Tests**
  - Integration tests now create and clean up their own sessions, functions, and personas, improving reliability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->