### PR TITLE
Standardize Node SDK release process

### DIFF
--- a/.github/workflows/node-sdk-publish.yml
+++ b/.github/workflows/node-sdk-publish.yml
@@ -30,6 +30,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -38,8 +40,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: node-sdk/package-lock.json
           registry-url: https://registry.npmjs.org
 
       - run: npm ci
@@ -67,11 +67,32 @@ jobs:
         run: node scripts/check-package.js
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          published_version=$(npm view "notte-sdk@${RELEASE_VERSION}" version 2>/dev/null || true)
+          if [ "$published_version" = "$RELEASE_VERSION" ]; then
+            echo "notte-sdk@$RELEASE_VERSION is already published; continuing to verification"
+          else
+            npm publish --access public --provenance
+          fi
+
+  verify:
+    name: Verify notte-sdk from npm
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
+    steps:
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
 
       - name: Install the package from npm
         env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_VERSION: ${{ needs.publish.outputs.version }}
+        working-directory: ${{ runner.temp }}
         run: |
           set -euo pipefail
           workdir=$(mktemp -d)
@@ -86,7 +107,7 @@ jobs:
 
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts: Installing notte-sdk@${RELEASE_VERSION}..."
-            if npm install --prefer-online --no-audit --no-fund "notte-sdk@${RELEASE_VERSION}"; then
+            if npm install --ignore-scripts --prefer-online --no-audit --no-fund "notte-sdk@${RELEASE_VERSION}"; then
               echo "Installation successful!"
               break
             fi

--- a/.github/workflows/node-sdk-publish.yml
+++ b/.github/workflows/node-sdk-publish.yml
@@ -1,50 +1,113 @@
-name: Publish Node SDK
+name: Release Node SDK
 
+# Mirrors pypi-release.yml: pushing the same vX.Y.Z tag that publishes the
+# Python packages to PyPI publishes node-sdk to npm at the same version.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: read
 
 concurrency:
-  group: node-sdk-publish
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: node-sdk
 
 jobs:
   publish:
-    # Enable only after npm trusted publishing is configured and the previous
-    # publisher is disabled. Python release tags must never publish this package.
-    if: vars.NODE_SDK_PUBLISH_ENABLED == 'true' && startsWith(github.event.release.tag_name, 'node-sdk-v')
+    if: startsWith(github.ref, 'refs/tags/v')
+    name: Build and publish notte-sdk to npm
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
+    # npm trusted publishing is bound to this repository, this workflow file
+    # and this environment. No registry token is stored in the repository.
     environment: npm
     permissions:
       contents: read
       id-token: write
-    defaults:
-      run:
-        working-directory: node-sdk
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: node-sdk/package-lock.json
           registry-url: https://registry.npmjs.org
+
       - run: npm ci
-      - name: Set release version
+
+      - name: Set release version from tag
+        id: version
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          RELEASE_VERSION="${RELEASE_TAG#node-sdk-v}"
+          RELEASE_VERSION="${RELEASE_TAG#v}"
           if ! echo "$RELEASE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo 'Expected a stable node-sdk-vX.Y.Z release tag'
+            echo "::error::Expected a stable vX.Y.Z release tag, got '$RELEASE_TAG'"
             exit 1
           fi
+          echo "Releasing notte-sdk@$RELEASE_VERSION"
           npm version "$RELEASE_VERSION" --no-git-tag-version
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
       - run: npm run typecheck
       - run: npm run test:unit -- --run
-      - run: npx vitest run test/function-stream.integration.test.ts
+      - name: Test streaming over local HTTP
+        run: npx vitest run test/function-stream.integration.test.ts
       - run: npm run build
-      - run: node scripts/check-package.js
-      - run: npm publish --access public --provenance
+      - name: Smoke-test built package exports
+        run: node scripts/check-package.js
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+
+      - name: Install the package from npm
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          workdir=$(mktemp -d)
+          cd "$workdir"
+          npm init -y >/dev/null
+
+          # Retry installation with exponential backoff while npm replicates
+          # the new version. --prefer-online skips any stale local cache.
+          max_attempts=5
+          attempt=1
+          wait_time=30
+
+          while [ $attempt -le $max_attempts ]; do
+            echo "Attempt $attempt of $max_attempts: Installing notte-sdk@${RELEASE_VERSION}..."
+            if npm install --prefer-online --no-audit --no-fund "notte-sdk@${RELEASE_VERSION}"; then
+              echo "Installation successful!"
+              break
+            fi
+
+            if [ $attempt -lt $max_attempts ]; then
+              echo "Installation failed, waiting ${wait_time}s before retry..."
+              sleep $wait_time
+              wait_time=$((wait_time * 2))
+            else
+              echo "All installation attempts failed"
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+          done
+
+          installed=$(node -p "require('./node_modules/notte-sdk/package.json').version")
+          if [ "$installed" != "$RELEASE_VERSION" ]; then
+            echo "::error::Installed notte-sdk@$installed, expected $RELEASE_VERSION"
+            exit 1
+          fi
+
+          node --input-type=commonjs -e "const sdk = require('notte-sdk'); if (typeof sdk.NotteClient !== 'function') process.exit(1);"
+          node --input-type=module -e "import { NotteClient } from 'notte-sdk'; if (typeof NotteClient !== 'function') process.exit(1);"
+          echo "notte-sdk@$installed installs and loads from npm"

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -67,14 +67,16 @@ jobs:
           uv venv pypi
           source pypi/bin/activate
 
-          # Retry installation with exponential backoff
+          # Retry installation with exponential backoff. --refresh bypasses
+          # uv's cached copy of the PyPI index (served with max-age=600),
+          # which the publish step's --check-url primed before the upload.
           max_attempts=3
           attempt=1
           wait_time=60
 
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts: Installing notte==${RELEASE_TAG}..."
-            if uv pip install "notte==${RELEASE_TAG}"; then
+            if uv pip install --refresh "notte==${RELEASE_TAG}"; then
               echo "Installation successful!"
               break
             fi

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,3 +23,26 @@ both validation and serialization schemas.
 ## Installing Notte
 
 Follow the instructions in the [setup docs](../docs/setup.md) file.
+
+## Releasing
+
+The Python packages and the Node SDK are released together, from one tag and at
+one version. To cut a release:
+
+1. Open [Releases](https://github.com/nottelabs/notte/releases) and draft a new
+   release with a new tag `vX.Y.Z` targeting `main`. Generate the release notes
+   and publish the release.
+2. Pushing the tag runs two workflows:
+   - `pypi-release.yml` builds and publishes the root `notte` package and every
+     package under `packages/` to PyPI as `X.Y.Z`, verifies the install from
+     PyPI, then triggers the docs deployment.
+   - `node-sdk-publish.yml` builds and publishes the `notte-sdk` npm package as
+     `X.Y.Z` with provenance, then verifies the install from npm.
+
+Versions on `main` are placeholders (`1.4.4.dev` in the `pyproject.toml` files,
+`0.0.0-dev` in `node-sdk/package.json`); CI sets the real version from the tag.
+Do not bump versions in pull requests.
+
+If one workflow fails after the other succeeded, re-run the failed workflow from
+the Actions tab; PyPI uploads skip files that already exist and npm refuses to
+republish an existing version, so re-runs are safe.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,5 +44,6 @@ Versions on `main` are placeholders (`1.4.4.dev` in the `pyproject.toml` files,
 Do not bump versions in pull requests.
 
 If one workflow fails after the other succeeded, re-run the failed workflow from
-the Actions tab; PyPI uploads skip files that already exist and npm refuses to
-republish an existing version, so re-runs are safe.
+the Actions tab. PyPI uploads skip files that already exist, and the npm workflow
+detects an existing matching version, skips publishing it again, and continues
+with installation verification.

--- a/node-sdk/Makefile
+++ b/node-sdk/Makefile
@@ -9,7 +9,7 @@ help:
 	@echo "  make install     - Install dependencies and generate SDK"
 	@echo "  make sdk         - Generate SDK from OpenAPI spec (alias: make generate)"
 	@echo "  make check       - Check if SDK is up to date with staging"
-	@echo "  make release     - Release package to npm"
+	@echo "  make release <version> - Dry-run a release build (publishing happens in CI on a vX.Y.Z tag)"
 	@echo "  make tests       - Run all tests"
 	@echo "  make example <filename> - Run example file (e.g., make example persona)"
 	@echo ""
@@ -35,11 +35,21 @@ check:
 	@echo "Checking if SDK is up to date with staging..."
 	npm run check:staging
 
-# Release package to npm
+# Dry-run a release build at a given version, then restore the dev version.
+# Publishing happens in CI (.github/workflows/node-sdk-publish.yml) when a
+# vX.Y.Z tag is pushed, together with the Python packages.
 release:
-	@echo "Building and releasing to npm..."
+	@if [ -z "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
+		echo "Error: No version specified. Usage: make release <version>"; \
+		echo "Example: make release 1.9.0"; \
+		exit 1; \
+	fi
+	@echo "Building notte-sdk version: $(filter-out $@,$(MAKECMDGOALS))"
+	npm version "$(filter-out $@,$(MAKECMDGOALS))" --no-git-tag-version
 	npm run build
-	npm publish
+	node scripts/check-package.js
+	npm pack --dry-run
+	@git checkout package.json package-lock.json
 
 # Run all tests
 tests:

--- a/node-sdk/Makefile
+++ b/node-sdk/Makefile
@@ -45,11 +45,24 @@ release:
 		exit 1; \
 	fi
 	@echo "Building notte-sdk version: $(filter-out $@,$(MAKECMDGOALS))"
-	npm version "$(filter-out $@,$(MAKECMDGOALS))" --no-git-tag-version
-	npm run build
-	node scripts/check-package.js
+	@set -eu; \
+	package_backup=$$(mktemp); \
+	lock_backup=$$(mktemp); \
+	cp package.json "$$package_backup"; \
+	cp package-lock.json "$$lock_backup"; \
+	cleanup() { \
+		status=$$?; \
+		trap - EXIT HUP INT TERM; \
+		cp "$$package_backup" package.json; \
+		cp "$$lock_backup" package-lock.json; \
+		rm -f "$$package_backup" "$$lock_backup"; \
+		exit $$status; \
+	}; \
+	trap cleanup EXIT HUP INT TERM; \
+	npm version "$(filter-out $@,$(MAKECMDGOALS))" --no-git-tag-version; \
+	npm run build; \
+	node scripts/check-package.js; \
 	npm pack --dry-run
-	@git checkout package.json package-lock.json
 
 # Run all tests
 tests:

--- a/node-sdk/README.md
+++ b/node-sdk/README.md
@@ -48,16 +48,21 @@ checks remain limited to main pushes and manual workflow runs on main.
 The npm package remains `notte-sdk`. Its MIT license is in [LICENSE](LICENSE);
 the repository root license does not replace this package's license.
 
-Publishing is disabled by default. Before enabling it, maintainers must:
+The Node SDK is released together with the Python SDK, from the same tag and at
+the same version. Cutting a release means creating a GitHub release tagged
+`vX.Y.Z` on [nottelabs/notte](https://github.com/nottelabs/notte/releases):
 
-1. Disable the previous publishing workflow.
-2. Configure npm trusted publishing for `nottelabs/notte`, workflow
-   `node-sdk-publish.yml`, environment `npm`, and configure environment protection.
-3. Set the repository variable `NODE_SDK_PUBLISH_ENABLED=true`.
+- `pypi-release.yml` publishes the Python packages to PyPI as `X.Y.Z`.
+- `node-sdk-publish.yml` sets this package's version to `X.Y.Z`, runs the
+  typecheck, unit tests, streaming test and export smoke test, publishes to npm
+  with provenance, then installs the published version back from npm to verify it.
 
-Publishing a stable GitHub release tagged `node-sdk-vX.Y.Z` then runs validation
-and publishes with provenance. Python release tags do not trigger npm publishing.
-No registry credentials or publishing configuration are changed by adding this package.
+`package.json` stays at `0.0.0-dev` on `main`; the version is only set in CI
+from the tag, like the `.dev` placeholder in the Python `pyproject.toml` files.
+Publishing uses npm trusted publishing (GitHub OIDC) bound to this repository,
+workflow `node-sdk-publish.yml` and environment `npm`, so no npm token is stored
+in the repository. To dry-run a release build locally, run `make release X.Y.Z`
+in this directory; it never publishes.
 
 Importing the SDK does not contact the npm registry. To explicitly check for an
 update, call `await checkForLatestVersion()` from `notte-sdk`.

--- a/tests/scripts/test_release_publish.py
+++ b/tests/scripts/test_release_publish.py
@@ -1,5 +1,9 @@
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).parents[2]
@@ -59,32 +63,46 @@ def test_python_and_node_releases_share_the_same_tag() -> None:
 def test_node_release_publishes_the_tag_version_with_provenance() -> None:
     workflow = _load_workflow("node-sdk-publish.yml")
     publish_job = workflow["jobs"]["publish"]
-    steps = publish_job["steps"]
-    names = [step.get("name") for step in steps]
+    publish_steps = publish_job["steps"]
+    publish_names = [step.get("name") for step in publish_steps]
+    verify_job = workflow["jobs"]["verify"]
+    verify_steps = verify_job["steps"]
 
     assert publish_job["permissions"]["id-token"] == "write"
     assert publish_job["environment"] == "npm"
+    assert publish_job["outputs"]["version"] == "${{ steps.version.outputs.version }}"
     assert workflow["defaults"]["run"]["working-directory"] == "node-sdk"
 
-    version = next(step for step in steps if step.get("name") == "Set release version from tag")
+    setup = next(step for step in publish_steps if str(step.get("uses", "")).startswith("actions/setup-node@"))
+    assert "cache" not in setup["with"]
+    assert "cache-dependency-path" not in setup["with"]
+
+    version = next(step for step in publish_steps if step.get("name") == "Set release version from tag")
     assert version["env"] == {"RELEASE_TAG": "${{ github.ref_name }}"}
     assert 'RELEASE_VERSION="${RELEASE_TAG#v}"' in version["run"]
     assert 'npm version "$RELEASE_VERSION" --no-git-tag-version' in version["run"]
 
     assert (
-        names.index("Set release version from tag")
-        < names.index("Smoke-test built package exports")
-        < names.index("Publish to npm")
-        < names.index("Install the package from npm")
+        publish_names.index("Set release version from tag")
+        < publish_names.index("Smoke-test built package exports")
+        < publish_names.index("Publish to npm")
     )
+    assert publish_names[-1] == "Publish to npm", "no code should run after publishing in the OIDC job"
 
-    publish = next(step for step in steps if step.get("name") == "Publish to npm")
-    assert publish["run"] == "npm publish --access public --provenance"
+    publish = next(step for step in publish_steps if step.get("name") == "Publish to npm")
+    assert 'npm view "notte-sdk@${RELEASE_VERSION}" version' in publish["run"]
+    assert "npm publish --access public --provenance" in publish["run"]
     assert "NODE_AUTH_TOKEN" not in yaml.safe_dump(workflow)
     assert "NPM_TOKEN" not in yaml.safe_dump(workflow)
 
-    verify = next(step for step in steps if step.get("name") == "Install the package from npm")
-    assert 'npm install --prefer-online --no-audit --no-fund "notte-sdk@${RELEASE_VERSION}"' in verify["run"]
+    assert verify_job["needs"] == "publish"
+    assert verify_job["permissions"] == {}
+    verify = next(step for step in verify_steps if step.get("name") == "Install the package from npm")
+    assert verify["env"] == {"RELEASE_VERSION": "${{ needs.publish.outputs.version }}"}
+    assert (
+        'npm install --ignore-scripts --prefer-online --no-audit --no-fund "notte-sdk@${RELEASE_VERSION}"'
+        in verify["run"]
+    )
 
 
 def test_python_release_install_check_refreshes_the_pypi_index() -> None:
@@ -103,3 +121,51 @@ def test_node_package_keeps_a_dev_placeholder_version() -> None:
     package = json.loads((ROOT / "node-sdk/package.json").read_text())
     assert package["name"] == "notte-sdk"
     assert package["version"] == "0.0.0-dev", "the release version is set from the tag in CI"
+
+
+@pytest.mark.parametrize("build_exit_code", [0, 42])
+def test_node_release_dry_run_restores_existing_manifest_changes(tmp_path: Path, build_exit_code: int) -> None:
+    sdk = tmp_path / "node-sdk"
+    sdk.mkdir()
+    for name in ("Makefile", "package.json", "package-lock.json"):
+        shutil.copyfile(ROOT / "node-sdk" / name, sdk / name)
+
+    package = sdk / "package.json"
+    lock = sdk / "package-lock.json"
+    package.write_text(package.read_text() + "\npre-existing package edit\n")
+    lock.write_text(lock.read_text() + "\npre-existing lock edit\n")
+    original_package = package.read_bytes()
+    original_lock = lock.read_bytes()
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_npm = fake_bin / "npm"
+    fake_npm.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = version ]; then\n'
+        "  printf changed-by-npm-version > package.json\n"
+        "  printf changed-by-npm-version > package-lock.json\n"
+        "  exit 0\n"
+        "fi\n"
+        f'if [ "$1" = run ]; then exit {build_exit_code}; fi\n'
+        "exit 0\n"
+    )
+    fake_npm.chmod(0o755)
+    fake_node = fake_bin / "node"
+    fake_node.write_text("#!/bin/sh\nexit 0\n")
+    fake_node.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    result = subprocess.run(
+        ["make", "release", "1.9.0"],
+        cwd=sdk,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert (result.returncode == 0) is (build_exit_code == 0)
+    assert package.read_bytes() == original_package
+    assert lock.read_bytes() == original_lock

--- a/tests/scripts/test_release_publish.py
+++ b/tests/scripts/test_release_publish.py
@@ -32,3 +32,74 @@ def test_manual_release_uses_uv_environment_credentials() -> None:
     assert "--check-url https://pypi.org/simple" in build_script
     assert "twine upload" not in build_script
     assert "--token" not in build_script
+
+
+def _load_workflow(name: str) -> dict:
+    return yaml.safe_load((ROOT / ".github/workflows" / name).read_text())
+
+
+def _triggers(workflow: dict) -> dict:
+    # PyYAML parses the bare `on:` key as the boolean True.
+    return workflow.get("on", workflow.get(True))
+
+
+def test_python_and_node_releases_share_the_same_tag() -> None:
+    python = _load_workflow("pypi-release.yml")
+    node = _load_workflow("node-sdk-publish.yml")
+
+    assert _triggers(python) == {"push": {"tags": ["v*"]}}
+    assert _triggers(node) == _triggers(python)
+
+    text = (ROOT / ".github/workflows/node-sdk-publish.yml").read_text()
+    assert "node-sdk-v" not in text, "node releases must not use a separate tag prefix"
+    assert "NODE_SDK_PUBLISH_ENABLED" not in text, "node publishing must not be gated behind a variable"
+    assert "release:" not in text, "node releases are triggered by the tag push, like the python release"
+
+
+def test_node_release_publishes_the_tag_version_with_provenance() -> None:
+    workflow = _load_workflow("node-sdk-publish.yml")
+    publish_job = workflow["jobs"]["publish"]
+    steps = publish_job["steps"]
+    names = [step.get("name") for step in steps]
+
+    assert publish_job["permissions"]["id-token"] == "write"
+    assert publish_job["environment"] == "npm"
+    assert workflow["defaults"]["run"]["working-directory"] == "node-sdk"
+
+    version = next(step for step in steps if step.get("name") == "Set release version from tag")
+    assert version["env"] == {"RELEASE_TAG": "${{ github.ref_name }}"}
+    assert 'RELEASE_VERSION="${RELEASE_TAG#v}"' in version["run"]
+    assert 'npm version "$RELEASE_VERSION" --no-git-tag-version' in version["run"]
+
+    assert (
+        names.index("Set release version from tag")
+        < names.index("Smoke-test built package exports")
+        < names.index("Publish to npm")
+        < names.index("Install the package from npm")
+    )
+
+    publish = next(step for step in steps if step.get("name") == "Publish to npm")
+    assert publish["run"] == "npm publish --access public --provenance"
+    assert "NODE_AUTH_TOKEN" not in yaml.safe_dump(workflow)
+    assert "NPM_TOKEN" not in yaml.safe_dump(workflow)
+
+    verify = next(step for step in steps if step.get("name") == "Install the package from npm")
+    assert 'npm install --prefer-online --no-audit --no-fund "notte-sdk@${RELEASE_VERSION}"' in verify["run"]
+
+
+def test_python_release_install_check_refreshes_the_pypi_index() -> None:
+    workflow = _load_workflow("pypi-release.yml")
+    steps = workflow["jobs"]["build"]["steps"]
+    install = next(step for step in steps if step.get("name") == "Install the package from PyPI")
+
+    # uv caches the simple index (max-age=600) during `uv publish --check-url`,
+    # so without --refresh the freshly uploaded version is invisible to the check.
+    assert 'uv pip install --refresh "notte==${RELEASE_TAG}"' in install["run"]
+
+
+def test_node_package_keeps_a_dev_placeholder_version() -> None:
+    import json
+
+    package = json.loads((ROOT / "node-sdk/package.json").read_text())
+    assert package["name"] == "notte-sdk"
+    assert package["version"] == "0.0.0-dev", "the release version is set from the tag in CI"


### PR DESCRIPTION
## Summary

- publish the Node SDK from the same vX.Y.Z tags as the Python packages
- verify fresh PyPI and npm releases after publishing
- document the unified release flow and make local Node releases dry-run only
- add regression coverage for release workflow configuration

## Validation

- uv run pytest -q tests/scripts/test_release_publish.py
- npm run typecheck
- npm run test:unit -- --run
- npx vitest run test/function-stream.integration.test.ts
- npm run build
- node scripts/check-package.js

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791732330&installation_model_id=8247&pr_number=975&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F975&signature=697b4f26b4630113ef123908be20fb8d4f439e29bb6f46a22bfce6f4bf5cf308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases now publish the Python packages and Node SDK together from a single `vX.Y.Z` tag.
  * Published Node SDK packages are automatically installed and smoke-tested for CommonJS and ESM compatibility.
  * Added a local dry-run option to validate Node SDK release packages before publishing.
  * Retrying a release safely avoids republishing versions that are already available.

* **Documentation**
  * Updated release guidance for unified tagging, automated publishing, verification, and local dry runs.

* **Bug Fixes**
  * Improved PyPI verification to detect freshly published versions despite package-index caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->