### PR TITLE
ci: allow manual Node SDK releases

### DIFF
--- a/.github/workflows/node-sdk-publish.yml
+++ b/.github/workflows/node-sdk-publish.yml
@@ -1,11 +1,18 @@
 name: Release Node SDK
 
 # Mirrors pypi-release.yml: pushing the same vX.Y.Z tag that publishes the
-# Python packages to PyPI publishes node-sdk to npm at the same version.
+# Python packages to PyPI publishes node-sdk to npm at the same version. Manual
+# dispatch can recover a Node-only release without rerunning the Python release.
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable version to publish (X.Y.Z or vX.Y.Z)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -20,7 +27,7 @@ defaults:
 
 jobs:
   publish:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     name: Build and publish notte-sdk to npm
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -36,6 +43,9 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
+          # Recovery releases always publish the current default branch rather
+          # than whichever ref the dispatcher happens to select in the UI.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.repository.default_branch || github.ref }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -44,14 +54,14 @@ jobs:
 
       - run: npm ci
 
-      - name: Set release version from tag
+      - name: Set release version
         id: version
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
         run: |
           RELEASE_VERSION="${RELEASE_TAG#v}"
           if ! echo "$RELEASE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Expected a stable vX.Y.Z release tag, got '$RELEASE_TAG'"
+            echo "::error::Expected a stable X.Y.Z or vX.Y.Z release version, got '$RELEASE_TAG'"
             exit 1
           fi
           echo "Releasing notte-sdk@$RELEASE_VERSION"


### PR DESCRIPTION
## Summary
- add a manual dispatch input to the Node SDK release workflow for stable `X.Y.Z` or `vX.Y.Z` versions
- publish the current default branch for manual recovery runs instead of rewriting an existing release tag
- reuse the existing typecheck, unit tests, build, trusted npm publish, and registry verification

This provides a Node-only recovery path for `notte-sdk@1.9.0`, whose tag-triggered run failed before publishing. The Python 1.9.0 release does not need to run again.

## Validation
- `actionlint .github/workflows/node-sdk-publish.yml`
- shell validation accepts both `1.9.0` and `v1.9.0`
- pre-commit YAML and secret checks pass

## Follow-up after merge
Manually dispatch **Release Node SDK** from `main` with version `1.9.0`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791759699&installation_model_id=8247&pr_number=984&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F984&signature=2cc3e9224df111a0a03d2acaf54080615491455dcf5103f7a67daac9ba6e5683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Releases can now be initiated manually with a specified stable version, in addition to automatic tag-based publishing.
  - Recovery releases can use the default branch to restore publishing when needed.

- **Improvements**
  - Version input validation now accepts both standard version formats: `X.Y.Z` and `vX.Y.Z`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->