### PR TITLE
docs: refresh generated llms.txt

### DIFF
--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -285,10 +285,6 @@ The SDK docs below are for generated-code editing and reference. They are not th
 - [POST Improve Prompt](https://docs.notte.cc/api-reference/prompts/improve-prompt.md)
 - [POST Nudge Prompt](https://docs.notte.cc/api-reference/prompts/nudge-prompt.md)
 
-## Proxies
-
-- [POST Mint a short-lived proxy credential](https://docs.notte.cc/api-reference/proxies/mint-proxy-credentials.md): Returns a derived username/password for `proxy.notte.cc`, signed for this workspace and valid for your plan's maximum session duration (see `expires_at`). Traffic through it is billed to this API key's workspace at the proxy rate. Clients that support TLS to a proxy can also use the API key itself as the proxy password on port 443.
-
 ## Scrape
 
 - [POST Scrape From Html](https://docs.notte.cc/api-reference/scrape/scrape-from-html.md)


### PR DESCRIPTION
Automated daily regeneration of `docs/src/llms.txt` via `make docs-llms-refresh`, which builds the API section from the live OpenAPI spec.

Updated 2026-09-12 (UTC): +0 -4

No hand edits. The run fails instead of committing if the spec cannot be fetched or comes back incomplete.

Opened by .github/workflows/refresh-llms.yml. Merges automatically once the required checks pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nottelabs/codesmith/notte/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791783391&installation_model_id=8247&pr_number=986&repository=nottelabs%2Fnotte&return_to=https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte%2Fpull%2F986&signature=4830175a44cdb0483b7f9949fe43281933ed7156bfde79c1ed97329828f83aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the Proxies API reference section for creating short-lived proxy credentials from the documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->