### PR TITLE
test: retry transient session failures in paired docs CI

### DIFF
--- a/node-sdk/test/docs-snippets.integration.test.ts
+++ b/node-sdk/test/docs-snippets.integration.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { NotteClient, functionCreate, functionDelete, listFunctionRunsByFunctionId, functionRunStop } from '@/index';
+import { withPythonPageRetry } from './helpers/python-page-retry';
 import { expectSessionClosed } from './helpers/session-closure';
 import { collectExampleResult, verifyExampleOutput, type ExampleContract } from './helpers/docs-examples';
 
@@ -64,7 +65,7 @@ describe.skipIf(process.env.NOTTE_DOCS_LIVE !== '1')('paired documentation examp
     }
   }, 60_000);
 
-  it.each(snippets)('%s and its Python counterpart execute unchanged', { timeout: 180_000 }, async name => {
+  async function runExample(name: string) {
     if (name.startsWith('file-storage/')) {
       const directory = await mkdtemp(join(tmpdir(), 'notte-docs-files-'));
       const contract = contracts[name];
@@ -132,11 +133,13 @@ describe.skipIf(process.env.NOTTE_DOCS_LIVE !== '1')('paired documentation examp
     const pythonArgs = contract
       ? [fileURLToPath(new URL('../../docs/src/sniptest/run_python.py', import.meta.url)), pythonPath]
       : [pythonPath];
-    const { stdout, stderr } = await execute(process.env.NOTTE_DOCS_PYTHON || 'python', pythonArgs, {
-      env: process.env,
-      timeout: 120_000,
-      maxBuffer: 2 * 1024 * 1024,
-    });
+    const { stdout, stderr } = await withPythonPageRetry(name, () => execute(
+      process.env.NOTTE_DOCS_PYTHON || 'python', pythonArgs, {
+        env: process.env,
+        timeout: 120_000,
+        maxBuffer: 2 * 1024 * 1024,
+      },
+    ));
     if (contract) {
       // This getting-started example intentionally just prints the SDK response.
       // Capture that existing output instead of adding test exports to the example.
@@ -173,5 +176,12 @@ describe.skipIf(process.env.NOTTE_DOCS_LIVE !== '1')('paired documentation examp
         await expectSessionClosed(client, id as string, `${name} (${index === 0 ? 'typescript' : 'python'})`);
       }
     }
-  });
+  }
+
+  for (const name of snippets) {
+    it(`${name} and its Python counterpart execute unchanged`, {
+      // The timeout example may run Python twice, each with a 120s deadline.
+      timeout: name === 'sessions/configuration/timeout.ts' ? 300_000 : 180_000,
+    }, () => runExample(name));
+  }
 });

--- a/node-sdk/test/docs-snippets.integration.test.ts
+++ b/node-sdk/test/docs-snippets.integration.test.ts
@@ -5,7 +5,8 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import { NotteClient, functionCreate, functionDelete, listFunctionRunsByFunctionId, functionRunStop, sessionStatus } from '@/index';
+import { NotteClient, functionCreate, functionDelete, listFunctionRunsByFunctionId, functionRunStop } from '@/index';
+import { expectSessionClosed } from './helpers/session-closure';
 import { collectExampleResult, verifyExampleOutput, type ExampleContract } from './helpers/docs-examples';
 
 const execute = promisify(execFile);
@@ -87,8 +88,7 @@ describe.skipIf(process.env.NOTTE_DOCS_LIVE !== '1')('paired documentation examp
           const id = verifyExampleOutput(JSON.stringify(collectExampleResult(values, contract)), contract, `${stdout}\n${stderr}`);
           expect(id).toBeTruthy();
           ids.push(id!);
-          const stopped = await sessionStatus({ client: client.getClient(), path: { session_id: id! }, throwOnError: true });
-          expect(stopped.data.status).toBe('closed');
+          await expectSessionClosed(client, id!, `${name} (${language})`);
         }
         expect(ids[0]).not.toBe(ids[1]);
       } finally {
@@ -151,9 +151,8 @@ describe.skipIf(process.env.NOTTE_DOCS_LIVE !== '1')('paired documentation examp
       ];
       if (contract.closedSession) {
         expect(ids[0]).not.toBe(ids[1]);
-        for (const id of ids) {
-          const session = await sessionStatus({ client: client.getClient(), path: { session_id: id! }, throwOnError: true });
-          expect(session.data.status).toBe('closed');
+        for (const [index, id] of ids.entries()) {
+          await expectSessionClosed(client, id!, `${name} (${index === 0 ? 'typescript' : 'python'})`);
         }
       }
       return;
@@ -169,10 +168,9 @@ describe.skipIf(process.env.NOTTE_DOCS_LIVE !== '1')('paired documentation examp
     }
     if (name === 'sessions/lifecycle/context_manager.ts') {
       const ids = [logged[0][0], stdout.trim()];
-      for (const id of ids) {
+      for (const [index, id] of ids.entries()) {
         expect(typeof id).toBe('string');
-        const session = await sessionStatus({ client: client.getClient(), path: { session_id: id as string }, throwOnError: true });
-        expect(session.data.status).toBe('closed');
+        await expectSessionClosed(client, id as string, `${name} (${index === 0 ? 'typescript' : 'python'})`);
       }
     }
   });

--- a/node-sdk/test/helpers/python-page-retry.ts
+++ b/node-sdk/test/helpers/python-page-retry.ts
@@ -1,0 +1,19 @@
+/** Retry only the known browser-loss failure in the read-only timeout example. */
+export async function withPythonPageRetry<T>(example: string, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (example !== 'sessions/configuration/timeout.ts') throw error;
+    const stderr = error && typeof error === 'object' && 'stderr' in error
+      ? String(error.stderr).replace(/\u001b\[[0-9;]*m/g, '') : '';
+    // Inspect the final traceback: a cleanup failure can chain the original
+    // TargetClosedError, but must not be mistaken for a safely retryable run.
+    const traceback = stderr.slice(stderr.lastIndexOf('Traceback (most recent call last):'));
+    if (!/^playwright\._impl\._errors\.TargetClosedError: Page\.goto: Target page, context or browser has been closed\s*$/m.test(traceback)) {
+      throw error;
+    }
+    console.warn(`${example} (python): browser closed during navigation; retrying once with a fresh session after 5000ms`);
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    return run();
+  }
+}

--- a/node-sdk/test/helpers/session-closure.ts
+++ b/node-sdk/test/helpers/session-closure.ts
@@ -1,0 +1,41 @@
+import { type NotteClient, sessionStatus } from '@/index';
+
+/** Stop acknowledges in-memory closure before background cleanup persists it. */
+export async function expectSessionClosed(client: NotteClient, sessionId: string, example: string): Promise<void> {
+  const timeout = 15_000;
+  const interval = 500;
+  const started = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  const observations: string[] = [];
+  const failure = () => new Error(
+    `${example}: session ${sessionId} did not become closed within ${timeout}ms; observed ${observations.join(', ') || 'no response'}`,
+  );
+  try {
+    while (!controller.signal.aborted) {
+      const response = await sessionStatus({
+        client: client.getClient(),
+        path: { session_id: sessionId },
+        signal: controller.signal,
+        throwOnError: true,
+      });
+      const status = response.data.status;
+      observations.push(`${Date.now() - started}ms=${status}`);
+      if (controller.signal.aborted) throw failure();
+      if (status === 'closed') return;
+      if (status !== 'active') {
+        throw new Error(`${example}: session ${sessionId} returned unexpected status ${status}`);
+      }
+      const remaining = timeout - (Date.now() - started);
+      if (remaining <= 0) break;
+      await new Promise(resolve => setTimeout(resolve, Math.min(interval, remaining)));
+    }
+    throw failure();
+  } catch (error) {
+    if (controller.signal.aborted) throw failure();
+    // Authentication, transport, and other API errors are not closure delays.
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/node-sdk/test/python-page-retry.test.ts
+++ b/node-sdk/test/python-page-retry.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { withPythonPageRetry } from './helpers/python-page-retry';
+
+const example = 'sessions/configuration/timeout.ts';
+const traceback = 'Traceback (most recent call last):\n  page.goto("https://example.com")\nplaywright._impl._errors.TargetClosedError: Page.goto: Target page, context or browser has been closed\nCall log:\n  - navigating to "https://example.com/", waiting until "load"\n';
+const browserLost = Object.assign(new Error('Python failed'), { stderr: traceback });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+it('returns a successful execution without waiting', async () => {
+  const run = vi.fn().mockResolvedValue({ stdout: 'result' });
+  await expect(withPythonPageRetry(example, run)).resolves.toEqual({ stdout: 'result' });
+  expect(run).toHaveBeenCalledTimes(1);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it('reruns the Python process exactly once after five seconds', async () => {
+  const run = vi.fn().mockRejectedValueOnce(browserLost).mockResolvedValueOnce({ stdout: 'fresh result' });
+  const result = withPythonPageRetry(example, run);
+  await vi.advanceTimersByTimeAsync(4999);
+  expect(run).toHaveBeenCalledTimes(1);
+  await vi.advanceTimersByTimeAsync(1);
+  await expect(result).resolves.toEqual({ stdout: 'fresh result' });
+  expect(run).toHaveBeenCalledTimes(2);
+  expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('retrying once'));
+});
+
+it('surfaces the second failure', async () => {
+  const run = vi.fn().mockRejectedValue(browserLost);
+  const result = expect(withPythonPageRetry(example, run)).rejects.toBe(browserLost);
+  await vi.advanceTimersByTimeAsync(5000);
+  await result;
+  expect(run).toHaveBeenCalledTimes(2);
+});
+
+it.each([
+  ['sessions/lifecycle/create_session.ts', browserLost],
+  [example, new Error('Python timed out')],
+  [example, Object.assign(new Error('Python failed'), { stderr: 'RuntimeError: authentication failed' })],
+  [example, Object.assign(new Error('cleanup failed'), {
+    stderr: `${traceback}\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  session.stop()\nRuntimeError: failed to stop`,
+  })],
+])('does not retry unrelated failures or failed cleanup (%s)', async (name, error) => {
+  const run = vi.fn().mockRejectedValue(error);
+  await expect(withPythonPageRetry(name, run)).rejects.toBe(error);
+  expect(run).toHaveBeenCalledTimes(1);
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/node-sdk/test/session-closure.test.ts
+++ b/node-sdk/test/session-closure.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type NotteClient, sessionStatus } from '@/index';
+import { expectSessionClosed } from './helpers/session-closure';
+
+vi.mock('@/index', () => ({ sessionStatus: vi.fn() }));
+const client = { getClient: () => ({}) } as NotteClient;
+const status = (value: string) => ({ data: { status: value } }) as Awaited<ReturnType<typeof sessionStatus>>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(sessionStatus).mockReset();
+});
+afterEach(() => vi.useRealTimers());
+
+describe('session closure checks', () => {
+  it('returns immediately when closure is already persisted', async () => {
+    vi.mocked(sessionStatus).mockResolvedValue(status('closed'));
+    await expectSessionClosed(client, 'owned-session', 'example (python)');
+    expect(sessionStatus).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('waits through stale active reads and stops on the first closed response', async () => {
+    vi.mocked(sessionStatus)
+      .mockResolvedValueOnce(status('active'))
+      .mockResolvedValueOnce(status('active'))
+      .mockResolvedValueOnce(status('closed'));
+    const check = expectSessionClosed(client, 'owned-session', 'example (python)');
+    await vi.advanceTimersByTimeAsync(1000);
+    await check;
+    expect(sessionStatus).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('fails with resource, language and observations when closure never persists', async () => {
+    vi.mocked(sessionStatus).mockResolvedValue(status('active'));
+    const check = expectSessionClosed(client, 'owned-session', 'example (python)');
+    const assertion = expect(check).rejects.toThrow(/example \(python\): session owned-session.*15000ms; observed 0ms=active/);
+    await vi.advanceTimersByTimeAsync(15_000);
+    await assertion;
+    expect(sessionStatus).toHaveBeenCalledTimes(30);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not retry API failures', async () => {
+    const error = new Error('Unauthorized');
+    vi.mocked(sessionStatus).mockRejectedValue(error);
+    await expect(expectSessionClosed(client, 'owned-session', 'example')).rejects.toBe(error);
+    expect(sessionStatus).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not retry unexpected terminal statuses', async () => {
+    vi.mocked(sessionStatus).mockResolvedValue(status('error'));
+    await expect(expectSessionClosed(client, 'owned-session', 'example')).rejects.toThrow(
+      'example: session owned-session returned unexpected status error',
+    );
+    expect(sessionStatus).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('aborts a status request that exceeds the polling deadline', async () => {
+    vi.mocked(sessionStatus).mockImplementation(({ signal }) => new Promise<never>((_, reject) => {
+      signal!.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    }));
+    const check = expectSessionClosed(client, 'owned-session', 'example');
+    const assertion = expect(check).rejects.toThrow(/owned-session.*15000ms; observed no response/);
+    await vi.advanceTimersByTimeAsync(15_000);
+    await assertion;
+    expect(sessionStatus).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
Paired documentation CI has two intermittent session failures: a fresh status read can still report `active` after stop acknowledges closure ([run 34621145468](https://github.com/nottelabs/notte/actions/runs/34621145468)), and the Python timeout example can lose its browser during `page.goto()` ([run 34622996575](https://github.com/nottelabs/notte/actions/runs/34622996575)).

- Poll persisted session closure immediately, then every 500 ms for up to 15 seconds across all three closure-check paths. Abort outstanding requests at the deadline and report the example, language, session ID, and timestamped statuses. API errors and unexpected statuses fail immediately.
- For `sessions/configuration/timeout.ts` only, retry the Python subprocess once after five seconds when its final traceback reports Playwright's `TargetClosedError` during `Page.goto`. Each attempt executes the unchanged example with a fresh session. Inspecting the final traceback prevents retrying an original browser error masked by failed cleanup; all other errors and second-attempt failures propagate. Log the retry and give this one test 300 seconds to accommodate both 120-second subprocess deadlines.

SDK and displayed example behavior remains unchanged. Direct terminal response assertions remain strict.

Validation:
- All 618 Node unit tests pass, including delayed/persistent closure, request cancellation, retry delay/count, and cleanup-failure coverage; TypeScript typecheck passes.
- Six live staging pairs passed for the closure change: `create_session_2`, `selenium_javascript`, `playwright_events`, `context_manager`, and both file-storage examples.
- The timeout example passes live against staging in both languages (one selected pair; 41 unrelated cases skipped). The browser-loss retry itself is exercised deterministically in unit tests.
- Documentation generation, parity, live-coverage registration, TypeScript example checks, and 38 Python harness tests pass.
